### PR TITLE
ci: only run checks on PR, not on push to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,6 @@ name: CI
 on:
   pull_request:
     branches: [main]
-  push:
-    branches: [main]
 
 concurrency:
   group: ci-${{ github.ref }}


### PR DESCRIPTION
Since branch protection is enforced via rulesets (requiring all 4 CI checks to pass before merge), there's no need to re-run CI after every merge commit lands on main. This removes the redundant `push: branches: [main]` trigger.