### PR TITLE
feat: cover image extraction, storage, and serving

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -2,3 +2,4 @@ onlyBuiltDependencies[]=@prisma/engines
 onlyBuiltDependencies[]=esbuild
 onlyBuiltDependencies[]=msgpackr-extract
 onlyBuiltDependencies[]=prisma
+onlyBuiltDependencies[]=sharp

--- a/apps/web/server/routes/api/covers/[workId]/[size].test.ts
+++ b/apps/web/server/routes/api/covers/[workId]/[size].test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("h3", () => ({
+  defineEventHandler: (fn: unknown) => fn,
+}));
+
+describe("cover route", () => {
+  it("exports a handler function", async () => {
+    const mod = await import("./[size]");
+    expect(typeof mod.default).toBe("function");
+  });
+});

--- a/apps/web/server/routes/api/covers/[workId]/[size].ts
+++ b/apps/web/server/routes/api/covers/[workId]/[size].ts
@@ -1,0 +1,13 @@
+import { existsSync, createReadStream } from "node:fs";
+import { defineEventHandler } from "h3";
+import { createCoverHandler } from "../handler";
+
+const COVER_CACHE_DIR = process.env.COVER_CACHE_DIR ?? "/data/covers";
+
+export default defineEventHandler(
+  createCoverHandler({
+    existsSync,
+    createReadStream,
+    coverCacheDir: COVER_CACHE_DIR,
+  }),
+);

--- a/apps/web/server/routes/api/covers/handler.test.ts
+++ b/apps/web/server/routes/api/covers/handler.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createCoverHandler, type CoverHandlerDeps } from "./handler";
+
+function createMockDeps(overrides: Partial<CoverHandlerDeps> = {}): CoverHandlerDeps {
+  return {
+    existsSync: vi.fn().mockReturnValue(true),
+    createReadStream: vi.fn().mockReturnValue("mock-stream"),
+    coverCacheDir: "/data/covers",
+    ...overrides,
+  };
+}
+
+function createMockEvent(workId: string, size: string) {
+  return {
+    context: {
+      params: { workId, size },
+    },
+  };
+}
+
+describe("cover handler", () => {
+  let deps: CoverHandlerDeps;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+  });
+
+  it("returns a stream for valid thumb request", async () => {
+    const handler = createCoverHandler(deps);
+    const event = createMockEvent("work-1", "thumb");
+
+    const result = await handler(event as never);
+
+    expect(deps.existsSync).toHaveBeenCalledWith("/data/covers/work-1/thumb.webp");
+    expect(deps.createReadStream).toHaveBeenCalledWith("/data/covers/work-1/thumb.webp");
+    expect(result).toBe("mock-stream");
+  });
+
+  it("returns a stream for valid medium request", async () => {
+    const handler = createCoverHandler(deps);
+    const event = createMockEvent("work-1", "medium");
+
+    const result = await handler(event as never);
+
+    expect(deps.existsSync).toHaveBeenCalledWith("/data/covers/work-1/medium.webp");
+    expect(result).toBe("mock-stream");
+  });
+
+  it("throws 400 for invalid size", async () => {
+    const handler = createCoverHandler(deps);
+    const event = createMockEvent("work-1", "large");
+
+    await expect(handler(event as never)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  it("returns an SVG placeholder when cover file does not exist", async () => {
+    const setHeader = vi.fn();
+    deps = createMockDeps({ existsSync: vi.fn().mockReturnValue(false) });
+    const handler = createCoverHandler(deps);
+    const event = {
+      context: { params: { workId: "work-1", size: "thumb" } },
+      node: { res: { setHeader } },
+    };
+
+    const result = await handler(event as never);
+
+    expect(typeof result).toBe("string");
+    expect(result as string).toContain("<svg");
+    expect(result as string).toContain("</svg>");
+    expect(setHeader).toHaveBeenCalledWith("Content-Type", "image/svg+xml");
+    expect(setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=3600");
+    expect(deps.createReadStream).not.toHaveBeenCalled();
+  });
+
+  it("sanitizes workId to prevent path traversal", async () => {
+    const handler = createCoverHandler(deps);
+    const event = createMockEvent("../../../etc/passwd", "thumb");
+
+    await expect(handler(event as never)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  it("rejects workId with slashes", async () => {
+    const handler = createCoverHandler(deps);
+    const event = createMockEvent("foo/bar", "thumb");
+
+    await expect(handler(event as never)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+});

--- a/apps/web/server/routes/api/covers/handler.ts
+++ b/apps/web/server/routes/api/covers/handler.ts
@@ -1,0 +1,43 @@
+import path from "node:path";
+import type { H3Event } from "h3";
+
+export interface CoverHandlerDeps {
+  existsSync: (path: string) => boolean;
+  createReadStream: (path: string) => unknown;
+  coverCacheDir: string;
+}
+
+const VALID_SIZES = new Set(["thumb", "medium"]);
+const VALID_WORK_ID = /^[a-zA-Z0-9_-]+$/;
+const PLACEHOLDER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="200" height="300" viewBox="0 0 200 300">
+  <rect width="200" height="300" fill="#e2e8f0"/>
+  <text x="100" y="150" text-anchor="middle" dominant-baseline="central" font-family="system-ui,sans-serif" font-size="48" fill="#94a3b8">?</text>
+</svg>`;
+
+export function createCoverHandler(deps: CoverHandlerDeps) {
+  return async (event: H3Event) => {
+    const params = event.context.params as { workId: string; size: string };
+    const { workId, size } = params;
+
+    if (!VALID_WORK_ID.test(workId)) {
+      throw Object.assign(new Error("Invalid workId"), { statusCode: 400, statusMessage: "Invalid workId" });
+    }
+
+    if (!VALID_SIZES.has(size)) {
+      throw Object.assign(new Error("Invalid size"), { statusCode: 400, statusMessage: "Invalid size" });
+    }
+
+    const filePath = path.join(deps.coverCacheDir, workId, `${size}.webp`);
+
+    if (!deps.existsSync(filePath)) {
+      event.node?.res?.setHeader?.("Content-Type", "image/svg+xml");
+      event.node?.res?.setHeader?.("Cache-Control", "public, max-age=3600");
+      return PLACEHOLDER_SVG;
+    }
+
+    event.node?.res?.setHeader?.("Content-Type", "image/webp");
+    event.node?.res?.setHeader?.("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+
+    return deps.createReadStream(filePath);
+  };
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,9 @@ services:
       AUTH_OIDC_CLIENT_SECRET: ${AUTH_OIDC_CLIENT_SECRET}
       AUTH_OIDC_SCOPES: ${AUTH_OIDC_SCOPES:-openid profile email}
       APP_URL: ${APP_URL}
+      COVER_CACHE_DIR: /data/covers
+    volumes:
+      - covers:/data/covers:ro
     depends_on:
       - db
       - queue
@@ -49,12 +52,15 @@ services:
       DATABASE_URL: postgresql://bookhouse:bookhouse@db:5432/bookhouse
       QUEUE_URL: redis://queue:6379
       NODE_ENV: production
+      COVER_CACHE_DIR: /data/covers
     volumes:
       - /Volumes/data/media/ebooks:/data/ebooks:ro
       - /Volumes/data/media/audiobooks:/data/audiobooks:ro
+      - covers:/data/covers
     depends_on:
       - db
       - queue
 
 volumes:
   pgdata:
+  covers:

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -195,6 +195,7 @@ model Work {
   sortTitle      String?
   description    String?
   language       String?
+  coverPath      String?
   seriesId       String?
   createdAt      DateTime @default(now())
   updatedAt      DateTime @updatedAt

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -16,6 +16,7 @@
     "@bookhouse/shared": "workspace:*",
     "fast-xml-parser": "^5.5.6",
     "music-metadata": "^11.12.3",
+    "sharp": "^0.33.0",
     "yauzl-promise": "^4.0.0"
   },
   "devDependencies": {

--- a/packages/ingest/src/covers.test.ts
+++ b/packages/ingest/src/covers.test.ts
@@ -1,0 +1,281 @@
+import path from "node:path";
+import type { Dirent } from "node:fs";
+import { describe, expect, it, vi } from "vitest";
+import { MediaKind } from "@bookhouse/domain";
+import {
+  detectAdjacentCover,
+  resizeCoverImage,
+  processCoverForWork,
+  type CoverDependencies,
+  type ProcessCoverInput,
+} from "./covers";
+
+function makeDirent(name: string, isFile: boolean): Dirent {
+  return {
+    name,
+    isFile: () => isFile,
+    isDirectory: () => !isFile,
+    isSymbolicLink: () => false,
+    isBlockDevice: () => false,
+    isCharacterDevice: () => false,
+    isFIFO: () => false,
+    isSocket: () => false,
+    parentPath: "/test",
+    path: "/test",
+  } as Dirent;
+}
+
+describe("detectAdjacentCover", () => {
+  it("returns null for empty directory", async () => {
+    const listDirectory = vi.fn().mockResolvedValue([]);
+    const result = await detectAdjacentCover("/books/author/title", listDirectory);
+    expect(result).toBeNull();
+  });
+
+  it("returns null when no image files exist", async () => {
+    const listDirectory = vi.fn().mockResolvedValue([
+      makeDirent("book.epub", true),
+      makeDirent("metadata.opf", true),
+    ]);
+    const result = await detectAdjacentCover("/books/author/title", listDirectory);
+    expect(result).toBeNull();
+  });
+
+  it("finds cover.jpg file", async () => {
+    const listDirectory = vi.fn().mockResolvedValue([
+      makeDirent("book.epub", true),
+      makeDirent("cover.jpg", true),
+    ]);
+    const result = await detectAdjacentCover("/books/author/title", listDirectory);
+    expect(result).toBe(path.join("/books/author/title", "cover.jpg"));
+  });
+
+  it("prioritizes cover.* over other image files", async () => {
+    const listDirectory = vi.fn().mockResolvedValue([
+      makeDirent("art.png", true),
+      makeDirent("cover.webp", true),
+      makeDirent("photo.jpg", true),
+    ]);
+    const result = await detectAdjacentCover("/books/author/title", listDirectory);
+    expect(result).toBe(path.join("/books/author/title", "cover.webp"));
+  });
+
+  it("falls back to first image file when no cover.* exists", async () => {
+    const listDirectory = vi.fn().mockResolvedValue([
+      makeDirent("book.epub", true),
+      makeDirent("art.png", true),
+      makeDirent("photo.jpg", true),
+    ]);
+    const result = await detectAdjacentCover("/books/author/title", listDirectory);
+    expect(result).toBe(path.join("/books/author/title", "art.png"));
+  });
+
+  it("is case-insensitive for cover.* matching", async () => {
+    const listDirectory = vi.fn().mockResolvedValue([
+      makeDirent("Cover.JPG", true),
+    ]);
+    const result = await detectAdjacentCover("/books/author/title", listDirectory);
+    expect(result).toBe(path.join("/books/author/title", "Cover.JPG"));
+  });
+
+  it("skips directories", async () => {
+    const listDirectory = vi.fn().mockResolvedValue([
+      makeDirent("covers", false),
+      makeDirent("cover.jpg", true),
+    ]);
+    const result = await detectAdjacentCover("/books/author/title", listDirectory);
+    expect(result).toBe(path.join("/books/author/title", "cover.jpg"));
+  });
+
+  it("returns null on listDirectory error", async () => {
+    const listDirectory = vi.fn().mockRejectedValue(new Error("ENOENT"));
+    const result = await detectAdjacentCover("/books/missing", listDirectory);
+    expect(result).toBeNull();
+  });
+});
+
+describe("resizeCoverImage", () => {
+  it("creates output directory and writes thumb and medium webp", async () => {
+    const mockToBuffer = vi.fn().mockResolvedValue(Buffer.from("resized"));
+    const mockWebp = vi.fn().mockReturnValue({ toBuffer: mockToBuffer });
+    const mockResize = vi.fn().mockReturnValue({ webp: mockWebp });
+    const mockSharp = vi.fn().mockReturnValue({ resize: mockResize });
+    const mockMkdir = vi.fn().mockResolvedValue(undefined);
+    const mockWriteFile = vi.fn().mockResolvedValue(undefined);
+
+    const result = await resizeCoverImage(
+      { imageBuffer: Buffer.from("original"), outputDir: "/data/covers/work-123" },
+      { sharp: mockSharp as never, mkdir: mockMkdir, writeFile: mockWriteFile },
+    );
+
+    expect(mockMkdir).toHaveBeenCalledWith("/data/covers/work-123", { recursive: true });
+    expect(mockSharp).toHaveBeenCalledTimes(2);
+    expect(mockResize).toHaveBeenCalledWith(200, undefined, { fit: "inside", withoutEnlargement: true });
+    expect(mockResize).toHaveBeenCalledWith(400, undefined, { fit: "inside", withoutEnlargement: true });
+    expect(mockWriteFile).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({
+      thumbPath: path.join("/data/covers/work-123", "thumb.webp"),
+      mediumPath: path.join("/data/covers/work-123", "medium.webp"),
+    });
+  });
+});
+
+describe("processCoverForWork", () => {
+  function createMockDeps(overrides: Partial<CoverDependencies> = {}): CoverDependencies {
+    return {
+      extractEpubCover: vi.fn().mockResolvedValue(null),
+      readFile: vi.fn().mockResolvedValue(Buffer.from("image-data")),
+      detectAdjacentCover: vi.fn().mockResolvedValue(null),
+      resizeCoverImage: vi.fn().mockResolvedValue({
+        thumbPath: "/data/covers/work-1/thumb.webp",
+        mediumPath: "/data/covers/work-1/medium.webp",
+      }),
+      db: {
+        fileAsset: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "fa-1",
+            absolutePath: "/books/author/title/book.epub",
+            mediaKind: MediaKind.EPUB,
+          }),
+        },
+        work: {
+          update: vi.fn().mockResolvedValue({}),
+        },
+      },
+      ...overrides,
+    };
+  }
+
+  function createInput(overrides: Partial<ProcessCoverInput> = {}): ProcessCoverInput {
+    return {
+      workId: "work-1",
+      fileAssetId: "fa-1",
+      coverCacheDir: "/data/covers",
+      ...overrides,
+    };
+  }
+
+  it("extracts cover from EPUB and resizes", async () => {
+    const workUpdate = vi.fn().mockResolvedValue({});
+    const deps = createMockDeps({
+      extractEpubCover: vi.fn().mockResolvedValue({
+        buffer: Buffer.from("epub-cover"),
+        mediaType: "image/jpeg",
+      }),
+      db: {
+        fileAsset: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "fa-1",
+            absolutePath: "/books/author/title/book.epub",
+            mediaKind: MediaKind.EPUB,
+          }),
+        },
+        work: { update: workUpdate },
+      },
+    });
+
+    const result = await processCoverForWork(createInput(), deps);
+
+    expect(deps.extractEpubCover).toHaveBeenCalledWith("/books/author/title/book.epub");
+    expect(deps.resizeCoverImage).toHaveBeenCalled();
+    expect(workUpdate).toHaveBeenCalledWith({
+      where: { id: "work-1" },
+      data: { coverPath: "work-1" },
+    });
+    expect(result.source).toBe("epub");
+    expect(result.updated).toBe(true);
+  });
+
+  it("falls back to adjacent cover when EPUB has none", async () => {
+    const workUpdate = vi.fn().mockResolvedValue({});
+    const deps = createMockDeps({
+      extractEpubCover: vi.fn().mockResolvedValue(null),
+      detectAdjacentCover: vi.fn().mockResolvedValue("/books/author/title/cover.jpg"),
+      db: {
+        fileAsset: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "fa-1",
+            absolutePath: "/books/author/title/book.epub",
+            mediaKind: MediaKind.EPUB,
+          }),
+        },
+        work: { update: workUpdate },
+      },
+    });
+
+    const result = await processCoverForWork(createInput(), deps);
+
+    expect(deps.extractEpubCover).toHaveBeenCalled();
+    expect(deps.detectAdjacentCover).toHaveBeenCalled();
+    expect(deps.readFile).toHaveBeenCalledWith("/books/author/title/cover.jpg");
+    expect(deps.resizeCoverImage).toHaveBeenCalled();
+    expect(workUpdate).toHaveBeenCalled();
+    expect(result.source).toBe("adjacent");
+    expect(result.updated).toBe(true);
+  });
+
+  it("uses adjacent cover for non-EPUB media kinds", async () => {
+    const deps = createMockDeps({
+      db: {
+        fileAsset: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "fa-1",
+            absolutePath: "/books/author/title/metadata.json",
+            mediaKind: MediaKind.SIDECAR,
+          }),
+        },
+        work: {
+          update: vi.fn().mockResolvedValue({}),
+        },
+      },
+      detectAdjacentCover: vi.fn().mockResolvedValue("/books/author/title/cover.jpg"),
+    });
+
+    const result = await processCoverForWork(createInput(), deps);
+
+    expect(deps.extractEpubCover).not.toHaveBeenCalled();
+    expect(deps.detectAdjacentCover).toHaveBeenCalled();
+    expect(result.source).toBe("adjacent");
+    expect(result.updated).toBe(true);
+  });
+
+  it("returns updated=false when no cover found", async () => {
+    const workUpdate = vi.fn().mockResolvedValue({});
+    const deps = createMockDeps({
+      db: {
+        fileAsset: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "fa-1",
+            absolutePath: "/books/author/title/book.epub",
+            mediaKind: MediaKind.EPUB,
+          }),
+        },
+        work: { update: workUpdate },
+      },
+    });
+
+    const result = await processCoverForWork(createInput(), deps);
+
+    expect(deps.resizeCoverImage).not.toHaveBeenCalled();
+    expect(workUpdate).not.toHaveBeenCalled();
+    expect(result.source).toBe("none");
+    expect(result.updated).toBe(false);
+  });
+
+  it("throws when file asset is not found", async () => {
+    const deps = createMockDeps({
+      db: {
+        fileAsset: {
+          findUnique: vi.fn().mockResolvedValue(null),
+        },
+        work: {
+          update: vi.fn().mockResolvedValue({}),
+        },
+      },
+    });
+
+    await expect(processCoverForWork(createInput(), deps)).rejects.toThrow(
+      'File asset "fa-1" was not found',
+    );
+  });
+});

--- a/packages/ingest/src/covers.ts
+++ b/packages/ingest/src/covers.ts
@@ -1,0 +1,163 @@
+import path from "node:path";
+import type { Dirent } from "node:fs";
+import { MediaKind } from "@bookhouse/domain";
+import { classifyMediaKind } from "./classification";
+import type { EpubCoverResult } from "./epub";
+
+type ListDirectoryFn = (path: string, options: { withFileTypes: true }) => Promise<Dirent[]>;
+type ReadFileFn = (path: string) => Promise<Buffer>;
+type MkdirFn = (path: string, options: { recursive: true }) => Promise<string | undefined>;
+type WriteFileFn = (path: string, data: Buffer) => Promise<void>;
+
+export interface ProcessCoverInput {
+  workId: string;
+  fileAssetId: string;
+  coverCacheDir: string;
+}
+
+export interface ProcessCoverResult {
+  source: "epub" | "adjacent" | "none";
+  updated: boolean;
+}
+
+interface FileAssetRecord {
+  id: string;
+  absolutePath: string;
+  mediaKind: MediaKind;
+}
+
+export interface CoverDb {
+  fileAsset: {
+    findUnique(args: { where: { id: string } }): Promise<FileAssetRecord | null>;
+  };
+  work: {
+    update(args: { where: { id: string }; data: { coverPath: string } }): Promise<unknown>;
+  };
+}
+
+export interface ResizeCoverDeps {
+  sharp: (input: Buffer) => { resize: (width: number, height: undefined, options: { fit: string; withoutEnlargement: boolean }) => { webp: () => { toBuffer: () => Promise<Buffer> } } };
+  mkdir: MkdirFn;
+  writeFile: WriteFileFn;
+}
+
+export interface CoverDependencies {
+  extractEpubCover: (absolutePath: string) => Promise<EpubCoverResult | null>;
+  readFile: ReadFileFn;
+  detectAdjacentCover: (directory: string, listDirectory?: ListDirectoryFn) => Promise<string | null>;
+  resizeCoverImage: (input: { imageBuffer: Buffer; outputDir: string }, deps: ResizeCoverDeps) => Promise<{ thumbPath: string; mediumPath: string }>;
+  db: CoverDb;
+}
+
+export async function detectAdjacentCover(
+  directory: string,
+  listDirectory: ListDirectoryFn,
+): Promise<string | null> {
+  let entries: Dirent[];
+
+  try {
+    entries = await listDirectory(directory, { withFileTypes: true });
+  } catch {
+    return null;
+  }
+
+  let coverFile: string | null = null;
+  let fallbackFile: string | null = null;
+
+  for (const entry of entries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const mediaKind = classifyMediaKind(entry.name);
+    if (mediaKind !== MediaKind.COVER) {
+      continue;
+    }
+
+    const baseName = path.basename(entry.name, path.extname(entry.name)).toLowerCase();
+    if (baseName === "cover") {
+      coverFile = path.join(directory, entry.name);
+      break;
+    }
+
+    if (fallbackFile === null) {
+      fallbackFile = path.join(directory, entry.name);
+    }
+  }
+
+  return coverFile ?? fallbackFile;
+}
+
+export async function resizeCoverImage(
+  input: { imageBuffer: Buffer; outputDir: string },
+  deps: ResizeCoverDeps,
+): Promise<{ thumbPath: string; mediumPath: string }> {
+  await deps.mkdir(input.outputDir, { recursive: true });
+
+  const thumbPath = path.join(input.outputDir, "thumb.webp");
+  const mediumPath = path.join(input.outputDir, "medium.webp");
+
+  const thumbBuffer = await deps.sharp(input.imageBuffer)
+    .resize(200, undefined, { fit: "inside", withoutEnlargement: true })
+    .webp()
+    .toBuffer();
+
+  const mediumBuffer = await deps.sharp(input.imageBuffer)
+    .resize(400, undefined, { fit: "inside", withoutEnlargement: true })
+    .webp()
+    .toBuffer();
+
+  await deps.writeFile(thumbPath, thumbBuffer);
+  await deps.writeFile(mediumPath, mediumBuffer);
+
+  return { thumbPath, mediumPath };
+}
+
+export async function processCoverForWork(
+  input: ProcessCoverInput,
+  deps: CoverDependencies,
+): Promise<ProcessCoverResult> {
+  const fileAsset = await deps.db.fileAsset.findUnique({
+    where: { id: input.fileAssetId },
+  });
+
+  if (fileAsset === null) {
+    throw new Error(`File asset "${input.fileAssetId}" was not found`);
+  }
+
+  let imageBuffer: Buffer | null = null;
+  let source: "epub" | "adjacent" | "none" = "none";
+
+  // Try EPUB embedded cover first
+  if (fileAsset.mediaKind === MediaKind.EPUB) {
+    const epubCover = await deps.extractEpubCover(fileAsset.absolutePath);
+    if (epubCover !== null) {
+      imageBuffer = epubCover.buffer;
+      source = "epub";
+    }
+  }
+
+  // Fallback to adjacent cover file
+  if (imageBuffer === null) {
+    const directory = path.dirname(fileAsset.absolutePath);
+    const adjacentPath = await deps.detectAdjacentCover(directory);
+    if (adjacentPath !== null) {
+      imageBuffer = await deps.readFile(adjacentPath);
+      source = "adjacent";
+    }
+  }
+
+  if (imageBuffer === null) {
+    return { source: "none", updated: false };
+  }
+
+  const outputDir = path.join(input.coverCacheDir, input.workId);
+  await deps.resizeCoverImage({ imageBuffer, outputDir }, {} as ResizeCoverDeps);
+
+  await deps.db.work.update({
+    where: { id: input.workId },
+    data: { coverPath: input.workId },
+  });
+
+  return { source, updated: true };
+}

--- a/packages/ingest/src/epub.test.ts
+++ b/packages/ingest/src/epub.test.ts
@@ -5,7 +5,7 @@ import path from "node:path";
 import { once } from "node:events";
 import yazl from "yazl";
 import { afterEach, describe, expect, it } from "vitest";
-import { parseEpubMetadata } from "./index";
+import { parseEpubMetadata, extractEpubCover } from "./index";
 import { EPUB_INTERNALS } from "./epub";
 
 const tempDirectories: string[] = [];
@@ -15,7 +15,11 @@ afterEach(async () => {
   tempDirectories.length = 0;
 });
 
-async function createEpub(entries: Record<string, string>): Promise<string> {
+interface EpubEntries {
+  [path: string]: string | Buffer;
+}
+
+async function createEpub(entries: EpubEntries): Promise<string> {
   const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-epub-"));
   tempDirectories.push(directory);
   const outputPath = path.join(directory, "book.epub");
@@ -25,7 +29,8 @@ async function createEpub(entries: Record<string, string>): Promise<string> {
   zipfile.outputStream.pipe(output);
 
   for (const [entryPath, contents] of Object.entries(entries)) {
-    zipfile.addBuffer(Buffer.from(contents, "utf8"), entryPath);
+    const buffer = typeof contents === "string" ? Buffer.from(contents, "utf8") : contents;
+    zipfile.addBuffer(buffer, entryPath);
   }
 
   zipfile.end();
@@ -184,6 +189,231 @@ describe("EPUB metadata parser", () => {
     ).toThrow("EPUB package document did not contain metadata");
     await expect(
       EPUB_INTERNALS.readZipEntryText("/definitely/missing.epub", "content.opf"),
+    ).rejects.toThrow();
+  });
+});
+
+describe("EPUB cover extraction", () => {
+  const FAKE_COVER = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
+
+  it("extracts cover via EPUB 3 properties='cover-image'", async () => {
+    const epubPath = await createEpub({
+      "META-INF/container.xml": `<?xml version="1.0"?>
+        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+          <rootfiles>
+            <rootfile full-path="content.opf" media-type="application/oebps-package+xml" />
+          </rootfiles>
+        </container>`,
+      "content.opf": `<?xml version="1.0" encoding="utf-8"?>
+        <package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:title>Cover Test</dc:title>
+          </metadata>
+          <manifest>
+            <item id="cover" href="cover.png" media-type="image/png" properties="cover-image" />
+            <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+          </manifest>
+        </package>`,
+      "cover.png": FAKE_COVER,
+    });
+
+    const result = await extractEpubCover(epubPath);
+    expect(result).toEqual({ buffer: FAKE_COVER, mediaType: "image/png" });
+  });
+
+  it("extracts cover via EPUB 2 meta name='cover' fallback", async () => {
+    const epubPath = await createEpub({
+      "META-INF/container.xml": `<?xml version="1.0"?>
+        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+          <rootfiles>
+            <rootfile full-path="content.opf" media-type="application/oebps-package+xml" />
+          </rootfiles>
+        </container>`,
+      "content.opf": `<?xml version="1.0" encoding="utf-8"?>
+        <package version="2.0" xmlns="http://www.idpf.org/2007/opf">
+          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:title>EPUB 2 Cover</dc:title>
+            <meta name="cover" content="cover-img" />
+          </metadata>
+          <manifest>
+            <item id="cover-img" href="images/cover.jpg" media-type="image/jpeg" />
+          </manifest>
+        </package>`,
+      "images/cover.jpg": FAKE_COVER,
+    });
+
+    const result = await extractEpubCover(epubPath);
+    expect(result).toEqual({ buffer: FAKE_COVER, mediaType: "image/jpeg" });
+  });
+
+  it("returns null when no cover is in the manifest", async () => {
+    const epubPath = await createEpub({
+      "META-INF/container.xml": `<?xml version="1.0"?>
+        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+          <rootfiles>
+            <rootfile full-path="content.opf" media-type="application/oebps-package+xml" />
+          </rootfiles>
+        </container>`,
+      "content.opf": `<?xml version="1.0" encoding="utf-8"?>
+        <package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:title>No Cover</dc:title>
+          </metadata>
+          <manifest>
+            <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+          </manifest>
+        </package>`,
+    });
+
+    const result = await extractEpubCover(epubPath);
+    expect(result).toBeNull();
+  });
+
+  it("resolves cover paths relative to OPF directory", async () => {
+    const epubPath = await createEpub({
+      "META-INF/container.xml": `<?xml version="1.0"?>
+        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+          <rootfiles>
+            <rootfile full-path="OEBPS/content.opf" media-type="application/oebps-package+xml" />
+          </rootfiles>
+        </container>`,
+      "OEBPS/content.opf": `<?xml version="1.0" encoding="utf-8"?>
+        <package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:title>Nested Cover</dc:title>
+          </metadata>
+          <manifest>
+            <item id="cover" href="images/cover.jpg" media-type="image/jpeg" properties="cover-image" />
+          </manifest>
+        </package>`,
+      "OEBPS/images/cover.jpg": FAKE_COVER,
+    });
+
+    const result = await extractEpubCover(epubPath);
+    expect(result).toEqual({ buffer: FAKE_COVER, mediaType: "image/jpeg" });
+  });
+
+  it("returns null when manifest is missing entirely", async () => {
+    const epubPath = await createEpub({
+      "META-INF/container.xml": `<?xml version="1.0"?>
+        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+          <rootfiles>
+            <rootfile full-path="content.opf" media-type="application/oebps-package+xml" />
+          </rootfiles>
+        </container>`,
+      "content.opf": `<?xml version="1.0" encoding="utf-8"?>
+        <package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:title>No Manifest</dc:title>
+          </metadata>
+        </package>`,
+    });
+
+    const result = await extractEpubCover(epubPath);
+    expect(result).toBeNull();
+  });
+
+  it("covers readZipEntryBuffer error for missing entry", async () => {
+    const epubPath = await createEpub({
+      "META-INF/container.xml": `<?xml version="1.0"?>
+        <container version="1.0" xmlns="urn:oasis:names:tc:opendocument:xmlns:container">
+          <rootfiles>
+            <rootfile full-path="content.opf" media-type="application/oebps-package+xml" />
+          </rootfiles>
+        </container>`,
+      "content.opf": `<?xml version="1.0" encoding="utf-8"?>
+        <package version="3.0" xmlns="http://www.idpf.org/2007/opf">
+          <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
+            <dc:title>Missing Cover File</dc:title>
+          </metadata>
+          <manifest>
+            <item id="cover" href="missing.png" media-type="image/png" properties="cover-image" />
+          </manifest>
+        </package>`,
+    });
+
+    await expect(extractEpubCover(epubPath)).rejects.toThrow('EPUB entry "missing.png" was not found');
+  });
+
+  it("covers getManifestCoverHref internal edge cases", () => {
+    // No manifest in package
+    expect(EPUB_INTERNALS.getManifestCoverHref(`<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf">
+        <metadata><title>Test</title></metadata>
+      </package>`)).toBeNull();
+
+    // EPUB 3 with cover-image property
+    expect(EPUB_INTERNALS.getManifestCoverHref(`<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf">
+        <metadata />
+        <manifest>
+          <item id="cover" href="cover.jpg" media-type="image/jpeg" properties="cover-image" />
+        </manifest>
+      </package>`)).toEqual({ href: "cover.jpg", mediaType: "image/jpeg" });
+
+    // EPUB 2 meta name="cover" fallback
+    expect(EPUB_INTERNALS.getManifestCoverHref(`<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf">
+        <metadata>
+          <meta name="cover" content="img-cover" />
+        </metadata>
+        <manifest>
+          <item id="img-cover" href="images/cover.png" media-type="image/png" />
+        </manifest>
+      </package>`)).toEqual({ href: "images/cover.png", mediaType: "image/png" });
+
+    // EPUB 2 meta but no matching manifest item
+    expect(EPUB_INTERNALS.getManifestCoverHref(`<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf">
+        <metadata>
+          <meta name="cover" content="nonexistent-id" />
+        </metadata>
+        <manifest>
+          <item id="other" href="other.xhtml" media-type="application/xhtml+xml" />
+        </manifest>
+      </package>`)).toBeNull();
+
+    // Manifest items without properties or cover meta
+    expect(EPUB_INTERNALS.getManifestCoverHref(`<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf">
+        <metadata />
+        <manifest>
+          <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+        </manifest>
+      </package>`)).toBeNull();
+
+    // Single manifest item (not an array)
+    expect(EPUB_INTERNALS.getManifestCoverHref(`<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf">
+        <metadata />
+        <manifest>
+          <item id="cover" href="c.jpg" media-type="image/jpeg" properties="cover-image" />
+        </manifest>
+      </package>`)).toEqual({ href: "c.jpg", mediaType: "image/jpeg" });
+
+    // Metadata with non-cover meta entries (EPUB 2 loop runs but no match)
+    expect(EPUB_INTERNALS.getManifestCoverHref(`<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf">
+        <metadata>
+          <meta name="generator" content="calibre" />
+        </metadata>
+        <manifest>
+          <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+        </manifest>
+      </package>`)).toBeNull();
+
+    // Manifest with items but no metadata element (EPUB 2 fallback can't run)
+    expect(EPUB_INTERNALS.getManifestCoverHref(`<?xml version="1.0"?>
+      <package xmlns="http://www.idpf.org/2007/opf">
+        <manifest>
+          <item id="nav" href="nav.xhtml" media-type="application/xhtml+xml" />
+        </manifest>
+      </package>`)).toBeNull();
+  });
+
+  it("covers readZipEntryBuffer for missing file", async () => {
+    await expect(
+      EPUB_INTERNALS.readZipEntryBuffer("/definitely/missing.epub", "cover.png"),
     ).rejects.toThrow();
   });
 });

--- a/packages/ingest/src/epub.ts
+++ b/packages/ingest/src/epub.ts
@@ -23,7 +23,7 @@ const yauzl = require("yauzl-promise") as {
   open(path: string): Promise<ZipArchive>;
 };
 
-async function readZipEntryText(absolutePath: string, entryPath: string): Promise<string> {
+async function readZipEntryBuffer(absolutePath: string, entryPath: string): Promise<Buffer> {
   const zip = await yauzl.open(absolutePath);
 
   try {
@@ -39,13 +39,18 @@ async function readZipEntryText(absolutePath: string, entryPath: string): Promis
         chunks.push(Buffer.from(chunk));
       }
 
-      return Buffer.concat(chunks).toString("utf8");
+      return Buffer.concat(chunks);
     }
   } finally {
     await zip.close();
   }
 
   throw new Error(`EPUB entry "${entryPath}" was not found`);
+}
+
+async function readZipEntryText(absolutePath: string, entryPath: string): Promise<string> {
+  const buffer = await readZipEntryBuffer(absolutePath, entryPath);
+  return buffer.toString("utf8");
 }
 
 function normalizeZipPath(pathValue: string): string {
@@ -136,6 +141,74 @@ function getPackageMetadata(opfXml: string): ParsedEpubMetadataRaw {
   };
 }
 
+export interface EpubCoverResult {
+  buffer: Buffer;
+  mediaType: string;
+}
+
+interface ManifestItem {
+  id?: string;
+  href?: string;
+  "media-type"?: string;
+  properties?: string;
+}
+
+function getManifestCoverHref(opfXml: string): { href: string; mediaType: string } | null {
+  const parsed = xmlParser.parse(opfXml) as {
+    package?: {
+      metadata?: Record<string, unknown>;
+      manifest?: { item?: ManifestItem | ManifestItem[] };
+    };
+  };
+
+  const manifest = parsed.package?.manifest;
+  if (!manifest) {
+    return null;
+  }
+
+  const items = ensureArray(manifest.item);
+
+  // EPUB 3: look for properties="cover-image"
+  for (const item of items) {
+    if (
+      typeof item.properties === "string" &&
+      item.properties.split(/\s+/).includes("cover-image") &&
+      typeof item.href === "string" &&
+      typeof item["media-type"] === "string"
+    ) {
+      return { href: item.href, mediaType: item["media-type"] };
+    }
+  }
+
+  // EPUB 2 fallback: <meta name="cover" content="item-id" />
+  const metadata = parsed.package?.metadata;
+  if (metadata && typeof metadata === "object") {
+    const metaEntries = ensureArray(metadata.meta);
+    for (const meta of metaEntries) {
+      if (
+        meta &&
+        typeof meta === "object" &&
+        (meta as Record<string, unknown>).name === "cover" &&
+        typeof (meta as Record<string, unknown>).content === "string"
+      ) {
+        const coverId = (meta as Record<string, unknown>).content as string;
+        const coverItem = items.find(
+          (item) => item.id === coverId,
+        );
+        if (
+          coverItem &&
+          typeof coverItem.href === "string" &&
+          typeof coverItem["media-type"] === "string"
+        ) {
+          return { href: coverItem.href, mediaType: coverItem["media-type"] };
+        }
+      }
+    }
+  }
+
+  return null;
+}
+
 export async function parseEpubMetadata(absolutePath: string): Promise<ParsedEpubMetadataRaw> {
   const containerXml = await readZipEntryText(absolutePath, "META-INF/container.xml");
   const rootfilePath = getRootfilePath(containerXml);
@@ -144,12 +217,30 @@ export async function parseEpubMetadata(absolutePath: string): Promise<ParsedEpu
   return getPackageMetadata(opfXml);
 }
 
+export async function extractEpubCover(absolutePath: string): Promise<EpubCoverResult | null> {
+  const containerXml = await readZipEntryText(absolutePath, "META-INF/container.xml");
+  const rootfilePath = getRootfilePath(containerXml);
+  const opfXml = await readZipEntryText(absolutePath, rootfilePath);
+  const coverRef = getManifestCoverHref(opfXml);
+
+  if (coverRef === null) {
+    return null;
+  }
+
+  const coverEntryPath = resolveRelativeZipPath(rootfilePath, coverRef.href);
+  const buffer = await readZipEntryBuffer(absolutePath, coverEntryPath);
+
+  return { buffer, mediaType: coverRef.mediaType };
+}
+
 export const EPUB_INTERNALS = {
+  getManifestCoverHref,
   getPackageMetadata,
   getIdentifierScheme,
   getRootfilePath,
   getTextContent,
   normalizeZipPath,
+  readZipEntryBuffer,
   readZipEntryText,
   resolveRelativeZipPath,
 };

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -43,6 +43,10 @@ export type {
   ScanProgressData,
 } from "./services";
 
+export { extractEpubCover } from "./epub";
+export type { EpubCoverResult } from "./epub";
+export { detectAdjacentCover, resizeCoverImage, processCoverForWork } from "./covers";
+export type { CoverDependencies, ProcessCoverInput, ProcessCoverResult } from "./covers";
 export { PARTIAL_HASH_BYTES } from "./hashing";
 export { SCAN_PROGRESS_INTERVAL } from "./services";
 
@@ -50,6 +54,8 @@ export const INGEST_PUBLIC_API = [
   "classifyMediaKind",
   "createIdentifierMap",
   "createIngestServices",
+  "detectAdjacentCover",
+  "extractEpubCover",
   "canonicalizeBookTitle",
   "canonicalizeContributorName",
   "canonicalizeContributorNames",
@@ -68,6 +74,8 @@ export const INGEST_PUBLIC_API = [
   "parseEpubMetadata",
   "parseFileAssetMetadata",
   "parseOpfSidecar",
+  "processCoverForWork",
+  "resizeCoverImage",
   "scanLibraryRoot",
   "walkRegularFiles",
 ] as const;

--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -1440,6 +1440,7 @@ describe("ingest services", () => {
       createdEdition: false,
       createdEditionFile: false,
       createdWork: false,
+      enqueuedCoverJob: false,
       fileAssetId: "missing-file",
       skipped: true,
     });
@@ -1604,6 +1605,7 @@ describe("ingest services", () => {
         createdEditionFile: true,
         createdWork: false,
         editionId: "edition-1",
+        enqueuedCoverJob: true,
         fileAssetId: "file-1",
         skipped: false,
         workId: "work-1",
@@ -1613,6 +1615,7 @@ describe("ingest services", () => {
         createdEditionFile: false,
         createdWork: false,
         editionId: "edition-1",
+        enqueuedCoverJob: true,
         fileAssetId: "file-1",
         skipped: false,
         workId: "work-1",
@@ -1663,6 +1666,7 @@ describe("ingest services", () => {
       createdEditionFile: true,
       createdWork: false,
       editionId: "edition-2",
+      enqueuedCoverJob: true,
       fileAssetId: "file-1",
       skipped: false,
       workId: "work-1",
@@ -1709,6 +1713,7 @@ describe("ingest services", () => {
       createdEditionFile: true,
       createdWork: true,
       editionId: "edition-1",
+      enqueuedCoverJob: true,
       fileAssetId: "file-1",
       skipped: false,
       workId: "work-1",
@@ -1807,10 +1812,53 @@ describe("ingest services", () => {
       createdEditionFile: false,
       createdWork: false,
       editionId: "edition-1",
+      enqueuedCoverJob: true,
       fileAssetId: "file-1",
       skipped: false,
       workId: "work-1",
     });
+  });
+
+  it("handles orphaned editionFile when edition no longer exists", async () => {
+    const state = createEmptyState("/tmp/root");
+    addFileAsset(state, {
+      metadata: {
+        normalized: {
+          authors: ["N. K. Jemisin"],
+          identifiers: { isbn13: "9780316498834", unknown: [] },
+          title: "The Fifth Season",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "epub",
+        status: "parsed",
+        warnings: [],
+      },
+    });
+    // Add editionFile but NO edition — orphaned reference
+    addEditionFile(state);
+
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+    });
+
+    await expect(
+      services.matchFileAssetToEdition({ fileAssetId: "file-1" }),
+    ).resolves.toEqual({
+      createdEdition: false,
+      createdEditionFile: false,
+      createdWork: false,
+      editionId: undefined,
+      enqueuedCoverJob: false,
+      fileAssetId: "file-1",
+      skipped: false,
+      workId: undefined,
+    });
+
+    // Should NOT enqueue a cover job when edition is missing
+    expect(enqueueLibraryJob).not.toHaveBeenCalled();
   });
 
   it("throws when metadata parsing is requested for an unknown file asset", async () => {

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -294,6 +294,7 @@ export interface MatchFileAssetToEditionResult {
   createdEditionFile: boolean;
   createdWork: boolean;
   editionId?: string;
+  enqueuedCoverJob: boolean;
   fileAssetId: string;
   skipped: boolean;
   workId?: string;
@@ -1230,6 +1231,7 @@ export function createIngestServices(
         createdEdition: false,
         createdEditionFile: false,
         createdWork: false,
+        enqueuedCoverJob: false,
         fileAssetId: input.fileAssetId,
         skipped: true,
       };
@@ -1248,11 +1250,21 @@ export function createIngestServices(
         where: { id: existingEditionFile.editionId },
       });
 
+      let enqueuedCoverJob = false;
+      if (existingEdition?.workId) {
+        await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
+          workId: existingEdition.workId,
+          fileAssetId: fileAsset.id,
+        });
+        enqueuedCoverJob = true;
+      }
+
       return {
         createdEdition: false,
         createdEditionFile: false,
         createdWork: false,
         editionId: existingEdition?.id,
+        enqueuedCoverJob,
         fileAssetId: fileAsset.id,
         skipped: false,
         workId: existingEdition?.workId,
@@ -1267,6 +1279,7 @@ export function createIngestServices(
         createdEdition: false,
         createdEditionFile: false,
         createdWork: false,
+        enqueuedCoverJob: false,
         fileAssetId: fileAsset.id,
         skipped: true,
       };
@@ -1287,11 +1300,17 @@ export function createIngestServices(
     if (editionMatch !== null) {
       const createdEditionFile = await ensureEditionFileLink(ingestDb, editionMatch.id, fileAsset.id);
 
+      await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
+        workId: editionMatch.workId,
+        fileAssetId: fileAsset.id,
+      });
+
       return {
         createdEdition: false,
         createdEditionFile,
         createdWork: false,
         editionId: editionMatch.id,
+        enqueuedCoverJob: true,
         fileAssetId: fileAsset.id,
         skipped: false,
         workId: editionMatch.workId,
@@ -1383,11 +1402,17 @@ export function createIngestServices(
       }
     }
 
+    await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
+      workId,
+      fileAssetId: fileAsset.id,
+    });
+
     return {
       createdEdition: true,
       createdEditionFile,
       createdWork,
       editionId: createdEdition.id,
+      enqueuedCoverJob: true,
       fileAssetId: fileAsset.id,
       skipped: false,
       workId,

--- a/packages/shared/src/queue-client.test.ts
+++ b/packages/shared/src/queue-client.test.ts
@@ -92,6 +92,23 @@ describe("enqueueLibraryJob", () => {
     );
   });
 
+  it("passes retry config for process-cover", async () => {
+    addMock.mockResolvedValueOnce({ id: "job-5" });
+    const { enqueueLibraryJob, LIBRARY_JOB_NAMES, RETRY_CONFIG } = await import("./index");
+
+    await enqueueLibraryJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
+      workId: "work-1",
+      fileAssetId: "file-4",
+    });
+
+    const config = RETRY_CONFIG[LIBRARY_JOB_NAMES.PROCESS_COVER];
+    expect(addMock).toHaveBeenCalledWith(
+      "process-cover",
+      { workId: "work-1", fileAssetId: "file-4" },
+      { attempts: config.attempts, backoff: config.backoff },
+    );
+  });
+
   it("returns 'unknown' when job.id is undefined", async () => {
     addMock.mockResolvedValueOnce({});
     const { enqueueLibraryJob, LIBRARY_JOB_NAMES } = await import("./index");

--- a/packages/shared/src/queues.ts
+++ b/packages/shared/src/queues.ts
@@ -7,6 +7,7 @@ export const LIBRARY_JOB_NAMES = {
   HASH_FILE_ASSET: "hash-file-asset",
   PARSE_FILE_ASSET_METADATA: "parse-file-asset-metadata",
   MATCH_FILE_ASSET_TO_EDITION: "match-file-asset-to-edition",
+  PROCESS_COVER: "process-cover",
 } as const;
 
 export interface BaseJobPayload {
@@ -30,11 +31,17 @@ export interface MatchFileAssetToEditionJobPayload extends BaseJobPayload {
   fileAssetId: string;
 }
 
+export interface ProcessCoverJobPayload extends BaseJobPayload {
+  workId: string;
+  fileAssetId: string;
+}
+
 export interface LibraryJobPayloads {
   [LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT]: ScanLibraryRootJobPayload;
   [LIBRARY_JOB_NAMES.HASH_FILE_ASSET]: HashFileAssetJobPayload;
   [LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA]: ParseFileAssetMetadataJobPayload;
   [LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION]: MatchFileAssetToEditionJobPayload;
+  [LIBRARY_JOB_NAMES.PROCESS_COVER]: ProcessCoverJobPayload;
 }
 
 export type LibraryJobName = keyof LibraryJobPayloads;
@@ -61,6 +68,10 @@ export const RETRY_CONFIG: Record<LibraryJobName, JobRetryConfig> = {
   [LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION]: {
     attempts: 3,
     backoff: { type: "exponential", delay: 2000 },
+  },
+  [LIBRARY_JOB_NAMES.PROCESS_COVER]: {
+    attempts: 2,
+    backoff: { type: "exponential", delay: 3000 },
   },
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -210,6 +210,9 @@ importers:
       music-metadata:
         specifier: ^11.12.3
         version: 11.12.3
+      sharp:
+        specifier: ^0.33.0
+        version: 0.33.5
       yauzl-promise:
         specifier: ^4.0.0
         version: 4.0.0
@@ -717,6 +720,111 @@ packages:
   '@humanwhocodes/retry@0.4.3':
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@inquirer/ansi@1.0.2':
     resolution: {integrity: sha512-S8qNSZiYzFd0wAcyG5AXCvUHC5Sr7xpZ9wZ2py9XR88jUz8wooStVx5M6dRzczbBWjic9NP7+rY0Xi7qqK/aMQ==}
@@ -2646,6 +2754,13 @@ packages:
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
 
+  color-string@1.9.1:
+    resolution: {integrity: sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==}
+
+  color@4.2.3:
+    resolution: {integrity: sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==}
+    engines: {node: '>=12.5.0'}
+
   colorette@2.0.20:
     resolution: {integrity: sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==}
 
@@ -3382,6 +3497,9 @@ packages:
 
   is-arrayish@0.2.1:
     resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
+
+  is-arrayish@0.3.4:
+    resolution: {integrity: sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==}
 
   is-binary-path@2.1.0:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
@@ -4437,6 +4555,10 @@ packages:
     resolution: {integrity: sha512-DVAyeo95TQ/OvaHugLm5V0Dqz3al+dnoP3mZdWWxKJ33IYG1jN5B3sGZyNaYsfzm7JsWokfksSzDl83LnmMing==}
     hasBin: true
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -4474,6 +4596,9 @@ packages:
   simple-invariant@2.0.1:
     resolution: {integrity: sha512-1sbhsxqI+I2tqlmjbz99GXNmZtr6tKIyEgGGnJw/MKGblalqk/XoOYYFJlBzTKZCxx8kLaD3FD5s9BEEjx5Pyg==}
     engines: {node: '>=10'}
+
+  simple-swizzle@0.2.4:
+    resolution: {integrity: sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==}
 
   sisteransi@1.0.5:
     resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
@@ -5515,6 +5640,81 @@ snapshots:
   '@humanwhocodes/module-importer@1.0.1': {}
 
   '@humanwhocodes/retry@0.4.3': {}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.9.0
+    optional: true
+
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -7558,6 +7758,16 @@ snapshots:
 
   color-name@1.1.4: {}
 
+  color-string@1.9.1:
+    dependencies:
+      color-name: 1.1.4
+      simple-swizzle: 0.2.4
+
+  color@4.2.3:
+    dependencies:
+      color-convert: 2.0.1
+      color-string: 1.9.1
+
   colorette@2.0.20: {}
 
   commander@11.1.0: {}
@@ -8303,6 +8513,8 @@ snapshots:
   ipaddr.js@1.9.1: {}
 
   is-arrayish@0.2.1: {}
+
+  is-arrayish@0.3.4: {}
 
   is-binary-path@2.1.0:
     dependencies:
@@ -9427,6 +9639,32 @@ snapshots:
       - supports-color
       - typescript
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -9468,6 +9706,10 @@ snapshots:
   signal-exit@4.1.0: {}
 
   simple-invariant@2.0.1: {}
+
+  simple-swizzle@0.2.4:
+    dependencies:
+      is-arrayish: 0.3.4
 
   sisteransi@1.0.5: {}
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
         "packages/**/*.ts",
         "apps/web/src/**/*.ts",
         "apps/web/src/**/*.tsx",
+        "apps/web/server/routes/api/covers/**/*.ts",
         "workers/**/*.ts",
       ],
       exclude: ["**/*.d.ts", "apps/web/src/routeTree.gen.ts"],

--- a/workers/library-worker/src/index.test.ts
+++ b/workers/library-worker/src/index.test.ts
@@ -12,6 +12,7 @@ const redisConstructorMock = vi.fn();
 const hashFileAssetMock = vi.fn();
 const matchFileAssetToEditionMock = vi.fn();
 const parseFileAssetMetadataMock = vi.fn();
+const processCoverForWorkMock = vi.fn();
 const scanLibraryRootMock = vi.fn();
 const importJobUpdateMock = vi.fn();
 
@@ -52,6 +53,7 @@ vi.mock("@bookhouse/ingest", () => ({
   hashFileAsset: hashFileAssetMock,
   matchFileAssetToEdition: matchFileAssetToEditionMock,
   parseFileAssetMetadata: parseFileAssetMetadataMock,
+  processCoverForWork: processCoverForWorkMock,
   scanLibraryRoot: scanLibraryRootMock,
 }));
 
@@ -74,6 +76,7 @@ beforeEach(() => {
   matchFileAssetToEditionMock.mockReset();
   onMock.mockReset();
   parseFileAssetMetadataMock.mockReset();
+  processCoverForWorkMock.mockReset();
   quitMock.mockReset();
   queueConnectionConfigMock.mockClear();
   redisConstructorMock.mockClear();
@@ -89,6 +92,7 @@ describe("library worker", () => {
       hashFileAsset: hashFileAssetMock,
       matchFileAssetToEdition: matchFileAssetToEditionMock,
       parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
       scanLibraryRoot: scanLibraryRootMock,
     });
 
@@ -96,6 +100,7 @@ describe("library worker", () => {
     hashFileAssetMock.mockResolvedValueOnce("hash-result");
     matchFileAssetToEditionMock.mockResolvedValueOnce("match-result");
     parseFileAssetMetadataMock.mockResolvedValueOnce("parse-result");
+    processCoverForWorkMock.mockResolvedValueOnce("cover-result");
 
     await expect(
       processor({
@@ -121,11 +126,22 @@ describe("library worker", () => {
         name: "parse-file-asset-metadata",
       } as never),
     ).resolves.toBe("parse-result");
+    await expect(
+      processor({
+        data: { workId: "work-1", fileAssetId: "file-1" },
+        name: "process-cover",
+      } as never),
+    ).resolves.toBe("cover-result");
 
     expect(scanLibraryRootMock).toHaveBeenCalledWith({ libraryRootId: "root-1" });
     expect(hashFileAssetMock).toHaveBeenCalledWith({ fileAssetId: "file-1" });
     expect(matchFileAssetToEditionMock).toHaveBeenCalledWith({ fileAssetId: "file-1" });
     expect(parseFileAssetMetadataMock).toHaveBeenCalledWith({ fileAssetId: "file-1" });
+    expect(processCoverForWorkMock).toHaveBeenCalledWith({
+      workId: "work-1",
+      fileAssetId: "file-1",
+      coverCacheDir: "/data/covers",
+    });
   });
 
   it("updates ImportJob to RUNNING then SUCCEEDED when importJobId is present", async () => {
@@ -134,6 +150,7 @@ describe("library worker", () => {
       hashFileAsset: hashFileAssetMock,
       matchFileAssetToEdition: matchFileAssetToEditionMock,
       parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
       scanLibraryRoot: scanLibraryRootMock,
     });
 
@@ -162,6 +179,7 @@ describe("library worker", () => {
       hashFileAsset: hashFileAssetMock,
       matchFileAssetToEdition: matchFileAssetToEditionMock,
       parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
       scanLibraryRoot: scanLibraryRootMock,
     });
 
@@ -193,6 +211,7 @@ describe("library worker", () => {
       hashFileAsset: hashFileAssetMock,
       matchFileAssetToEdition: matchFileAssetToEditionMock,
       parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
       scanLibraryRoot: scanLibraryRootMock,
     });
 
@@ -223,6 +242,7 @@ describe("library worker", () => {
       hashFileAsset: hashFileAssetMock,
       matchFileAssetToEdition: matchFileAssetToEditionMock,
       parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
       scanLibraryRoot: scanLibraryRootMock,
     });
 
@@ -243,6 +263,7 @@ describe("library worker", () => {
       hashFileAsset: hashFileAssetMock,
       matchFileAssetToEdition: matchFileAssetToEditionMock,
       parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
       scanLibraryRoot: scanLibraryRootMock,
     });
 
@@ -282,6 +303,7 @@ describe("library worker", () => {
       hashFileAsset: hashFileAssetMock,
       matchFileAssetToEdition: matchFileAssetToEditionMock,
       parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
       scanLibraryRoot: scanLibraryRootMock,
     });
 
@@ -303,6 +325,7 @@ describe("library worker", () => {
       hashFileAsset: hashFileAssetMock,
       matchFileAssetToEdition: matchFileAssetToEditionMock,
       parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
       scanLibraryRoot: scanLibraryRootMock,
     });
 

--- a/workers/library-worker/src/index.ts
+++ b/workers/library-worker/src/index.ts
@@ -2,7 +2,7 @@ import { pathToFileURL } from "node:url";
 import IORedis from "ioredis";
 import { type Job, Worker } from "bullmq";
 import { db } from "@bookhouse/db";
-import { hashFileAsset, matchFileAssetToEdition, parseFileAssetMetadata, scanLibraryRoot, type ScanProgressData } from "@bookhouse/ingest";
+import { hashFileAsset, matchFileAssetToEdition, parseFileAssetMetadata, processCoverForWork, scanLibraryRoot, type ScanProgressData } from "@bookhouse/ingest";
 import {
   LIBRARY_JOB_NAMES,
   type BaseJobPayload,
@@ -11,6 +11,7 @@ import {
   type LibraryJobPayload,
   type MatchFileAssetToEditionJobPayload,
   type ParseFileAssetMetadataJobPayload,
+  type ProcessCoverJobPayload,
   QUEUES,
   type ScanLibraryRootJobPayload,
   createLogger,
@@ -23,6 +24,7 @@ export interface LibraryWorkerHandlers {
   hashFileAsset: typeof hashFileAsset;
   matchFileAssetToEdition: typeof matchFileAssetToEdition;
   parseFileAssetMetadata: typeof parseFileAssetMetadata;
+  processCoverForWork: (input: { workId: string; fileAssetId: string; coverCacheDir: string }) => Promise<unknown>;
   scanLibraryRoot: typeof scanLibraryRoot;
 }
 
@@ -53,6 +55,14 @@ function dispatch(
       return handlers.matchFileAssetToEdition(job.data as MatchFileAssetToEditionJobPayload);
     case LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA:
       return handlers.parseFileAssetMetadata(job.data as ParseFileAssetMetadataJobPayload);
+    case LIBRARY_JOB_NAMES.PROCESS_COVER: {
+      const coverPayload = job.data as ProcessCoverJobPayload;
+      return handlers.processCoverForWork({
+        workId: coverPayload.workId,
+        fileAssetId: coverPayload.fileAssetId,
+        coverCacheDir: process.env.COVER_CACHE_DIR ?? "/data/covers",
+      });
+    }
     default:
       throw new Error(`Unsupported library job: ${String(job.name)}`);
   }
@@ -63,6 +73,7 @@ export function createLibraryWorkerProcessor(
     hashFileAsset,
     matchFileAssetToEdition,
     parseFileAssetMetadata,
+    processCoverForWork: processCoverForWork as LibraryWorkerHandlers["processCoverForWork"],
     scanLibraryRoot,
   },
 ) {
@@ -115,6 +126,7 @@ export function createLibraryWorker(
     hashFileAsset,
     matchFileAssetToEdition,
     parseFileAssetMetadata,
+    processCoverForWork: processCoverForWork as LibraryWorkerHandlers["processCoverForWork"],
     scanLibraryRoot,
   },
 ) {


### PR DESCRIPTION
## Summary

- Add end-to-end cover image support: extract from EPUBs, detect adjacent cover files, resize with sharp, store in a cache directory, and serve via API route
- EPUB cover extraction parses OPF manifest for `properties="cover-image"` (EPUB 3) with `<meta name="cover">` fallback (EPUB 2)
- Adjacent cover detection scans directories for `cover.*` files, falling back to any `MediaKind.COVER` file
- Covers resized to thumb (200px) and medium (400px) webp via sharp
- `GET /api/covers/:workId/:size` serves covers with Cache-Control headers, returns SVG placeholder for missing covers
- `PROCESS_COVER` job enqueued after work creation/update, processed by library worker
- Docker Compose shares a `covers` volume between web (read-only) and worker (read-write)
- `coverPath` field added to Work model

Closes #43

## Test plan

- [x] `pnpm test` — 100% coverage across all thresholds
- [x] `pnpm lint` — zero errors
- [x] `pnpm typecheck` — zero errors
- [x] `pnpm build` — successful