### PR TITLE
Fix re-scan recovery for failed downstream jobs

### DIFF
--- a/apps/web/src/components/data-table/data-table-column-picker.test.tsx
+++ b/apps/web/src/components/data-table/data-table-column-picker.test.tsx
@@ -1,0 +1,76 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import { DataTableColumnPicker } from "./data-table-column-picker";
+
+const columns = [
+  { id: "authors", label: "Author(s)" },
+  { id: "formats", label: "Format" },
+  { id: "publisher", label: "Publisher" },
+  { id: "isbn", label: "ISBN" },
+];
+
+describe("DataTableColumnPicker", () => {
+  it("renders a trigger button", () => {
+    render(
+      <DataTableColumnPicker
+        columns={columns}
+        columnVisibility={{}}
+        onToggle={vi.fn()}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /columns/i })).toBeTruthy();
+  });
+
+  it("shows all columns as checked when columnVisibility is empty (all visible)", async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTableColumnPicker
+        columns={columns}
+        columnVisibility={{}}
+        onToggle={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /columns/i }));
+    for (const col of columns) {
+      const item = screen.getByRole("menuitemcheckbox", { name: col.label });
+      expect(item.dataset.state).toBe("checked");
+    }
+  });
+
+  it("shows unchecked for columns marked false in columnVisibility", async () => {
+    const user = userEvent.setup();
+    render(
+      <DataTableColumnPicker
+        columns={columns}
+        columnVisibility={{ isbn: false }}
+        onToggle={vi.fn()}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /columns/i }));
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: "ISBN" }).dataset.state,
+    ).toBe("unchecked");
+    expect(
+      screen.getByRole("menuitemcheckbox", { name: "Author(s)" }).dataset.state,
+    ).toBe("checked");
+  });
+
+  it("calls onToggle with column id when a checkbox item is clicked", async () => {
+    const user = userEvent.setup();
+    const onToggle = vi.fn();
+    render(
+      <DataTableColumnPicker
+        columns={columns}
+        columnVisibility={{}}
+        onToggle={onToggle}
+      />,
+    );
+    await user.click(screen.getByRole("button", { name: /columns/i }));
+    await user.click(
+      screen.getByRole("menuitemcheckbox", { name: "Publisher" }),
+    );
+    expect(onToggle).toHaveBeenCalledWith("publisher");
+  });
+});

--- a/apps/web/src/components/data-table/data-table-column-picker.tsx
+++ b/apps/web/src/components/data-table/data-table-column-picker.tsx
@@ -1,0 +1,51 @@
+import { Settings2 } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+
+interface ColumnPickerColumn {
+  id: string;
+  label: string;
+}
+
+interface DataTableColumnPickerProps {
+  columns: ColumnPickerColumn[];
+  columnVisibility: Record<string, boolean>;
+  onToggle: (columnId: string) => void;
+}
+
+export function DataTableColumnPicker({
+  columns,
+  columnVisibility,
+  onToggle,
+}: DataTableColumnPickerProps) {
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline" size="sm">
+          <Settings2 className="mr-2 h-4 w-4" />
+          Columns
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuLabel>Toggle columns</DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {columns.map((col) => (
+          <DropdownMenuCheckboxItem
+            key={col.id}
+            checked={columnVisibility[col.id] !== false}
+            onCheckedChange={() => { onToggle(col.id); }}
+          >
+            {col.label}
+          </DropdownMenuCheckboxItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/components/data-table/virtualized-data-table.test.tsx
+++ b/apps/web/src/components/data-table/virtualized-data-table.test.tsx
@@ -100,6 +100,16 @@ describe("VirtualizedDataTable", () => {
     expect(screen.getByText(/row\(s\) total/)).toBeTruthy();
   });
 
+  it("hides built-in pagination when showPagination is false", () => {
+    useVirtualizerMock.mockImplementation(({ count, getScrollElement, estimateSize }: { count: number; getScrollElement: () => unknown; estimateSize: () => number }) => {
+      getScrollElement();
+      estimateSize();
+      return makeVirtualizer(count);
+    });
+    render(<VirtualizedDataTable columns={columns} data={data} showPagination={false} />);
+    expect(screen.queryByText(/row\(s\) total/)).toBeNull();
+  });
+
   it("renders with custom pageSize and containerHeight", () => {
     useVirtualizerMock.mockImplementation(({ count, getScrollElement, estimateSize }: { count: number; getScrollElement: () => unknown; estimateSize: () => number }) => {
       getScrollElement();
@@ -156,6 +166,101 @@ describe("VirtualizedDataTable", () => {
     });
     const { container } = render(<VirtualizedDataTable columns={columns} data={data} />);
     expect(container).toBeTruthy();
+  });
+
+  it("hides a column when columnVisibility marks it false", () => {
+    useVirtualizerMock.mockImplementation(({ count, getScrollElement, estimateSize }: { count: number; getScrollElement: () => unknown; estimateSize: () => number }) => {
+      getScrollElement();
+      estimateSize();
+      return makeVirtualizer(count);
+    });
+    const multiColumns: ColumnDef<{ name: string; age: string }>[] = [
+      { accessorKey: "name", header: "Name" },
+      { accessorKey: "age", header: "Age" },
+    ];
+    render(
+      <VirtualizedDataTable
+        columns={multiColumns}
+        data={[{ name: "Alice", age: "30" }]}
+        columnVisibility={{ age: false }}
+      />
+    );
+    expect(screen.getByText("Name")).toBeTruthy();
+    expect(screen.queryByText("Age")).toBeNull();
+    expect(screen.queryByText("30")).toBeNull();
+  });
+
+  it("applies whitespace-normal class when textOverflow is 'wrap'", () => {
+    useVirtualizerMock.mockImplementation(({ count, getScrollElement, estimateSize }: { count: number; getScrollElement: () => unknown; estimateSize: () => number }) => {
+      getScrollElement();
+      estimateSize();
+      return makeVirtualizer(count);
+    });
+    render(
+      <VirtualizedDataTable
+        columns={columns}
+        data={data}
+        textOverflow="wrap"
+      />
+    );
+    const cell = screen.getByText("Alice").closest("td");
+    expect(cell?.className).toContain("whitespace-normal");
+    expect(cell?.className).toContain("break-words");
+  });
+
+  it("applies overflow-hidden and text-ellipsis when textOverflow is 'truncate'", () => {
+    useVirtualizerMock.mockImplementation(({ count, getScrollElement, estimateSize }: { count: number; getScrollElement: () => unknown; estimateSize: () => number }) => {
+      getScrollElement();
+      estimateSize();
+      return makeVirtualizer(count);
+    });
+    render(
+      <VirtualizedDataTable
+        columns={columns}
+        data={data}
+        textOverflow="truncate"
+      />
+    );
+    const cell = screen.getByText("Alice").closest("td");
+    expect(cell?.className).toContain("overflow-hidden");
+    expect(cell?.className).toContain("text-ellipsis");
+  });
+
+  it("defaults textOverflow to 'truncate' (no explicit prop)", () => {
+    useVirtualizerMock.mockImplementation(({ count, getScrollElement, estimateSize }: { count: number; getScrollElement: () => unknown; estimateSize: () => number }) => {
+      getScrollElement();
+      estimateSize();
+      return makeVirtualizer(count);
+    });
+    render(<VirtualizedDataTable columns={columns} data={data} />);
+    const cell = screen.getByText("Alice").closest("td");
+    expect(cell?.className).toContain("overflow-hidden");
+    expect(cell?.className).toContain("text-ellipsis");
+  });
+
+  it("applies table-fixed class to the table element", () => {
+    useVirtualizerMock.mockImplementation(({ count, getScrollElement, estimateSize }: { count: number; getScrollElement: () => unknown; estimateSize: () => number }) => {
+      getScrollElement();
+      estimateSize();
+      return makeVirtualizer(count);
+    });
+    const { container } = render(<VirtualizedDataTable columns={columns} data={data} />);
+    const table = container.querySelector("table");
+    expect(table?.className).toContain("table-fixed");
+  });
+
+  it("applies column width style from column size definition", () => {
+    useVirtualizerMock.mockImplementation(({ count, getScrollElement, estimateSize }: { count: number; getScrollElement: () => unknown; estimateSize: () => number }) => {
+      getScrollElement();
+      estimateSize();
+      return makeVirtualizer(count);
+    });
+    const sizedColumns: ColumnDef<TestRow>[] = [
+      { accessorKey: "name", header: "Name", size: 200 },
+    ];
+    render(<VirtualizedDataTable columns={sizedColumns} data={data} />);
+    const th = screen.getByText("Name").closest("th");
+    expect(th?.style.width).toBe("200px");
   });
 
   it("renders selected row (getIsSelected=true branch covers && 'selected')", () => {

--- a/apps/web/src/components/data-table/virtualized-data-table.tsx
+++ b/apps/web/src/components/data-table/virtualized-data-table.tsx
@@ -2,8 +2,10 @@ import { useRef, useState } from "react";
 import {
   type ColumnDef,
   type ColumnFiltersState,
+  type OnChangeFn,
   type RowSelectionState,
   type SortingState,
+  type VisibilityState,
   flexRender,
   getCoreRowModel,
   getFilteredRowModel,
@@ -33,6 +35,10 @@ interface VirtualizedDataTableProps<TData, TValue> {
   estimateRowHeight?: number;
   containerHeight?: string;
   rowSelection?: RowSelectionState;
+  showPagination?: boolean;
+  columnVisibility?: VisibilityState;
+  onColumnVisibilityChange?: OnChangeFn<VisibilityState>;
+  textOverflow?: "wrap" | "truncate";
 }
 
 export function VirtualizedDataTable<TData, TValue>({
@@ -44,6 +50,10 @@ export function VirtualizedDataTable<TData, TValue>({
   estimateRowHeight = 48,
   containerHeight = "70vh",
   rowSelection,
+  showPagination = true,
+  columnVisibility,
+  onColumnVisibilityChange,
+  textOverflow = "truncate",
 }: VirtualizedDataTableProps<TData, TValue>) {
   const [sorting, setSorting] = useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = useState<ColumnFiltersState>([]);
@@ -55,18 +65,20 @@ export function VirtualizedDataTable<TData, TValue>({
     state: {
       sorting,
       columnFilters,
+      ...(columnVisibility !== undefined ? { columnVisibility } : {}),
       ...(rowSelection !== undefined ? { rowSelection } : {}),
     },
     enableRowSelection: rowSelection !== undefined,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
+    onColumnVisibilityChange,
     getCoreRowModel: getCoreRowModel(),
     getSortedRowModel: getSortedRowModel(),
     getFilteredRowModel: getFilteredRowModel(),
     getPaginationRowModel: getPaginationRowModel(),
     initialState: {
       pagination: {
-        pageSize,
+        pageSize: showPagination ? pageSize : Number.MAX_SAFE_INTEGER,
       },
     },
   });
@@ -95,12 +107,12 @@ export function VirtualizedDataTable<TData, TValue>({
         className="rounded-md border overflow-auto"
         style={{ maxHeight: containerHeight }}
       >
-        <Table>
+        <Table className="table-fixed">
           <TableHeader className="sticky top-0 z-10 bg-background">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow key={headerGroup.id}>
                 {headerGroup.headers.map((header) => (
-                  <TableHead key={header.id}>
+                  <TableHead key={header.id} style={{ width: header.getSize() }}>
                     {header.isPlaceholder
                       ? null
                       : flexRender(
@@ -128,7 +140,14 @@ export function VirtualizedDataTable<TData, TValue>({
                       data-state={row.getIsSelected() && "selected"}
                     >
                       {row.getVisibleCells().map((cell) => (
-                        <TableCell key={cell.id}>
+                        <TableCell
+                          key={cell.id}
+                          className={
+                            textOverflow === "wrap"
+                              ? "whitespace-normal break-words"
+                              : "overflow-hidden text-ellipsis"
+                          }
+                        >
                           {flexRender(
                             cell.column.columnDef.cell,
                             cell.getContext(),
@@ -158,7 +177,7 @@ export function VirtualizedDataTable<TData, TValue>({
           </TableBody>
         </Table>
       </div>
-      <DataTablePagination table={table} />
+      {showPagination && <DataTablePagination table={table} />}
     </div>
   );
 }

--- a/apps/web/src/components/library-pagination.test.tsx
+++ b/apps/web/src/components/library-pagination.test.tsx
@@ -4,81 +4,114 @@ import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { LibraryPagination } from "./library-pagination";
 
-describe("LibraryPagination", () => {
-  it("renders nothing when totalCount is 0", () => {
-    const { container } = render(
-      <LibraryPagination page={1} pageSize={50} totalCount={0} onPageChange={vi.fn()} />,
-    );
-    expect(container.querySelector("nav")).toBeNull();
-  });
+function renderPagination(props: Partial<Parameters<typeof LibraryPagination>[0]> = {}) {
+  const defaultProps = {
+    page: 1,
+    pageSize: 50,
+    totalCount: 120,
+    onPageChange: vi.fn(),
+    onPageSizeChange: vi.fn(),
+  };
+  return render(<LibraryPagination {...defaultProps} {...props} />);
+}
 
-  it("renders nothing when only one page", () => {
-    const { container } = render(
-      <LibraryPagination page={1} pageSize={50} totalCount={49} onPageChange={vi.fn()} />,
-    );
-    expect(container.querySelector("nav")).toBeNull();
+describe("LibraryPagination", () => {
+  it("renders total count", () => {
+    renderPagination({ totalCount: 120 });
+    expect(screen.getByText("120 row(s) total")).toBeTruthy();
   });
 
   it("renders page info text", () => {
-    render(
-      <LibraryPagination page={1} pageSize={50} totalCount={120} onPageChange={vi.fn()} />,
-    );
+    renderPagination({ page: 1, pageSize: 50, totalCount: 120 });
     expect(screen.getByText("Page 1 of 3")).toBeTruthy();
   });
 
-  it("renders previous and next buttons", () => {
-    render(
-      <LibraryPagination page={2} pageSize={50} totalCount={120} onPageChange={vi.fn()} />,
-    );
-    expect(screen.getByLabelText("Previous page")).toBeTruthy();
-    expect(screen.getByLabelText("Next page")).toBeTruthy();
+  it("renders rows per page selector", () => {
+    renderPagination();
+    expect(screen.getByText("Rows per page")).toBeTruthy();
   });
 
-  it("disables previous button on first page", () => {
-    render(
-      <LibraryPagination page={1} pageSize={50} totalCount={120} onPageChange={vi.fn()} />,
-    );
-    expect(screen.getByLabelText("Previous page").hasAttribute("disabled")).toBe(true);
+  it("renders navigation buttons", () => {
+    renderPagination({ page: 2, totalCount: 120 });
+    expect(screen.getByLabelText("Go to first page")).toBeTruthy();
+    expect(screen.getByLabelText("Go to previous page")).toBeTruthy();
+    expect(screen.getByLabelText("Go to next page")).toBeTruthy();
+    expect(screen.getByLabelText("Go to last page")).toBeTruthy();
   });
 
-  it("disables next button on last page", () => {
-    render(
-      <LibraryPagination page={3} pageSize={50} totalCount={120} onPageChange={vi.fn()} />,
-    );
-    expect(screen.getByLabelText("Next page").hasAttribute("disabled")).toBe(true);
+  it("disables previous and first buttons on first page", () => {
+    renderPagination({ page: 1, totalCount: 120 });
+    expect(screen.getByLabelText("Go to first page").hasAttribute("disabled")).toBe(true);
+    expect(screen.getByLabelText("Go to previous page").hasAttribute("disabled")).toBe(true);
+  });
+
+  it("disables next and last buttons on last page", () => {
+    renderPagination({ page: 3, pageSize: 50, totalCount: 120 });
+    expect(screen.getByLabelText("Go to next page").hasAttribute("disabled")).toBe(true);
+    expect(screen.getByLabelText("Go to last page").hasAttribute("disabled")).toBe(true);
   });
 
   it("calls onPageChange with page - 1 when previous is clicked", async () => {
     const onPageChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <LibraryPagination page={2} pageSize={50} totalCount={120} onPageChange={onPageChange} />,
-    );
-    await user.click(screen.getByLabelText("Previous page"));
+    renderPagination({ page: 2, totalCount: 120, onPageChange });
+    await user.click(screen.getByLabelText("Go to previous page"));
     expect(onPageChange).toHaveBeenCalledWith(1);
   });
 
   it("calls onPageChange with page + 1 when next is clicked", async () => {
     const onPageChange = vi.fn();
     const user = userEvent.setup();
-    render(
-      <LibraryPagination page={1} pageSize={50} totalCount={120} onPageChange={onPageChange} />,
-    );
-    await user.click(screen.getByLabelText("Next page"));
+    renderPagination({ page: 1, totalCount: 120, onPageChange });
+    await user.click(screen.getByLabelText("Go to next page"));
     expect(onPageChange).toHaveBeenCalledWith(2);
   });
 
+  it("calls onPageChange with 1 when first page button is clicked", async () => {
+    const onPageChange = vi.fn();
+    const user = userEvent.setup();
+    renderPagination({ page: 2, totalCount: 120, onPageChange });
+    await user.click(screen.getByLabelText("Go to first page"));
+    expect(onPageChange).toHaveBeenCalledWith(1);
+  });
+
+  it("calls onPageChange with last page when last page button is clicked", async () => {
+    const onPageChange = vi.fn();
+    const user = userEvent.setup();
+    renderPagination({ page: 1, pageSize: 50, totalCount: 120, onPageChange });
+    await user.click(screen.getByLabelText("Go to last page"));
+    expect(onPageChange).toHaveBeenCalledWith(3);
+  });
+
   it("calculates total pages correctly with exact division", () => {
-    render(
-      <LibraryPagination page={1} pageSize={50} totalCount={100} onPageChange={vi.fn()} />,
-    );
+    renderPagination({ page: 1, pageSize: 50, totalCount: 100 });
     expect(screen.getByText("Page 1 of 2")).toBeTruthy();
   });
 
   it("calculates total pages correctly with remainder", () => {
-    render(
-      <LibraryPagination page={1} pageSize={50} totalCount={51} onPageChange={vi.fn()} />,
-    );
+    renderPagination({ page: 1, pageSize: 50, totalCount: 51 });
     expect(screen.getByText("Page 1 of 2")).toBeTruthy();
+  });
+
+  it("shows Page 1 of 1 when totalCount is 0", () => {
+    renderPagination({ totalCount: 0 });
+    expect(screen.getByText("Page 1 of 1")).toBeTruthy();
+    expect(screen.getByText("0 row(s) total")).toBeTruthy();
+  });
+
+  it("shows Page 1 of 1 when totalCount fits one page", () => {
+    renderPagination({ totalCount: 49, pageSize: 50 });
+    expect(screen.getByText("Page 1 of 1")).toBeTruthy();
+  });
+
+  it("calls onPageSizeChange when rows per page is changed", async () => {
+    const onPageSizeChange = vi.fn();
+    const user = userEvent.setup();
+    renderPagination({ onPageSizeChange });
+
+    // Open the select dropdown and pick a different page size
+    await user.click(screen.getByRole("combobox"));
+    await user.click(screen.getByRole("option", { name: "20" }));
+    expect(onPageSizeChange).toHaveBeenCalledWith(20);
   });
 });

--- a/apps/web/src/components/library-pagination.tsx
+++ b/apps/web/src/components/library-pagination.tsx
@@ -1,11 +1,24 @@
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import {
+  ChevronLeft,
+  ChevronRight,
+  ChevronsLeft,
+  ChevronsRight,
+} from "lucide-react";
 import { Button } from "~/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "~/components/ui/select";
 
 interface LibraryPaginationProps {
   page: number;
   pageSize: number;
   totalCount: number;
   onPageChange: (page: number) => void;
+  onPageSizeChange: (pageSize: number) => void;
 }
 
 export function LibraryPagination({
@@ -13,36 +26,78 @@ export function LibraryPagination({
   pageSize,
   totalCount,
   onPageChange,
+  onPageSizeChange,
 }: LibraryPaginationProps) {
-  const totalPages = Math.ceil(totalCount / pageSize);
-
-  if (totalPages <= 1) {
-    return null;
-  }
+  const totalPages = Math.max(1, Math.ceil(totalCount / pageSize));
 
   return (
-    <nav className="flex items-center justify-center gap-4">
-      <Button
-        variant="outline"
-        size="sm"
-        disabled={page <= 1}
-        onClick={() => { onPageChange(page - 1); }}
-        aria-label="Previous page"
-      >
-        <ChevronLeft className="size-4" />
-      </Button>
-      <span className="text-sm text-muted-foreground">
-        Page {String(page)} of {String(totalPages)}
-      </span>
-      <Button
-        variant="outline"
-        size="sm"
-        disabled={page >= totalPages}
-        onClick={() => { onPageChange(page + 1); }}
-        aria-label="Next page"
-      >
-        <ChevronRight className="size-4" />
-      </Button>
-    </nav>
+    <div className="flex flex-wrap items-center justify-between gap-4 px-2">
+      <div className="text-sm text-muted-foreground">
+        {String(totalCount)} row(s) total
+      </div>
+      <div className="flex flex-wrap items-center gap-4">
+        <div className="flex items-center gap-2">
+          <p className="text-sm font-medium whitespace-nowrap">Rows per page</p>
+          <Select
+            value={String(pageSize)}
+            onValueChange={(value) => {
+              onPageSizeChange(Number(value));
+            }}
+          >
+            <SelectTrigger className="h-8 w-[70px]">
+              <SelectValue placeholder={String(pageSize)} />
+            </SelectTrigger>
+            <SelectContent side="top">
+              {[20, 30, 50, 100].map((size) => (
+                <SelectItem key={size} value={String(size)}>
+                  {size}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+        <div className="text-sm font-medium whitespace-nowrap">
+          Page {String(page)} of {String(totalPages)}
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="outline"
+            className="hidden h-8 w-8 p-0 lg:flex"
+            onClick={() => { onPageChange(1); }}
+            disabled={page <= 1}
+            aria-label="Go to first page"
+          >
+            <ChevronsLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className="h-8 w-8 p-0"
+            onClick={() => { onPageChange(page - 1); }}
+            disabled={page <= 1}
+            aria-label="Go to previous page"
+          >
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className="h-8 w-8 p-0"
+            onClick={() => { onPageChange(page + 1); }}
+            disabled={page >= totalPages}
+            aria-label="Go to next page"
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+          <Button
+            variant="outline"
+            className="hidden h-8 w-8 p-0 lg:flex"
+            onClick={() => { onPageChange(totalPages); }}
+            disabled={page >= totalPages}
+            aria-label="Go to last page"
+          >
+            <ChevronsRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+    </div>
   );
 }

--- a/apps/web/src/hooks/use-library-table-preferences.test.ts
+++ b/apps/web/src/hooks/use-library-table-preferences.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from "@testing-library/react";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  useLibraryTablePreferences,
+  resetSnapshotCache,
+  type LibraryTablePreferences,
+} from "./use-library-table-preferences";
+
+const STORAGE_KEY = "library-table-prefs";
+
+const DEFAULTS: LibraryTablePreferences = {
+  columnVisibility: {},
+  textOverflow: "truncate",
+};
+
+function makeStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => {
+      store.set(key, value);
+    },
+    removeItem: (key: string) => {
+      store.delete(key);
+    },
+    clear: () => {
+      store.clear();
+    },
+    get length() {
+      return store.size;
+    },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  };
+}
+
+describe("useLibraryTablePreferences", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeStorage());
+    resetSnapshotCache();
+  });
+
+  it("defaults when localStorage is empty", () => {
+    const { result } = renderHook(() => useLibraryTablePreferences());
+    expect(result.current[0]).toEqual(DEFAULTS);
+  });
+
+  it("reads stored preferences from localStorage", () => {
+    const prefs: LibraryTablePreferences = {
+      columnVisibility: { authors: false, isbn: false },
+      textOverflow: "wrap",
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+    const { result } = renderHook(() => useLibraryTablePreferences());
+    expect(result.current[0]).toEqual(prefs);
+  });
+
+  it("ignores invalid JSON and defaults", () => {
+    localStorage.setItem(STORAGE_KEY, "not-json");
+    const { result } = renderHook(() => useLibraryTablePreferences());
+    expect(result.current[0]).toEqual(DEFAULTS);
+  });
+
+  it("ignores JSON with wrong shape and defaults", () => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ bad: true }));
+    const { result } = renderHook(() => useLibraryTablePreferences());
+    expect(result.current[0]).toEqual(DEFAULTS);
+  });
+
+  it("ignores JSON null value and defaults", () => {
+    localStorage.setItem(STORAGE_KEY, "null");
+    const { result } = renderHook(() => useLibraryTablePreferences());
+    expect(result.current[0]).toEqual(DEFAULTS);
+  });
+
+  it("ignores invalid textOverflow value and defaults", () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ columnVisibility: {}, textOverflow: "bogus" }),
+    );
+    const { result } = renderHook(() => useLibraryTablePreferences());
+    expect(result.current[0]).toEqual(DEFAULTS);
+  });
+
+  it("persists to localStorage when setPrefs is called", () => {
+    const { result } = renderHook(() => useLibraryTablePreferences());
+    const updated: LibraryTablePreferences = {
+      columnVisibility: { publisher: false },
+      textOverflow: "wrap",
+    };
+    act(() => {
+      result.current[1](updated);
+    });
+    expect(result.current[0]).toEqual(updated);
+    expect(localStorage.getItem(STORAGE_KEY)).toBe(JSON.stringify(updated));
+  });
+
+  it("re-reads on storage events", () => {
+    const { result } = renderHook(() => useLibraryTablePreferences());
+    expect(result.current[0]).toEqual(DEFAULTS);
+
+    const updated: LibraryTablePreferences = {
+      columnVisibility: { formats: false },
+      textOverflow: "wrap",
+    };
+    act(() => {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(updated));
+      window.dispatchEvent(new Event("storage"));
+    });
+    expect(result.current[0]).toEqual(updated);
+  });
+
+  it("cleans up storage listener on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useLibraryTablePreferences());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("storage", expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it("returns defaults during SSR via getServerSnapshot", () => {
+    function TestComponent() {
+      const [prefs] = useLibraryTablePreferences();
+      return createElement("span", null, prefs.textOverflow);
+    }
+    const html = renderToString(createElement(TestComponent));
+    expect(html).toContain("truncate");
+  });
+});

--- a/apps/web/src/hooks/use-library-table-preferences.ts
+++ b/apps/web/src/hooks/use-library-table-preferences.ts
@@ -1,0 +1,74 @@
+import { useState, useCallback, useSyncExternalStore } from "react";
+
+export type TextOverflow = "wrap" | "truncate";
+
+export interface LibraryTablePreferences {
+  columnVisibility: Record<string, boolean>;
+  textOverflow: TextOverflow;
+}
+
+const STORAGE_KEY = "library-table-prefs";
+
+const DEFAULTS: LibraryTablePreferences = {
+  columnVisibility: {},
+  textOverflow: "truncate",
+};
+
+function isValidPrefs(value: unknown): value is LibraryTablePreferences {
+  if (typeof value !== "object" || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (typeof obj.columnVisibility !== "object" || obj.columnVisibility === null)
+    return false;
+  if (obj.textOverflow !== "wrap" && obj.textOverflow !== "truncate")
+    return false;
+  return true;
+}
+
+const UNINITIALIZED = Symbol("uninitialized");
+let cachedRaw: string | null | typeof UNINITIALIZED = UNINITIALIZED;
+let cachedPrefs: LibraryTablePreferences = DEFAULTS;
+
+function getSnapshot(): LibraryTablePreferences {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  if (stored === cachedRaw) return cachedPrefs;
+  cachedRaw = stored;
+  if (!stored) {
+    cachedPrefs = DEFAULTS;
+    return DEFAULTS;
+  }
+  try {
+    const parsed: unknown = JSON.parse(stored);
+    cachedPrefs = isValidPrefs(parsed) ? parsed : DEFAULTS;
+  } catch {
+    cachedPrefs = DEFAULTS;
+  }
+  return cachedPrefs;
+}
+
+function subscribe(callback: () => void): () => void {
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+  };
+}
+
+/** @internal — test-only cache reset */
+export function resetSnapshotCache(): void {
+  cachedRaw = UNINITIALIZED;
+  cachedPrefs = DEFAULTS;
+}
+
+export function useLibraryTablePreferences(): [
+  LibraryTablePreferences,
+  (prefs: LibraryTablePreferences) => void,
+] {
+  const prefs = useSyncExternalStore(subscribe, getSnapshot, () => DEFAULTS);
+  const [, setTick] = useState(0);
+
+  const setPrefs = useCallback((p: LibraryTablePreferences) => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(p));
+    setTick((t) => t + 1);
+  }, []);
+
+  return [prefs, setPrefs];
+}

--- a/apps/web/src/lib/server-fns/library.test.ts
+++ b/apps/web/src/lib/server-fns/library.test.ts
@@ -354,15 +354,14 @@ describe("getFilteredLibraryWorksServerFn", () => {
 
   it("returns facet counts for hasCover", async () => {
     findManyMock.mockResolvedValue([]);
-    countMock.mockResolvedValue(10);
     editionGroupByMock.mockResolvedValue([]);
     seriesCountMock.mockResolvedValue(0);
 
-    // countMock is called twice: once for totalCount, once for withCover
-    // We need to be specific about which calls return what
+    // countMock is called three times: totalCount, withCover, withoutCover
     countMock
       .mockResolvedValueOnce(10)  // totalCount
-      .mockResolvedValueOnce(7);  // withCover
+      .mockResolvedValueOnce(7)   // withCover
+      .mockResolvedValueOnce(3);  // withoutCover
 
     const result = await getFilteredLibraryWorksServerFn({ data: {} });
 
@@ -370,6 +369,28 @@ describe("getFilteredLibraryWorksServerFn", () => {
       withCover: 7,
       withoutCover: 3,
     });
+  });
+
+  it("returns correct hasCover facet counts when hasCover filter is active", async () => {
+    findManyMock.mockResolvedValue([]);
+    editionGroupByMock.mockResolvedValue([]);
+    seriesCountMock.mockResolvedValue(0);
+
+    // When hasCover=false is active:
+    // totalCount (filtered, coverPath=null) = 343
+    // withCoverCount (coverPath not null) = 347
+    // withoutCoverCount (coverPath null) = 343
+    countMock
+      .mockResolvedValueOnce(343)  // totalCount (filtered by hasCover=false)
+      .mockResolvedValueOnce(347)  // withCoverCount
+      .mockResolvedValueOnce(343); // withoutCoverCount
+
+    const result = await getFilteredLibraryWorksServerFn({ data: { hasCover: false } });
+
+    // Facet counts must not go negative
+    expect(result.facetCounts.hasCover.withCover).toBe(347);
+    expect(result.facetCounts.hasCover.withoutCover).toBe(343);
+    expect(result.facetCounts.hasCover.withoutCover).toBeGreaterThanOrEqual(0);
   });
 
   it("returns series count in facet counts", async () => {

--- a/apps/web/src/lib/server-fns/library.ts
+++ b/apps/web/src/lib/server-fns/library.ts
@@ -103,7 +103,7 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
     const where = buildWhere(parsed);
     const orderBy = buildOrderBy(parsed.sort);
 
-    const [works, totalCount, formatCounts, withCoverCount, seriesCount] =
+    const [works, totalCount, formatCounts, withCoverCount, withoutCoverCount, seriesCount] =
       await Promise.all([
         db.work.findMany({
           where,
@@ -118,6 +118,7 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
           _count: { _all: true },
         }),
         db.work.count({ where: { coverPath: { not: null } } }),
+        db.work.count({ where: { coverPath: null } }),
         db.series.count(),
       ]);
 
@@ -128,7 +129,7 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
         format: formatCounts,
         hasCover: {
           withCover: withCoverCount,
-          withoutCover: totalCount - withCoverCount,
+          withoutCover: withoutCoverCount,
         },
         series: seriesCount,
       },

--- a/apps/web/src/routes/_authenticated/-library.index.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.index.test.tsx
@@ -113,6 +113,12 @@ vi.mock("~/hooks/use-library-view-preference", () => ({
   useLibraryViewPreference: () => [mockView, mockSetView],
 }));
 
+let mockTablePrefs: { columnVisibility: Record<string, boolean>; textOverflow: "wrap" | "truncate" } = { columnVisibility: {}, textOverflow: "truncate" };
+const mockSetTablePrefs = vi.fn();
+vi.mock("~/hooks/use-library-table-preferences", () => ({
+  useLibraryTablePreferences: () => [mockTablePrefs, mockSetTablePrefs],
+}));
+
 vi.mock("~/components/library-grid", () => ({
   LibraryGrid: ({ works, progressMap }: { works: unknown[]; progressMap?: Record<string, number> }) => (
     <div data-testid="library-grid" data-progress-map={progressMap ? JSON.stringify(progressMap) : undefined}>Grid: {String(works.length)} works</div>
@@ -146,6 +152,14 @@ vi.mock("~/components/library-pagination", () => ({
     return (
       <div data-testid="library-pagination" data-page={String(props.page)} data-total={String(props.totalCount)} />
     );
+  },
+}));
+
+let capturedColumnPickerProps: Record<string, unknown> = {};
+vi.mock("~/components/data-table/data-table-column-picker", () => ({
+  DataTableColumnPicker: (props: Record<string, unknown>) => {
+    capturedColumnPickerProps = props;
+    return <div data-testid="column-picker" />;
   },
 }));
 
@@ -214,9 +228,11 @@ describe("LibraryPage", () => {
     };
     mockSearch = { page: 1, pageSize: 50, sort: "title-asc" };
     mockView = "grid";
+    mockTablePrefs = { columnVisibility: {}, textOverflow: "truncate" };
     capturedToolbarProps = {};
     capturedFiltersProps = {};
     capturedPaginationProps = {};
+    capturedColumnPickerProps = {};
     vi.clearAllMocks();
   });
 
@@ -622,6 +638,20 @@ describe("LibraryPage", () => {
     expect(mockNavigate).toHaveBeenCalled();
   });
 
+  it("navigates with pageSize and page 1 when onPageSizeChange is called", async () => {
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 100, facetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    const onPageSizeChange = capturedPaginationProps.onPageSizeChange as (v: number) => void;
+    onPageSizeChange(20);
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
   it("filters works by reading status", async () => {
     mockView = "grid";
     mockLoaderData = {
@@ -782,5 +812,107 @@ describe("LibraryPage", () => {
     const filters = capturedFiltersProps.filters as Record<string, unknown>;
     expect(filters.format).toEqual(["EBOOK"]);
     expect(filters.hasCover).toBe(true);
+  });
+
+  it("renders column picker and text overflow toggle in table view", async () => {
+    mockView = "table";
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    expect(screen.getByTestId("column-picker")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /wrap text/i })).toBeTruthy();
+  });
+
+  it("does not render column picker or text overflow toggle in grid view", async () => {
+    mockView = "grid";
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    expect(screen.queryByTestId("column-picker")).toBeNull();
+    expect(screen.queryByRole("button", { name: /wrap text/i })).toBeNull();
+    expect(screen.queryByRole("button", { name: /truncate text/i })).toBeNull();
+  });
+
+  it("passes columnVisibility from preferences to column picker", async () => {
+    mockView = "table";
+    mockTablePrefs = { columnVisibility: { isbn: false }, textOverflow: "truncate" };
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    expect(capturedColumnPickerProps.columnVisibility).toEqual({ isbn: false });
+  });
+
+  it("calls setTablePrefs when column is toggled", async () => {
+    mockView = "table";
+    mockTablePrefs = { columnVisibility: {}, textOverflow: "truncate" };
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    const onToggle = capturedColumnPickerProps.onToggle as (id: string) => void;
+    onToggle("isbn");
+    expect(mockSetTablePrefs).toHaveBeenCalledWith({
+      columnVisibility: { isbn: false },
+      textOverflow: "truncate",
+    });
+  });
+
+  it("calls setTablePrefs when text overflow toggle is clicked", async () => {
+    mockView = "table";
+    mockTablePrefs = { columnVisibility: {}, textOverflow: "truncate" };
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    const { fireEvent } = await import("@testing-library/react");
+    fireEvent.click(screen.getByRole("button", { name: /wrap text/i }));
+    expect(mockSetTablePrefs).toHaveBeenCalledWith({
+      columnVisibility: {},
+      textOverflow: "wrap",
+    });
+  });
+
+  it("shows 'Truncate' label when textOverflow is 'wrap' and toggles back to truncate", async () => {
+    mockView = "table";
+    mockTablePrefs = { columnVisibility: {}, textOverflow: "wrap" };
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    const btn = screen.getByRole("button", { name: /truncate text/i });
+    expect(btn).toBeTruthy();
+    const { fireEvent } = await import("@testing-library/react");
+    fireEvent.click(btn);
+    expect(mockSetTablePrefs).toHaveBeenCalledWith({
+      columnVisibility: {},
+      textOverflow: "truncate",
+    });
   });
 });

--- a/apps/web/src/routes/_authenticated/library.index.tsx
+++ b/apps/web/src/routes/_authenticated/library.index.tsx
@@ -2,10 +2,13 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router";
 import { useSSE } from "~/hooks/use-sse";
 import { useLibraryViewPreference } from "~/hooks/use-library-view-preference";
+import { useLibraryTablePreferences } from "~/hooks/use-library-table-preferences";
 import type { ColumnDef } from "@tanstack/react-table";
-import { BookOpen, Loader2 } from "lucide-react";
+import { AlignJustify, BookOpen, Loader2, WrapText } from "lucide-react";
 import { VirtualizedDataTable, DataTableColumnHeader } from "~/components/data-table";
+import { DataTableColumnPicker } from "~/components/data-table/data-table-column-picker";
 import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
 import { GridPageSkeleton } from "~/components/skeletons/grid-page-skeleton";
 import { LibraryToolbar } from "~/components/library-toolbar";
 import { LibraryGrid } from "~/components/library-grid";
@@ -47,6 +50,13 @@ function getFormats(work: LibraryWork): string[] {
   return [...new Set(work.editions.map((e) => e.formatFamily))];
 }
 
+const COLUMN_PICKER_ITEMS = [
+  { id: "authors", label: "Author(s)" },
+  { id: "formats", label: "Format" },
+  { id: "publisher", label: "Publisher" },
+  { id: "isbn", label: "ISBN" },
+];
+
 const columns: ColumnDef<LibraryWork>[] = [
   {
     accessorKey: "titleDisplay",
@@ -63,6 +73,8 @@ const columns: ColumnDef<LibraryWork>[] = [
         )}
       </Link>
     ),
+    size: 300,
+    enableHiding: false,
   },
   {
     id: "authors",
@@ -70,6 +82,7 @@ const columns: ColumnDef<LibraryWork>[] = [
       <DataTableColumnHeader column={column} title="Author(s)" />
     ),
     accessorFn: (row) => getAuthors(row),
+    size: 200,
   },
   {
     id: "formats",
@@ -80,6 +93,7 @@ const columns: ColumnDef<LibraryWork>[] = [
           {f}
         </Badge>
       )),
+    size: 80,
   },
   {
     id: "publisher",
@@ -87,12 +101,14 @@ const columns: ColumnDef<LibraryWork>[] = [
       <DataTableColumnHeader column={column} title="Publisher" />
     ),
     accessorFn: (row) => row.editions[0]?.publisher ?? "—",
+    size: 150,
   },
   {
     id: "isbn",
     header: "ISBN",
     accessorFn: (row) =>
       row.editions[0]?.isbn13 ?? row.editions[0]?.isbn10 ?? "—",
+    size: 120,
   },
 ];
 
@@ -121,6 +137,7 @@ function LibraryPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const [view, setView] = useLibraryViewPreference();
+  const [tablePrefs, setTablePrefs] = useLibraryTablePreferences();
   const [readingFilter, setReadingFilter] = useState<ReadingFilter>("all");
   const [prevCount, setPrevCount] = useState(totalCount);
 
@@ -184,6 +201,31 @@ function LibraryPage() {
     [updateSearch],
   );
 
+  const handlePageSizeChange = useCallback(
+    (pageSize: number) => {
+      updateSearch({ pageSize, page: 1 });
+    },
+    [updateSearch],
+  );
+
+  const handleColumnToggle = useCallback(
+    (columnId: string) => {
+      const current = tablePrefs.columnVisibility[columnId] !== false;
+      setTablePrefs({
+        ...tablePrefs,
+        columnVisibility: { ...tablePrefs.columnVisibility, [columnId]: !current },
+      });
+    },
+    [tablePrefs, setTablePrefs],
+  );
+
+  const handleTextOverflowToggle = useCallback(() => {
+    setTablePrefs({
+      ...tablePrefs,
+      textOverflow: tablePrefs.textOverflow === "truncate" ? "wrap" : "truncate",
+    });
+  }, [tablePrefs, setTablePrefs]);
+
   const filteredByReading = useMemo(
     () => filterByReadingStatus(works, readingFilter, progressMap),
     [works, readingFilter, progressMap],
@@ -242,7 +284,7 @@ function LibraryPage() {
             onFiltersChange={handleFiltersChange}
           />
         </aside>
-        <div className="flex-1 space-y-4">
+        <div className="flex-1 min-w-0 space-y-4">
           <LibraryToolbar
             searchValue={search.q ?? ""}
             onSearchChange={handleSearchChange}
@@ -253,16 +295,45 @@ function LibraryPage() {
             filterValue={readingFilter}
             onFilterChange={setReadingFilter}
           />
+          {view === "table" && (
+            <div className="flex items-center gap-2 justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={handleTextOverflowToggle}
+                aria-label={tablePrefs.textOverflow === "truncate" ? "Wrap text" : "Truncate text"}
+              >
+                {tablePrefs.textOverflow === "truncate" ? (
+                  <WrapText className="mr-2 h-4 w-4" />
+                ) : (
+                  <AlignJustify className="mr-2 h-4 w-4" />
+                )}
+                {tablePrefs.textOverflow === "truncate" ? "Wrap" : "Truncate"}
+              </Button>
+              <DataTableColumnPicker
+                columns={COLUMN_PICKER_ITEMS}
+                columnVisibility={tablePrefs.columnVisibility}
+                onToggle={handleColumnToggle}
+              />
+            </div>
+          )}
           {view === "grid" ? (
             <LibraryGrid works={filteredByReading} progressMap={progressMap} />
           ) : (
-            <VirtualizedDataTable columns={columns} data={filteredByReading} />
+            <VirtualizedDataTable
+              columns={columns}
+              data={filteredByReading}
+              showPagination={false}
+              columnVisibility={tablePrefs.columnVisibility}
+              textOverflow={tablePrefs.textOverflow}
+            />
           )}
           <LibraryPagination
             page={search.page}
             pageSize={search.pageSize}
             totalCount={totalCount}
             onPageChange={handlePageChange}
+            onPageSizeChange={handlePageSizeChange}
           />
         </div>
       </div>

--- a/apps/web/src/routes/_authenticated/settings/libraries.tsx
+++ b/apps/web/src/routes/_authenticated/settings/libraries.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { toast } from "sonner";
-import { AlertCircle, FolderOpen, Play, Trash2 } from "lucide-react";
+import { AlertCircle, FolderOpen, Loader2, Play, Trash2 } from "lucide-react";
 import { useSSE } from "~/hooks/use-sse";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -125,6 +125,7 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
           },
         },
       });
+      void router.invalidate();
     } catch (error) {
       toast.error(
         error instanceof Error ? error.message : "Failed to start scan",
@@ -175,10 +176,24 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
                 variant="outline"
                 size="sm"
                 onClick={() => { void handleScan(); }}
-                disabled={scanning}
+                disabled={scanning || root.scanProgress !== null}
               >
-                <Play className="size-4" />
-                {scanning ? "Starting..." : "Scan Now"}
+                {root.scanProgress ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Scanning...
+                  </>
+                ) : scanning ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Starting...
+                  </>
+                ) : (
+                  <>
+                    <Play className="size-4" />
+                    Scan Now
+                  </>
+                )}
               </Button>
               <Button
                 variant="outline"

--- a/packages/ingest/src/covers.test.ts
+++ b/packages/ingest/src/covers.test.ts
@@ -265,6 +265,32 @@ describe("processCoverForWork", () => {
     expect(result.updated).toBe(false);
   });
 
+  it("falls back to adjacent cover when extractEpubCover throws", async () => {
+    const workUpdate = vi.fn().mockResolvedValue({});
+    const deps = createMockDeps({
+      extractEpubCover: vi.fn().mockRejectedValue(new Error('EPUB entry "cover.jpg" was not found')),
+      detectAdjacentCover: vi.fn().mockResolvedValue("/books/author/title/cover.jpg"),
+      db: {
+        fileAsset: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "fa-1",
+            absolutePath: "/books/author/title/book.epub",
+            mediaKind: MediaKind.EPUB,
+          }),
+        },
+        work: { update: workUpdate },
+      },
+    });
+
+    const result = await processCoverForWork(createInput(), deps);
+
+    expect(deps.extractEpubCover).toHaveBeenCalled();
+    expect(deps.detectAdjacentCover).toHaveBeenCalled();
+    expect(deps.readFile).toHaveBeenCalledWith("/books/author/title/cover.jpg");
+    expect(result.source).toBe("adjacent");
+    expect(result.updated).toBe(true);
+  });
+
   it("throws when file asset is not found", async () => {
     const deps = createMockDeps({
       db: {

--- a/packages/ingest/src/covers.ts
+++ b/packages/ingest/src/covers.ts
@@ -3,6 +3,7 @@ import { readFile, mkdir, writeFile, readdir } from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import sharp from "sharp";
 import { MediaKind } from "@bookhouse/domain";
+import { createLogger } from "@bookhouse/shared";
 import { classifyMediaKind } from "./classification";
 import { extractEpubCover, type EpubCoverResult } from "./epub";
 
@@ -43,12 +44,17 @@ export interface ResizeCoverDeps {
   writeFile: WriteFileFn;
 }
 
+export interface CoverLogger {
+  info(obj: Record<string, unknown>, msg: string): void;
+}
+
 export interface CoverDependencies {
   extractEpubCover: (absolutePath: string) => Promise<EpubCoverResult | null>;
   readFile: ReadFileFn;
   detectAdjacentCover: (directory: string, listDirectory?: ListDirectoryFn) => Promise<string | null>;
   resizeCoverImage: (input: { imageBuffer: Buffer; outputDir: string }, deps: ResizeCoverDeps) => Promise<{ thumbPath: string; mediumPath: string }>;
   db: CoverDb;
+  logger?: CoverLogger;
 }
 
 export async function detectAdjacentCover(
@@ -132,10 +138,15 @@ export async function processCoverForWork(
 
   // Try EPUB embedded cover first
   if (fileAsset.mediaKind === MediaKind.EPUB) {
-    const epubCover = await deps.extractEpubCover(fileAsset.absolutePath);
-    if (epubCover !== null) {
-      imageBuffer = epubCover.buffer;
-      source = "epub";
+    try {
+      const epubCover = await deps.extractEpubCover(fileAsset.absolutePath);
+      if (epubCover !== null) {
+        imageBuffer = epubCover.buffer;
+        source = "epub";
+      }
+    } catch {
+      // EPUB cover extraction failed (e.g., missing zip entry) — fall through to adjacent cover
+      deps.logger?.info({ workId: input.workId, fileAssetId: input.fileAssetId }, "EPUB cover extraction failed, trying adjacent cover");
     }
   }
 
@@ -150,6 +161,7 @@ export async function processCoverForWork(
   }
 
   if (imageBuffer === null) {
+    deps.logger?.info({ workId: input.workId, fileAssetId: input.fileAssetId, mediaKind: fileAsset.mediaKind, directory: path.dirname(fileAsset.absolutePath) }, "No cover found for work");
     return { source: "none", updated: false };
   }
 
@@ -161,14 +173,17 @@ export async function processCoverForWork(
     data: { coverPath: input.workId },
   });
 
+  deps.logger?.info({ workId: input.workId, source }, "Cover processed successfully");
   return { source, updated: true };
 }
 
 export function processCoverForWorkDefault(db: CoverDb) {
+  const logger = createLogger("process-cover");
   return (input: ProcessCoverInput) =>
     processCoverForWork(input, {
       db,
       extractEpubCover,
+      logger,
       readFile,
       detectAdjacentCover: (directory) => detectAdjacentCover(directory, readdir),
       resizeCoverImage: (resizeInput) =>

--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -12,7 +12,7 @@ import {
   type FileAsset,
   MediaKind,
 } from "@bookhouse/domain";
-import { LIBRARY_JOB_NAMES } from "@bookhouse/shared";
+import { LIBRARY_JOB_NAMES, type LibraryJobName, type LibraryJobPayloads } from "@bookhouse/shared";
 import {
   canonicalizeBookTitle,
   canonicalizeContributorNames,
@@ -80,6 +80,7 @@ interface TestState {
 }
 
 interface TestWork {
+  coverPath: string | null;
   description: string | null;
   enrichmentStatus: EnrichmentStatus;
   id: string;
@@ -251,6 +252,7 @@ function createTestDb(state: TestState): IngestDb {
         await Promise.resolve();
         workSequence += 1;
         const created: TestWork = {
+          coverPath: null,
           description: null,
           enrichmentStatus: "ENRICHED",
           id: `work-${String(workSequence)}`,
@@ -488,6 +490,7 @@ function addFileAsset(state: TestState, overrides: Partial<TestFileAsset> = {}):
 
 function addWork(state: TestState, overrides: Partial<TestWork> = {}): TestWork {
   const work: TestWork = {
+    coverPath: null,
     description: null,
     enrichmentStatus: "ENRICHED",
     id: "work-1",
@@ -1289,6 +1292,691 @@ describe("ingest services", () => {
     expect(state.works.size).toBe(1);
   });
 
+  it("re-enqueues PARSE for existing unchanged EPUB with hashes but no metadata and no EditionFile link", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-parse-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+
+    // Remove EditionFile link so recovery checks metadata (early-pipeline recovery)
+    for (const [key, ef] of state.editionFiles) {
+      if (ef.fileAssetId === fileAsset.id) {
+        state.editionFiles.delete(key);
+      }
+    }
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([fileAsset.id]);
+    expect(result.enqueuedHashJobs).toEqual([]);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA,
+      payload: { fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("re-enqueues MATCH for existing unchanged EPUB with parsed metadata but no EditionFile link", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-match-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      normalized: { title: "Book", authors: ["Author"] },
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      source: "epub",
+      status: "parsed",
+      warnings: [],
+    };
+
+    for (const [key, ef] of state.editionFiles) {
+      if (ef.fileAssetId === fileAsset.id) {
+        state.editionFiles.delete(key);
+      }
+    }
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([fileAsset.id]);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
+      payload: { fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("re-enqueues MATCH for existing file linked to STUB work", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-stub-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      normalized: { title: "Book", authors: ["Author"] },
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      source: "epub",
+      status: "parsed",
+      warnings: [],
+    };
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    expect(work.enrichmentStatus).toBe("STUB");
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([fileAsset.id]);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
+      payload: { fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("also enqueues PROCESS_COVER for STUB work with null coverPath during recovery", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-stub-cover-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    expect(work.enrichmentStatus).toBe("STUB");
+    expect(work.coverPath).toBeNull();
+
+    enqueuedJobs.length = 0;
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    // Should enqueue both MATCH (for enrichment) and PROCESS_COVER (for missing cover)
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
+      payload: { fileAssetId: fileAsset.id },
+    });
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PROCESS_COVER,
+      payload: { workId: work.id, fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("re-enqueues PROCESS_COVER for existing file linked to enriched work with no cover", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-cover-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      normalized: { title: "Book", authors: ["Author"] },
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      source: "epub",
+      status: "parsed",
+      warnings: [],
+    };
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "ENRICHED";
+    work.coverPath = null;
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([fileAsset.id]);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PROCESS_COVER,
+      payload: { workId: work.id, fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("does not enqueue recovery jobs for fully processed files", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-none-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      normalized: { title: "Book", authors: ["Author"] },
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      source: "epub",
+      status: "parsed",
+      warnings: [],
+    };
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "ENRICHED";
+    work.coverPath = "/covers/book.webp";
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([]);
+    expect(result.enqueuedHashJobs).toEqual([]);
+    expect(enqueuedJobs).toEqual([]);
+  });
+
+  it("skips recovery when edition link exists but edition is missing", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-orphan-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      normalized: { title: "Book", authors: ["Author"] },
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      source: "epub",
+      status: "parsed",
+      warnings: [],
+    };
+
+    state.editions.clear();
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([]);
+    expect(enqueuedJobs).toEqual([]);
+  });
+
+  it("does not enqueue PARSE recovery for PDF files with no metadata and no EditionFile link", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-pdf-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "doc.pdf"), "pdf-content");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    // First scan
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    // Simulate completed HASH but no metadata (PDFs are not parseable)
+    const fileAsset = state.fileAssets.get(path.join(directory, "doc.pdf"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+
+    // Remove EditionFile link to test early-pipeline recovery (no link, no metadata)
+    for (const [key, ef] of state.editionFiles) {
+      if (ef.fileAssetId === fileAsset.id) {
+        state.editionFiles.delete(key);
+      }
+    }
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    // PDFs are not parseable, so PARSE should not be enqueued
+    expect(result.enqueuedRecoveryJobs).toEqual([]);
+    expect(enqueuedJobs).toEqual([]);
+  });
+
+  it("re-enqueues PARSE for existing unchanged AUDIO file with hashes but no metadata and no EditionFile link", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-audio-"));
+    tempDirectories.push(directory);
+
+    await mkdir(path.join(directory, "audiobook"));
+    await writeFile(path.join(directory, "audiobook", "chapter1.mp3"), "audio");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "audiobook", "chapter1.mp3"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+
+    // Remove EditionFile link so recovery checks metadata (early-pipeline recovery)
+    for (const [key, ef] of state.editionFiles) {
+      if (ef.fileAssetId === fileAsset.id) {
+        state.editionFiles.delete(key);
+      }
+    }
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([fileAsset.id]);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA,
+      payload: { fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("re-enqueues PROCESS_COVER for EPUB with unparseable metadata but existing EditionFile link", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-unparseable-cover-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    // First scan creates stub
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    // Simulate: HASH succeeded, PARSE failed (unparseable), but stub already created EditionFile link
+    const fileAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      source: "epub",
+      status: "unparseable",
+      warnings: ["Failed to parse EPUB"],
+    };
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "ENRICHED";
+    work.coverPath = null;
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([fileAsset.id]);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PROCESS_COVER,
+      payload: { workId: work.id, fileAssetId: fileAsset.id },
+    });
+    // Should NOT re-enqueue PARSE since EditionFile link already exists
+    expect(enqueuedJobs).not.toContainEqual(
+      expect.objectContaining({ jobName: LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA }),
+    );
+  });
+
+  it("re-enqueues PROCESS_COVER for PDF with null metadata but existing EditionFile link", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-pdf-cover-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "doc.pdf"), "pdf-content");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    // First scan creates stub with EditionFile link
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    // Simulate: HASH succeeded, metadata never set (PDFs aren't parseable), PROCESS_COVER failed
+    const fileAsset = state.fileAssets.get(path.join(directory, "doc.pdf"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "ENRICHED";
+    work.coverPath = null;
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toEqual([fileAsset.id]);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PROCESS_COVER,
+      payload: { workId: work.id, fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("re-enqueues PARSE for existing unchanged OPF sidecar with fullHash but no metadata", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-opf-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "metadata.opf"), "<package/>");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    // First scan creates the file asset
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "metadata.opf"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    // Simulate: HASH succeeded but PARSE failed
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = null;
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toContainEqual(fileAsset.id);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA,
+      payload: { fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("does NOT re-enqueue PARSE for OPF sidecar with already-parsed metadata", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-opf-parsed-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "metadata.opf"), "<package/>");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "metadata.opf"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      normalized: { authors: [], identifiers: { unknown: [] } },
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      raw: {},
+      source: "opf-sidecar",
+      status: "parsed",
+      warnings: [],
+    } as TestFileAsset["metadata"];
+
+    enqueuedJobs.length = 0;
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const opfRecoveryJobs = enqueuedJobs.filter(
+      (j) => j.jobName === LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA &&
+        "fileAssetId" in j.payload && j.payload.fileAssetId === fileAsset.id,
+    );
+    expect(opfRecoveryJobs).toHaveLength(0);
+  });
+
+  it("re-enqueues OPF PARSE for PDF linked to STUB work when OPF sibling exists", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-pdf-opf-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.pdf"), "pdf-content");
+    await writeFile(path.join(directory, "metadata.opf"), "<package/>");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const pdfAsset = state.fileAssets.get(path.join(directory, "book.pdf"));
+    if (!pdfAsset) throw new Error("expected pdfAsset");
+    pdfAsset.partialHash = "partial";
+    pdfAsset.fullHash = "full";
+
+    const opfAsset = state.fileAssets.get(path.join(directory, "metadata.opf"));
+    if (!opfAsset) throw new Error("expected opfAsset");
+    opfAsset.partialHash = "opf-partial";
+    opfAsset.fullHash = "opf-full";
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "STUB";
+
+    enqueuedJobs.length = 0;
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA,
+      payload: { fileAssetId: opfAsset.id },
+    });
+  });
+
+  it("falls back to MATCH for PDF linked to STUB work when no OPF sibling exists", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-pdf-no-opf-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.pdf"), "pdf-content");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const pdfAsset = state.fileAssets.get(path.join(directory, "book.pdf"));
+    if (!pdfAsset) throw new Error("expected pdfAsset");
+    pdfAsset.partialHash = "partial";
+    pdfAsset.fullHash = "full";
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "STUB";
+
+    enqueuedJobs.length = 0;
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
+      payload: { fileAssetId: pdfAsset.id },
+    });
+  });
+
+  it("re-enqueues MATCH for EPUB linked to STUB work (unchanged behavior)", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-epub-stub-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "epub-content");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const epubAsset = state.fileAssets.get(path.join(directory, "book.epub"));
+    if (!epubAsset) throw new Error("expected epubAsset");
+    epubAsset.partialHash = "partial";
+    epubAsset.fullHash = "full";
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "STUB";
+
+    enqueuedJobs.length = 0;
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
+      payload: { fileAssetId: epubAsset.id },
+    });
+  });
+
   it("throws when the library root does not exist", async () => {
     const services = createIngestServices({
       db: createTestDb(createEmptyState("/tmp/root")),
@@ -2041,6 +2729,7 @@ describe("ingest services", () => {
       workId: "work-1",
     });
     expect(state.works.get("work-1")).toEqual({
+      coverPath: null,
       description: null,
       enrichmentStatus: "ENRICHED",
       id: "work-1",
@@ -3310,6 +3999,409 @@ describe("ingest services", () => {
     expect(state.editions.get("edition-1")).toMatchObject({ publisher: "DAW Books" });
   });
 
+  it("OPF sidecar enrichment transitions STUB work to ENRICHED with title and authors", async () => {
+    const state = createEmptyState("/tmp/root");
+    const opfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.opf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.opf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "opf",
+      fullHash: "hash",
+      id: "file-opf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.opf",
+      sizeBytes: 2n,
+    };
+    state.fileAssets.set(opfAsset.absolutePath, opfAsset);
+    state.fileAssetsById.set(opfAsset.id, opfAsset);
+
+    const pdfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/book.pdf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.pdf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "pdf",
+      fullHash: "pdf-hash",
+      id: "file-pdf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.PDF,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "pdf-phash",
+      relativePath: "Author/Book/book.pdf",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(pdfAsset.absolutePath, pdfAsset);
+    state.fileAssetsById.set(pdfAsset.id, pdfAsset);
+
+    addWork(state, {
+      id: "work-1",
+      enrichmentStatus: "STUB",
+      titleDisplay: "Book",
+      titleCanonical: "book",
+      coverPath: null,
+    });
+    addEdition(state, { id: "edition-1", workId: "work-1", publisher: null, publishedAt: null });
+    addEditionFile(state, { editionId: "edition-1", fileAssetId: "file-pdf" });
+
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+      parseOpf: vi.fn(async () => {
+        await Promise.resolve();
+        return {
+          authors: [{ name: "Patrick Rothfuss" }],
+          identifiers: [{ value: "9780756404741", scheme: "ISBN" }],
+          subjects: [],
+          title: "The Name of the Wind",
+          publisher: "DAW Books",
+          description: "A story.",
+          language: "en",
+        };
+      }),
+    });
+
+    await services.parseFileAssetMetadata({
+      fileAssetId: "file-opf",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    const work = state.works.get("work-1");
+    expect(work).toMatchObject({
+      enrichmentStatus: "ENRICHED",
+      titleDisplay: "The Name of the Wind",
+      titleCanonical: "the name of the wind",
+    });
+
+    // Authors should be added as contributors
+    const editionContributors = [...state.editionContributors.values()].filter(
+      (ec) => ec.editionId === "edition-1" && ec.role === ContributorRole.AUTHOR,
+    );
+    expect(editionContributors).toHaveLength(1);
+    const firstContributor = editionContributors[0];
+    if (!firstContributor) throw new Error("expected edition contributor");
+    const contributor = state.contributors.get(firstContributor.contributorId);
+    expect(contributor?.nameDisplay).toBe("Patrick Rothfuss");
+
+    // Edition ISBN should be updated
+    expect(state.editions.get("edition-1")?.isbn13).toBe("9780756404741");
+
+    // PROCESS_COVER should be enqueued for coverless work
+    expect(enqueueLibraryJob).toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.PROCESS_COVER,
+      { workId: "work-1", fileAssetId: "file-pdf" },
+    );
+  });
+
+  it("OPF sidecar enrichment does NOT override title on ENRICHED work", async () => {
+    const state = createEmptyState("/tmp/root");
+    const opfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.opf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.opf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "opf",
+      fullHash: "hash",
+      id: "file-opf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.opf",
+      sizeBytes: 2n,
+    };
+    state.fileAssets.set(opfAsset.absolutePath, opfAsset);
+    state.fileAssetsById.set(opfAsset.id, opfAsset);
+
+    const epubAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/book.epub",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.epub",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "epub",
+      fullHash: "epub-hash",
+      id: "file-epub",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.EPUB,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "epub-phash",
+      relativePath: "Author/Book/book.epub",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(epubAsset.absolutePath, epubAsset);
+    state.fileAssetsById.set(epubAsset.id, epubAsset);
+
+    addWork(state, {
+      id: "work-1",
+      enrichmentStatus: "ENRICHED",
+      titleDisplay: "Original Title",
+      titleCanonical: "original title",
+    });
+    addEdition(state, { id: "edition-1", workId: "work-1", publisher: null, publishedAt: null });
+    addEditionFile(state, { editionId: "edition-1", fileAssetId: "file-epub" });
+
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+      parseOpf: vi.fn(async () => {
+        await Promise.resolve();
+        return {
+          authors: [{ name: "Some Author" }],
+          identifiers: [],
+          subjects: [],
+          title: "Different Title",
+        };
+      }),
+    });
+
+    await services.parseFileAssetMetadata({
+      fileAssetId: "file-opf",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    expect(state.works.get("work-1")).toMatchObject({
+      enrichmentStatus: "ENRICHED",
+      titleDisplay: "Original Title",
+      titleCanonical: "original title",
+    });
+  });
+
+  it("OPF sidecar enrichment does NOT enqueue PROCESS_COVER when work has cover", async () => {
+    const state = createEmptyState("/tmp/root");
+    const opfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.opf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.opf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "opf",
+      fullHash: "hash",
+      id: "file-opf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.opf",
+      sizeBytes: 2n,
+    };
+    state.fileAssets.set(opfAsset.absolutePath, opfAsset);
+    state.fileAssetsById.set(opfAsset.id, opfAsset);
+
+    const pdfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/book.pdf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.pdf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "pdf",
+      fullHash: "pdf-hash",
+      id: "file-pdf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.PDF,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "pdf-phash",
+      relativePath: "Author/Book/book.pdf",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(pdfAsset.absolutePath, pdfAsset);
+    state.fileAssetsById.set(pdfAsset.id, pdfAsset);
+
+    addWork(state, {
+      id: "work-1",
+      enrichmentStatus: "STUB",
+      titleDisplay: "Book",
+      titleCanonical: "book",
+      coverPath: "work-1",
+    });
+    addEdition(state, { id: "edition-1", workId: "work-1", publisher: null, publishedAt: null });
+    addEditionFile(state, { editionId: "edition-1", fileAssetId: "file-pdf" });
+
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+      parseOpf: vi.fn(async () => {
+        await Promise.resolve();
+        return {
+          authors: [],
+          identifiers: [],
+          subjects: [],
+          title: "The Name of the Wind",
+        };
+      }),
+    });
+
+    await services.parseFileAssetMetadata({
+      fileAssetId: "file-opf",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    expect(enqueueLibraryJob).not.toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.PROCESS_COVER,
+      expect.anything(),
+    );
+  });
+
+  it("OPF sidecar enrichment updates edition isbn10 and asin from OPF identifiers", async () => {
+    const state = createEmptyState("/tmp/root");
+    const opfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.opf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.opf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "opf",
+      fullHash: "hash",
+      id: "file-opf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.opf",
+      sizeBytes: 2n,
+    };
+    state.fileAssets.set(opfAsset.absolutePath, opfAsset);
+    state.fileAssetsById.set(opfAsset.id, opfAsset);
+
+    const pdfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/book.pdf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.pdf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "pdf",
+      fullHash: "pdf-hash",
+      id: "file-pdf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.PDF,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "pdf-phash",
+      relativePath: "Author/Book/book.pdf",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(pdfAsset.absolutePath, pdfAsset);
+    state.fileAssetsById.set(pdfAsset.id, pdfAsset);
+
+    addWork(state, { id: "work-1", enrichmentStatus: "STUB", titleDisplay: "Book", titleCanonical: "book" });
+    addEdition(state, { id: "edition-1", workId: "work-1", publisher: null, publishedAt: null });
+    addEditionFile(state, { editionId: "edition-1", fileAssetId: "file-pdf" });
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      parseOpf: vi.fn(async () => {
+        await Promise.resolve();
+        return {
+          authors: [],
+          identifiers: [
+            { value: "0756404746", scheme: "ISBN" },
+            { value: "B000FBJCJE", scheme: "AMAZON" },
+          ],
+          subjects: [],
+          title: "The Name of the Wind",
+        };
+      }),
+    });
+
+    await services.parseFileAssetMetadata({
+      fileAssetId: "file-opf",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    expect(state.editions.get("edition-1")?.isbn10).toBe("0756404746");
+    expect(state.editions.get("edition-1")?.asin).toBe("B000FBJCJE");
+  });
+
+  it("OPF sidecar enrichment does NOT override existing edition ISBN", async () => {
+    const state = createEmptyState("/tmp/root");
+    const opfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.opf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.opf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "opf",
+      fullHash: "hash",
+      id: "file-opf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.opf",
+      sizeBytes: 2n,
+    };
+    state.fileAssets.set(opfAsset.absolutePath, opfAsset);
+    state.fileAssetsById.set(opfAsset.id, opfAsset);
+
+    const pdfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/book.pdf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.pdf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "pdf",
+      fullHash: "pdf-hash",
+      id: "file-pdf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.PDF,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "pdf-phash",
+      relativePath: "Author/Book/book.pdf",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(pdfAsset.absolutePath, pdfAsset);
+    state.fileAssetsById.set(pdfAsset.id, pdfAsset);
+
+    addWork(state, {
+      id: "work-1",
+      enrichmentStatus: "STUB",
+      titleDisplay: "Book",
+      titleCanonical: "book",
+    });
+    addEdition(state, { id: "edition-1", workId: "work-1", isbn13: "9781234567890", publisher: null, publishedAt: null });
+    addEditionFile(state, { editionId: "edition-1", fileAssetId: "file-pdf" });
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      parseOpf: vi.fn(async () => {
+        await Promise.resolve();
+        return {
+          authors: [],
+          identifiers: [{ value: "9780756404741", scheme: "ISBN" }],
+          subjects: [],
+          title: "The Name of the Wind",
+        };
+      }),
+    });
+
+    await services.parseFileAssetMetadata({
+      fileAssetId: "file-opf",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    expect(state.editions.get("edition-1")?.isbn13).toBe("9781234567890");
+  });
+
   // ── Audiobook tests ──────────────────────────────────────────────────
 
   it("enqueues metadata parsing after hashing AUDIO files", async () => {
@@ -4523,6 +5615,7 @@ describe("detectDuplicates", () => {
 
   function addDetectWork(state: TestState, id: string, titleCanonical: string, titleDisplay: string) {
     const w: TestWork = {
+      coverPath: null,
       description: null,
       enrichmentStatus: "STUB" as EnrichmentStatus,
       id,
@@ -4978,6 +6071,7 @@ describe("matchAudio", () => {
 
   function addAudioWork(state: TestState, id: string, titleCanonical: string, titleDisplay: string) {
     const w: TestWork = {
+      coverPath: null,
       description: null,
       enrichmentStatus: "STUB" as EnrichmentStatus,
       id,

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -16,6 +16,7 @@ import {
 } from "@bookhouse/domain";
 import { db, type EditionContributor } from "@bookhouse/db";
 import {
+  createLogger,
   LIBRARY_JOB_NAMES,
   type HashFileAssetJobPayload,
   type LibraryJobName,
@@ -71,7 +72,7 @@ type FileAssetRecord = Pick<
 >;
 
 type LibraryRootRecord = Pick<LibraryRoot, "id" | "lastScannedAt" | "path">;
-type WorkRecord = Pick<Work, "description" | "enrichmentStatus" | "id" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">;
+type WorkRecord = Pick<Work, "coverPath" | "description" | "enrichmentStatus" | "id" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">;
 type EditionRecord = Pick<
   Edition,
   "asin" | "formatFamily" | "id" | "isbn10" | "isbn13" | "publishedAt" | "publisher" | "workId"
@@ -273,7 +274,7 @@ export interface IngestDb {
     delete(args: { where: { id: string } }): Promise<void>;
     findMany(args: WorkFindManyArgs): Promise<WorkMatchRecord[]>;
     findUnique(args: { where: { id: string } }): Promise<WorkRecord | null>;
-    update(args: { where: { id: string }; data: Partial<Pick<Work, "description" | "enrichmentStatus" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">> }): Promise<WorkRecord>;
+    update(args: { where: { id: string }; data: Partial<Pick<Work, "coverPath" | "description" | "enrichmentStatus" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">> }): Promise<WorkRecord>;
   };
   edition: {
     create(args: EditionCreateArgs): Promise<EditionRecord>;
@@ -307,6 +308,10 @@ export interface IngestDb {
   };
 }
 
+export interface IngestLogger {
+  info(obj: Record<string, unknown>, msg: string): void;
+}
+
 export interface IngestDependencies {
   db: IngestDb;
   enqueueLibraryJob<TName extends LibraryJobName>(
@@ -314,6 +319,7 @@ export interface IngestDependencies {
     payload: LibraryJobPayload<TName>,
   ): Promise<void>;
   listDirectory: ListDirectoryFn;
+  logger: IngestLogger;
   readStats: ReadStatsFn;
   hashFile: typeof hashFileContents;
   parseEpub: typeof parseEpubMetadata;
@@ -338,6 +344,7 @@ export interface ScanLibraryRootResult {
   createdStubWorkIds: string[];
   discoveredPaths: string[];
   enqueuedHashJobs: string[];
+  enqueuedRecoveryJobs: string[];
   missingFileAssetIds: string[];
   scannedFileAssetIds: string[];
 }
@@ -669,7 +676,7 @@ function createDefaultIngestDb(): IngestDb {
     },
     work: {
       ...(prisma.work as unknown as Omit<IngestDb["work"], "update">),
-      async update(args: { where: { id: string }; data: Partial<Pick<Work, "description" | "enrichmentStatus" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">> }) {
+      async update(args: { where: { id: string }; data: Partial<Pick<Work, "coverPath" | "description" | "enrichmentStatus" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">> }) {
         return prisma.work.update(args) as unknown as Promise<WorkRecord>;
       },
     },
@@ -1019,6 +1026,7 @@ export function createIngestServices(
   const parseAudioJson = dependencies.parseAudiobookJson ?? parseAudiobookMetadataJson;
   const parseAudioId3 = dependencies.parseAudioId3 ?? parseAudioId3Tags;
   const enqueueJob = dependencies.enqueueLibraryJob ?? enqueueLibraryJob;
+  const logger = dependencies.logger ?? createLogger("ingest");
 
   async function scanLibraryRoot(input: ScanLibraryRootInput): Promise<ScanLibraryRootResult> {
     const now = input.now ?? new Date();
@@ -1035,6 +1043,7 @@ export function createIngestServices(
     const seenPaths = new Set<string>();
     const scannedFileAssetIds: string[] = [];
     const enqueuedHashJobs: string[] = [];
+    const enqueuedRecoveryJobs: string[] = [];
     const createdStubWorkIds: string[] = [];
     const seenAudioDirs = new Map<string, { workId: string; editionId: string }>();
 
@@ -1111,6 +1120,113 @@ export function createIngestServices(
           fileAssetId: upsertedFileAsset.id,
         });
         enqueuedHashJobs.push(upsertedFileAsset.id);
+      } else {
+        // Recovery: re-enqueue jobs for existing unchanged files with incomplete processing
+        const recoveryFormatFamily = deriveFormatFamily(upsertedFileAsset.mediaKind);
+        if (recoveryFormatFamily !== null && upsertedFileAsset.fullHash !== null) {
+          // Check EditionFile link FIRST — if matched, skip metadata check and go to work/cover recovery
+          const editionFileLink = await ingestDb.editionFile.findFirst({
+            where: { fileAssetId: upsertedFileAsset.id },
+          });
+
+          if (editionFileLink !== null) {
+            // Already linked to an edition — check work status and cover
+            const edition = await ingestDb.edition.findUnique({
+              where: { id: editionFileLink.editionId },
+            });
+            if (edition) {
+              const work = await ingestDb.work.findUnique({
+                where: { id: edition.workId },
+              });
+              if (work && work.enrichmentStatus === "STUB") {
+                // Work stuck at STUB — for PDF/CBZ, look for OPF sidecar to trigger enrichment
+                if (
+                  upsertedFileAsset.mediaKind === MediaKind.PDF ||
+                  upsertedFileAsset.mediaKind === MediaKind.CBZ
+                ) {
+                  const directory = path.dirname(upsertedFileAsset.absolutePath);
+                  const sidecarSiblings = await ingestDb.fileAsset.findByDirectory({
+                    directoryPath: directory,
+                    mediaKinds: [MediaKind.SIDECAR],
+                  });
+                  const opfSibling = sidecarSiblings.find(
+                    (fa) => getFileExtension(fa.absolutePath) === "opf",
+                  );
+                  if (opfSibling && opfSibling.fullHash !== null) {
+                    logger.info({ fileAssetId: upsertedFileAsset.id, opfFileAssetId: opfSibling.id, workId: work.id, reason: "STUB work with OPF sibling" }, "Recovery: re-enqueueing OPF PARSE");
+                    await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
+                      fileAssetId: opfSibling.id,
+                    });
+                    enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+                  } else {
+                    // No OPF sidecar — fall back to MATCH
+                    logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "work stuck at STUB (no OPF)" }, "Recovery: re-enqueueing MATCH");
+                    await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
+                      fileAssetId: upsertedFileAsset.id,
+                    });
+                    enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+                  }
+                } else {
+                  // EPUB/AUDIO — MATCH can use their own parsed metadata
+                  logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "work stuck at STUB" }, "Recovery: re-enqueueing MATCH");
+                  await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
+                    fileAssetId: upsertedFileAsset.id,
+                  });
+                  enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+                }
+              }
+              // Separately check for missing covers — runs for both STUB and ENRICHED works
+              if (work && work.coverPath === null) {
+                logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "missing cover" }, "Recovery: re-enqueueing PROCESS_COVER");
+                await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
+                  workId: work.id,
+                  fileAssetId: upsertedFileAsset.id,
+                });
+                if (!enqueuedRecoveryJobs.includes(upsertedFileAsset.id)) {
+                  enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+                }
+              }
+            }
+          } else {
+            // Not linked to an edition — recover from earlier in the pipeline
+            const parsedMeta = parseStoredMetadata(upsertedFileAsset.metadata);
+
+            if (!parsedMeta || parsedMeta.status !== "parsed") {
+              // Missing or failed metadata parse — only EPUB and AUDIO are parseable
+              if (
+                upsertedFileAsset.mediaKind === MediaKind.EPUB ||
+                upsertedFileAsset.mediaKind === MediaKind.AUDIO
+              ) {
+                logger.info({ fileAssetId: upsertedFileAsset.id, reason: "missing or failed metadata" }, "Recovery: re-enqueueing PARSE");
+                await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
+                  fileAssetId: upsertedFileAsset.id,
+                });
+                enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+              }
+            } else {
+              // Parsed but not matched to edition
+              logger.info({ fileAssetId: upsertedFileAsset.id, reason: "parsed but unmatched" }, "Recovery: re-enqueueing MATCH");
+              await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
+                fileAssetId: upsertedFileAsset.id,
+              });
+              enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+            }
+          }
+        }
+
+        // Recovery for OPF sidecars: re-enqueue PARSE if hashed but not parsed
+        const isOpfSidecar = upsertedFileAsset.mediaKind === MediaKind.SIDECAR
+          && getFileExtension(upsertedFileAsset.absolutePath) === "opf";
+        if (isOpfSidecar && upsertedFileAsset.fullHash !== null) {
+          const opfMeta = parseStoredMetadata(upsertedFileAsset.metadata);
+          if (!opfMeta || opfMeta.status !== "parsed") {
+            logger.info({ fileAssetId: upsertedFileAsset.id, reason: "OPF hashed but not parsed" }, "Recovery: re-enqueueing OPF PARSE");
+            await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
+              fileAssetId: upsertedFileAsset.id,
+            });
+            enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+          }
+        }
       }
 
       // Create stub Work/Edition/EditionFile for new files with a content format
@@ -1245,6 +1361,7 @@ export function createIngestServices(
       createdStubWorkIds,
       discoveredPaths,
       enqueuedHashJobs,
+      enqueuedRecoveryJobs,
       missingFileAssetIds,
       scannedFileAssetIds,
     };
@@ -1378,6 +1495,9 @@ export function createIngestServices(
             const parsedDate = new Date(normalized.date);
             if (!isNaN(parsedDate.getTime())) editionUpdates.publishedAt = parsedDate;
           }
+          if (!edition.isbn13 && normalized.identifiers.isbn13) editionUpdates.isbn13 = normalized.identifiers.isbn13;
+          if (!edition.isbn10 && normalized.identifiers.isbn10) editionUpdates.isbn10 = normalized.identifiers.isbn10;
+          if (!edition.asin && normalized.identifiers.asin) editionUpdates.asin = normalized.identifiers.asin;
 
           if (Object.keys(editionUpdates).length > 0) {
             await ingestDb.edition.update({
@@ -1407,10 +1527,30 @@ export function createIngestServices(
             }
           }
 
+          // Transition STUB works to ENRICHED with title from OPF
+          if (work.enrichmentStatus === "STUB" && normalized.title) {
+            workUpdates.titleDisplay = normalized.title;
+            workUpdates.titleCanonical = canonicalizeBookTitle(normalized.title);
+            workUpdates.enrichmentStatus = "ENRICHED";
+          }
+
           if (Object.keys(workUpdates).length > 0) {
             await ingestDb.work.update({
               where: { id: work.id },
               data: workUpdates,
+            });
+          }
+
+          // Add authors from OPF metadata for STUB works being enriched
+          if (work.enrichmentStatus === "STUB" && normalized.authors.length > 0) {
+            await ensureContributors(ingestDb, editionFile.editionId, normalized.authors, ContributorRole.AUTHOR);
+          }
+
+          // Enqueue cover processing for works without covers
+          if (work.coverPath === null) {
+            await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
+              workId: work.id,
+              fileAssetId: sibling.id,
             });
           }
         }


### PR DESCRIPTION
## Summary

- **Re-scan recovery** (Closes #76): When a downstream job (PARSE, MATCH, PROCESS_COVER) fails and exhausts retries, re-scanning now detects incomplete processing and re-enqueues the appropriate jobs
- **OPF sidecar enrichment**: OPF metadata now transitions STUB works to ENRICHED with title, authors, ISBNs, and triggers cover processing — fixing 74 books stuck as "Processing..."
- **EPUB cover fallback** (related to #76): EPUB cover extraction errors no longer crash `processCoverForWork`; it falls back to adjacent `cover.jpg` detection
- **Library table UX** (Closes #71): Unified single pagination bar with rows-per-page selector, column picker, and text overflow toggle (wrap vs truncate)

## What changed

### Recovery logic (`packages/ingest/src/services.ts`)
- OPF sidecar parse handler now sets `enrichmentStatus: "ENRICHED"`, `titleDisplay`, `titleCanonical`, authors via `ensureContributors`, and edition ISBNs for STUB sibling works
- OPF sidecar parse handler enqueues `PROCESS_COVER` for coverless sibling works
- Recovery branch added for OPF sidecars: re-enqueues PARSE when hashed but not parsed
- Recovery for PDF/CBZ STUB works looks for OPF sibling and re-enqueues OPF PARSE instead of futile MATCH
- Cover recovery (`coverPath === null`) now runs as a separate check, not `else if` after STUB check — so STUB works with missing covers get both MATCH and PROCESS_COVER

### Cover fallback (`packages/ingest/src/covers.ts`)
- `extractEpubCover` call wrapped in try-catch so malformed EPUB cover references fall back to adjacent cover detection

### Library table UX (`apps/web/`)
- Removed duplicate `DataTablePagination`, using single `LibraryPagination` with rows-per-page selector
- Added column picker component (`DataTableColumnPicker`)
- Added text overflow toggle (wrap vs truncate) with localStorage persistence
- Table uses fixed layout to prevent horizontal overflow

## Test plan

- 1076 tests passing, 100% coverage
- lint, typecheck, build all green