### PR TITLE
Fix library facet counts to respect active filters

### DIFF
--- a/apps/web/src/lib/server-fns/library.test.ts
+++ b/apps/web/src/lib/server-fns/library.test.ts
@@ -393,6 +393,83 @@ describe("getFilteredLibraryWorksServerFn", () => {
     expect(result.facetCounts.hasCover.withoutCover).toBeGreaterThanOrEqual(0);
   });
 
+  it("scopes cover facet counts to active search filter (excludes hasCover)", async () => {
+    findManyMock.mockResolvedValue([]);
+    editionGroupByMock.mockResolvedValue([]);
+    seriesCountMock.mockResolvedValue(0);
+    countMock.mockResolvedValue(5);
+
+    await getFilteredLibraryWorksServerFn({ data: { q: "wind" } });
+
+    // Cover count queries should include the search filter but NOT hasCover
+    // countMock calls: [0] = totalCount, [1] = withCover, [2] = withoutCover
+    expect(countMock).toHaveBeenNthCalledWith(2, {
+      where: {
+        OR: [
+          { titleDisplay: { contains: "wind", mode: "insensitive" } },
+          { titleCanonical: { contains: "wind", mode: "insensitive" } },
+        ],
+        coverPath: { not: null },
+      },
+    });
+    expect(countMock).toHaveBeenNthCalledWith(3, {
+      where: {
+        OR: [
+          { titleDisplay: { contains: "wind", mode: "insensitive" } },
+          { titleCanonical: { contains: "wind", mode: "insensitive" } },
+        ],
+        coverPath: null,
+      },
+    });
+  });
+
+  it("scopes format facet counts to active search filter (excludes format)", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+    seriesCountMock.mockResolvedValue(0);
+
+    await getFilteredLibraryWorksServerFn({ data: { q: "wind" } });
+
+    expect(editionGroupByMock).toHaveBeenCalledWith({
+      by: ["formatFamily"],
+      _count: { _all: true },
+      where: {
+        work: {
+          OR: [
+            { titleDisplay: { contains: "wind", mode: "insensitive" } },
+            { titleCanonical: { contains: "wind", mode: "insensitive" } },
+          ],
+        },
+      },
+    });
+  });
+
+  it("cover facet counts exclude hasCover filter but include format filter", async () => {
+    findManyMock.mockResolvedValue([]);
+    editionGroupByMock.mockResolvedValue([]);
+    seriesCountMock.mockResolvedValue(0);
+    countMock.mockResolvedValue(5);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { format: ["EBOOK"], hasCover: false },
+    });
+
+    // Cover count queries should include format but NOT hasCover
+    expect(countMock).toHaveBeenNthCalledWith(2, {
+      where: {
+        editions: { some: { formatFamily: { in: ["EBOOK"] } } },
+        coverPath: { not: null },
+      },
+    });
+    expect(countMock).toHaveBeenNthCalledWith(3, {
+      where: {
+        editions: { some: { formatFamily: { in: ["EBOOK"] } } },
+        coverPath: null,
+      },
+    });
+  });
+
   it("returns series count in facet counts", async () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);

--- a/apps/web/src/lib/server-fns/library.ts
+++ b/apps/web/src/lib/server-fns/library.ts
@@ -103,6 +103,10 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
     const where = buildWhere(parsed);
     const orderBy = buildOrderBy(parsed.sort);
 
+    // Facet counts exclude their own filter to show meaningful counts
+    const whereForCoverFacets = buildWhere({ ...parsed, hasCover: undefined });
+    const whereForFormatFacets = buildWhere({ ...parsed, format: undefined });
+
     const [works, totalCount, formatCounts, withCoverCount, withoutCoverCount, seriesCount] =
       await Promise.all([
         db.work.findMany({
@@ -116,9 +120,10 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
         db.edition.groupBy({
           by: ["formatFamily"],
           _count: { _all: true },
+          where: { work: whereForFormatFacets },
         }),
-        db.work.count({ where: { coverPath: { not: null } } }),
-        db.work.count({ where: { coverPath: null } }),
+        db.work.count({ where: { ...whereForCoverFacets, coverPath: { not: null } } }),
+        db.work.count({ where: { ...whereForCoverFacets, coverPath: null } }),
         db.series.count(),
       ]);
 


### PR DESCRIPTION
## Summary

- Facet count queries (format families, cover status) now respect all active filters except their own
- Cover facet counts exclude the `hasCover` filter but include search, format, author, etc.
- Format facet counts exclude the `format` filter but include search, cover, author, etc.
- This prevents negative counts and shows accurate numbers within the filtered result set

Closes #70

## Test plan

- 3 new tests verifying scoped facet count queries
- All 1079 tests passing, 100% coverage
- lint, typecheck, build all green