### PR TITLE
Show warning when scan appears stuck

### DIFF
--- a/apps/web/src/lib/server-fns/library-roots.test.ts
+++ b/apps/web/src/lib/server-fns/library-roots.test.ts
@@ -247,12 +247,13 @@ describe("getScanProgressServerFn", () => {
     importJobFindFirstMock.mockReset();
   });
 
-  it("returns progress data for an active scan", async () => {
+  it("returns progress data with stale: false for a recent scan", async () => {
     importJobFindFirstMock.mockResolvedValue({
       status: "RUNNING",
       totalFiles: 100,
       processedFiles: 42,
       errorCount: 2,
+      updatedAt: new Date(),
     });
 
     const result = await getScanProgressServerFn({
@@ -270,6 +271,7 @@ describe("getScanProgressServerFn", () => {
         totalFiles: true,
         processedFiles: true,
         errorCount: true,
+        updatedAt: true,
       },
       orderBy: { createdAt: "desc" },
     });
@@ -278,6 +280,30 @@ describe("getScanProgressServerFn", () => {
       totalFiles: 100,
       processedFiles: 42,
       errorCount: 2,
+      stale: false,
+    });
+  });
+
+  it("returns stale: true when updatedAt exceeds threshold", async () => {
+    const sixMinutesAgo = new Date(Date.now() - 6 * 60 * 1000);
+    importJobFindFirstMock.mockResolvedValue({
+      status: "RUNNING",
+      totalFiles: 500,
+      processedFiles: 200,
+      errorCount: 0,
+      updatedAt: sixMinutesAgo,
+    });
+
+    const result = await getScanProgressServerFn({
+      data: { libraryRootId: "root-1" },
+    });
+
+    expect(result).toEqual({
+      status: "RUNNING",
+      totalFiles: 500,
+      processedFiles: 200,
+      errorCount: 0,
+      stale: true,
     });
   });
 

--- a/apps/web/src/lib/server-fns/library-roots.ts
+++ b/apps/web/src/lib/server-fns/library-roots.ts
@@ -77,13 +77,15 @@ const libraryRootIdSchema = z.object({
   libraryRootId: z.string().min(1),
 });
 
+export const STALE_SCAN_THRESHOLD_MS = 5 * 60 * 1000;
+
 export const getScanProgressServerFn = createServerFn({
   method: "GET",
 })
   .inputValidator(libraryRootIdSchema)
   .handler(async ({ data }) => {
     const { db } = await import("@bookhouse/db");
-    return db.importJob.findFirst({
+    const job = await db.importJob.findFirst({
       where: {
         libraryRootId: data.libraryRootId,
         kind: "SCAN_ROOT",
@@ -94,9 +96,16 @@ export const getScanProgressServerFn = createServerFn({
         totalFiles: true,
         processedFiles: true,
         errorCount: true,
+        updatedAt: true,
       },
       orderBy: { createdAt: "desc" },
     });
+    if (!job) return null;
+    const { updatedAt, ...rest } = job;
+    return {
+      ...rest,
+      stale: Date.now() - updatedAt.getTime() > STALE_SCAN_THRESHOLD_MS,
+    };
   });
 
 export const getLibraryIssueCountServerFn = createServerFn({

--- a/apps/web/src/routes/_authenticated/settings/-libraries.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-libraries.test.tsx
@@ -12,7 +12,7 @@ let mockLoaderData: {
     scanMode: string;
     isEnabled: boolean;
     lastScannedAt: string | null;
-    scanProgress: { status: string; totalFiles: number | null; processedFiles: number | null; errorCount: number | null } | null;
+    scanProgress: { status: string; totalFiles: number | null; processedFiles: number | null; errorCount: number | null; stale: boolean } | null;
     issueCount: number;
   }[]
 } = { roots: [] };
@@ -72,7 +72,7 @@ const makeRoot = (overrides: Partial<{
   scanMode: string;
   isEnabled: boolean;
   lastScannedAt: string | null;
-  scanProgress: { status: string; totalFiles: number | null; processedFiles: number | null; errorCount: number | null } | null;
+  scanProgress: { status: string; totalFiles: number | null; processedFiles: number | null; errorCount: number | null; stale: boolean } | null;
   issueCount: number;
 }> = {}) => ({
   id: "root-1",
@@ -383,7 +383,7 @@ describe("LibrariesPage", () => {
   it("shows progress bar when scan is active", async () => {
     mockLoaderData = {
       roots: [makeRoot({
-        scanProgress: { status: "RUNNING", totalFiles: 100, processedFiles: 42, errorCount: 2 },
+        scanProgress: { status: "RUNNING", totalFiles: 100, processedFiles: 42, errorCount: 2, stale: false },
       })],
     };
     const { Route } = await import("./libraries");
@@ -430,7 +430,7 @@ describe("LibrariesPage", () => {
   it("shows progress with null processedFiles and totalFiles", async () => {
     mockLoaderData = {
       roots: [makeRoot({
-        scanProgress: { status: "QUEUED", totalFiles: null, processedFiles: null, errorCount: null },
+        scanProgress: { status: "QUEUED", totalFiles: null, processedFiles: null, errorCount: null, stale: false },
       })],
     };
     const { Route } = await import("./libraries");
@@ -443,13 +443,40 @@ describe("LibrariesPage", () => {
   it("shows progress without error count when errorCount is 0", async () => {
     mockLoaderData = {
       roots: [makeRoot({
-        scanProgress: { status: "RUNNING", totalFiles: 50, processedFiles: 10, errorCount: 0 },
+        scanProgress: { status: "RUNNING", totalFiles: 50, processedFiles: 10, errorCount: 0, stale: false },
       })],
     };
     const { Route } = await import("./libraries");
     const LibrariesPage = (Route.options.component as React.ComponentType);
     render(<LibrariesPage />);
     expect(screen.getByText("Scanning... 10 / 50 files")).toBeTruthy();
+  });
+
+  it("shows stalled warning when scan is stale", async () => {
+    mockLoaderData = {
+      roots: [makeRoot({
+        scanProgress: { status: "RUNNING", totalFiles: 500, processedFiles: 200, errorCount: 0, stale: true },
+      })],
+    };
+    const { Route } = await import("./libraries");
+    const LibrariesPage = (Route.options.component as React.ComponentType);
+    render(<LibrariesPage />);
+    expect(screen.getByText("Scan Stalled")).toBeTruthy();
+    expect(screen.getByText(/Scan appears stalled/)).toBeTruthy();
+  });
+
+  it("shows normal scanning state when scan is not stale", async () => {
+    mockLoaderData = {
+      roots: [makeRoot({
+        scanProgress: { status: "RUNNING", totalFiles: 100, processedFiles: 42, errorCount: 0, stale: false },
+      })],
+    };
+    const { Route } = await import("./libraries");
+    const LibrariesPage = (Route.options.component as React.ComponentType);
+    render(<LibrariesPage />);
+    expect(screen.getByText("Scanning... 42 / 100 files")).toBeTruthy();
+    expect(screen.queryByText("Scan Stalled")).toBeNull();
+    expect(screen.queryByText(/Scan appears stalled/)).toBeNull();
   });
 
   it("toast success action navigates to job detail", async () => {

--- a/apps/web/src/routes/_authenticated/settings/libraries.tsx
+++ b/apps/web/src/routes/_authenticated/settings/libraries.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { toast } from "sonner";
-import { AlertCircle, FolderOpen, Loader2, Play, Trash2 } from "lucide-react";
+import { AlertCircle, AlertTriangle, FolderOpen, Loader2, Play, Trash2 } from "lucide-react";
 import { useSSE } from "~/hooks/use-sse";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
@@ -179,10 +179,17 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
                 disabled={scanning || root.scanProgress !== null}
               >
                 {root.scanProgress ? (
-                  <>
-                    <Loader2 className="size-4 animate-spin" />
-                    Scanning...
-                  </>
+                  root.scanProgress.stale ? (
+                    <>
+                      <AlertTriangle className="size-4 text-amber-600" />
+                      Scan Stalled
+                    </>
+                  ) : (
+                    <>
+                      <Loader2 className="size-4 animate-spin" />
+                      Scanning...
+                    </>
+                  )
                 ) : scanning ? (
                   <>
                     <Loader2 className="size-4 animate-spin" />
@@ -236,10 +243,17 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
                 value={root.scanProgress.processedFiles ?? 0}
                 max={root.scanProgress.totalFiles ?? 1}
               />
-              <p className="text-xs text-muted-foreground">
-                Scanning... {root.scanProgress.processedFiles ?? 0} / {root.scanProgress.totalFiles ?? "?"} files
-                {root.scanProgress.errorCount ? ` (${String(root.scanProgress.errorCount)} errors)` : ""}
-              </p>
+              {root.scanProgress.stale ? (
+                <p className="text-xs text-amber-600 flex items-center gap-1">
+                  <AlertTriangle className="size-3.5" />
+                  Scan appears stalled — no progress updates received
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  Scanning... {root.scanProgress.processedFiles ?? 0} / {root.scanProgress.totalFiles ?? "?"} files
+                  {root.scanProgress.errorCount ? ` (${String(root.scanProgress.errorCount)} errors)` : ""}
+                </p>
+              )}
             </div>
           )}
         </CardContent>


### PR DESCRIPTION
## Summary
- Detect stale/stuck scans by comparing `ImportJob.updatedAt` against a 5-minute threshold in `getScanProgressServerFn`
- Return `stale: boolean` flag to the frontend (without exposing raw `updatedAt`)
- Render amber "Scan Stalled" indicator with `AlertTriangle` icon when a scan has no progress updates for 5+ minutes

Closes #75