### PR TITLE
Handle ID3 encoding errors gracefully and fix Retry All

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@bookhouse/auth": "workspace:*",
     "@bookhouse/db": "workspace:*",
     "@bookhouse/domain": "workspace:*",
+    "@bookhouse/ingest": "workspace:*",
     "@bookhouse/shared": "workspace:*",
     "@tanstack/react-router": "^1.167.4",
     "@tanstack/react-router-devtools": "^1.166.9",

--- a/apps/web/src/lib/server-fns/library-roots.test.ts
+++ b/apps/web/src/lib/server-fns/library-roots.test.ts
@@ -51,11 +51,23 @@ vi.mock("@bookhouse/db", () => ({
 }));
 
 const enqueueLibraryJobMock = vi.fn();
-const LIBRARY_JOB_NAMES = { SCAN_LIBRARY_ROOT: "SCAN_LIBRARY_ROOT" };
+const LIBRARY_JOB_NAMES = {
+  SCAN_LIBRARY_ROOT: "SCAN_LIBRARY_ROOT",
+  PARSE_FILE_ASSET_METADATA: "PARSE_FILE_ASSET_METADATA",
+};
 
 vi.mock("@bookhouse/shared", () => ({
   enqueueLibraryJob: enqueueLibraryJobMock,
   LIBRARY_JOB_NAMES,
+}));
+
+const parseFileAssetMetadataMock = vi.fn();
+const createIngestServicesMock = vi.fn(() => ({
+  parseFileAssetMetadata: parseFileAssetMetadataMock,
+}));
+
+vi.mock("@bookhouse/ingest", () => ({
+  createIngestServices: createIngestServicesMock,
 }));
 
 import {
@@ -66,6 +78,7 @@ import {
   getScanProgressServerFn,
   getLibraryIssueCountServerFn,
   getLibraryIssuesServerFn,
+  retryLibraryIssuesServerFn,
 } from "./library-roots";
 
 describe("getLibraryRootsServerFn", () => {
@@ -393,5 +406,69 @@ describe("getLibraryIssuesServerFn", () => {
     expect(fileAssetFindManyMock).toHaveBeenCalledWith(
       expect.objectContaining({ skip: 20, take: 10 }),
     );
+  });
+});
+
+describe("retryLibraryIssuesServerFn", () => {
+  beforeEach(() => {
+    fileAssetFindManyMock.mockReset();
+    parseFileAssetMetadataMock.mockReset();
+    createIngestServicesMock.mockClear();
+  });
+
+  it("calls parseFileAssetMetadata for each unparseable file sequentially", async () => {
+    const fakeAssets = [
+      { id: "fa-1" },
+      { id: "fa-2" },
+      { id: "fa-3" },
+    ];
+    fileAssetFindManyMock.mockResolvedValue(fakeAssets);
+    parseFileAssetMetadataMock.mockResolvedValue({ skipped: false });
+
+    const result = await retryLibraryIssuesServerFn({
+      data: { libraryRootId: "root-1" },
+    });
+
+    expect(fileAssetFindManyMock).toHaveBeenCalledWith({
+      where: {
+        libraryRootId: "root-1",
+        metadata: { path: ["status"], equals: "unparseable" },
+      },
+      select: { id: true },
+    });
+
+    expect(createIngestServicesMock).toHaveBeenCalledWith({
+      enqueueLibraryJob: expect.any(Function) as unknown,
+    });
+
+    // Verify the wrapper delegates to the real enqueueLibraryJob
+    const calls = createIngestServicesMock.mock.calls as unknown as Array<
+      Array<{ enqueueLibraryJob: (jobName: string, payload: unknown) => Promise<void> }>
+    >;
+    const firstCall = calls[0];
+    if (!firstCall) throw new Error("expected createIngestServices call");
+    const firstArg = firstCall[0];
+    if (!firstArg) throw new Error("expected createIngestServices argument");
+    enqueueLibraryJobMock.mockResolvedValue("job-id");
+    await firstArg.enqueueLibraryJob("SOME_JOB", { fileAssetId: "fa-99" });
+    expect(enqueueLibraryJobMock).toHaveBeenCalledWith("SOME_JOB", { fileAssetId: "fa-99" });
+
+    expect(parseFileAssetMetadataMock).toHaveBeenCalledTimes(3);
+    expect(parseFileAssetMetadataMock).toHaveBeenCalledWith({ fileAssetId: "fa-1" });
+    expect(parseFileAssetMetadataMock).toHaveBeenCalledWith({ fileAssetId: "fa-2" });
+    expect(parseFileAssetMetadataMock).toHaveBeenCalledWith({ fileAssetId: "fa-3" });
+
+    expect(result).toEqual({ retriedCount: 3 });
+  });
+
+  it("returns retriedCount 0 when no issues exist", async () => {
+    fileAssetFindManyMock.mockResolvedValue([]);
+
+    const result = await retryLibraryIssuesServerFn({
+      data: { libraryRootId: "root-1" },
+    });
+
+    expect(parseFileAssetMetadataMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ retriedCount: 0 });
   });
 });

--- a/apps/web/src/lib/server-fns/library-roots.ts
+++ b/apps/web/src/lib/server-fns/library-roots.ts
@@ -193,3 +193,32 @@ export const scanLibraryRootServerFn = createServerFn({
 
     return { jobId, importJobId: importJob.id };
   });
+
+export const retryLibraryIssuesServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(libraryRootIdSchema)
+  .handler(async ({ data }) => {
+    const { db } = await import("@bookhouse/db");
+    const { createIngestServices } = await import("@bookhouse/ingest");
+    const { enqueueLibraryJob } = await import("@bookhouse/shared");
+
+    const issues = await db.fileAsset.findMany({
+      where: {
+        libraryRootId: data.libraryRootId,
+        metadata: { path: ["status"], equals: "unparseable" },
+      },
+      select: { id: true },
+    });
+
+    const services = createIngestServices({
+      async enqueueLibraryJob(jobName, payload) {
+        await enqueueLibraryJob(jobName, payload);
+      },
+    });
+    for (const issue of issues) {
+      await services.parseFileAssetMetadata({ fileAssetId: issue.id });
+    }
+
+    return { retriedCount: issues.length };
+  });

--- a/apps/web/src/routes/_authenticated/settings/-library-issues.$libraryRootId.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-library-issues.$libraryRootId.test.tsx
@@ -1,6 +1,7 @@
 // @vitest-environment happy-dom
 import type * as TanstackRouter from "@tanstack/react-router";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 let mockLoaderData: {
@@ -9,9 +10,15 @@ let mockLoaderData: {
 } = { libraryRootId: "root-1", issues: { items: [], total: 0 } };
 
 const getLibraryIssuesServerFnMock = vi.fn();
+const retryLibraryIssuesServerFnMock = vi.fn();
 
 vi.mock("~/lib/server-fns/library-roots", () => ({
   getLibraryIssuesServerFn: getLibraryIssuesServerFnMock,
+  retryLibraryIssuesServerFn: retryLibraryIssuesServerFnMock,
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
 }));
 
 interface MockRoute {
@@ -129,5 +136,129 @@ describe("LibraryIssuesPage", () => {
     const Page = Route.options.component;
     render(<Page />);
     expect(screen.getByText("author/broken.epub")).toBeTruthy();
+  });
+
+  it("renders Retry All button when issues exist", async () => {
+    mockLoaderData = {
+      libraryRootId: "root-1",
+      issues: {
+        items: [
+          {
+            id: "fa-1",
+            relativePath: "author/book.epub",
+            mediaKind: "EPUB",
+            metadata: { status: "unparseable", warnings: ["Bad XML"] },
+            lastSeenAt: null,
+          },
+        ],
+        total: 1,
+      },
+    };
+    const mod = await import("./library-issues.$libraryRootId");
+    const { Route } = mod as unknown as { Route: MockRoute };
+    const Page = Route.options.component;
+    render(<Page />);
+    expect(screen.getByRole("button", { name: /retry all/i })).toBeTruthy();
+  });
+
+  it("does not render Retry All button when no issues", async () => {
+    const mod = await import("./library-issues.$libraryRootId");
+    const { Route } = mod as unknown as { Route: MockRoute };
+    const Page = Route.options.component;
+    render(<Page />);
+    expect(screen.queryByRole("button", { name: /retry all/i })).toBeNull();
+  });
+
+  it("calls retryLibraryIssuesServerFn when Retry All is clicked", async () => {
+    mockLoaderData = {
+      libraryRootId: "root-1",
+      issues: {
+        items: [
+          {
+            id: "fa-1",
+            relativePath: "author/book.epub",
+            mediaKind: "EPUB",
+            metadata: { status: "unparseable", warnings: ["Bad XML"] },
+            lastSeenAt: null,
+          },
+        ],
+        total: 1,
+      },
+    };
+    retryLibraryIssuesServerFnMock
+      .mockResolvedValueOnce({ retriedCount: 1 })
+      .mockResolvedValueOnce({ retriedCount: 3 });
+    const mod = await import("./library-issues.$libraryRootId");
+    const { Route } = mod as unknown as { Route: MockRoute };
+    const Page = Route.options.component;
+    const { unmount } = render(<Page />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /retry all/i }));
+
+    expect(retryLibraryIssuesServerFnMock).toHaveBeenCalledWith({
+      data: { libraryRootId: "root-1" },
+    });
+
+    // Click again to cover plural branch
+    unmount();
+    render(<Page />);
+    await user.click(screen.getByRole("button", { name: /retry all/i }));
+  });
+
+  it("shows error toast when retry fails with Error", async () => {
+    mockLoaderData = {
+      libraryRootId: "root-1",
+      issues: {
+        items: [
+          {
+            id: "fa-1",
+            relativePath: "author/book.epub",
+            mediaKind: "EPUB",
+            metadata: { status: "unparseable", warnings: ["Bad XML"] },
+            lastSeenAt: null,
+          },
+        ],
+        total: 1,
+      },
+    };
+    retryLibraryIssuesServerFnMock.mockRejectedValue(new Error("Queue connection failed"));
+    const mod = await import("./library-issues.$libraryRootId");
+    const { Route } = mod as unknown as { Route: MockRoute };
+    const Page = Route.options.component;
+    render(<Page />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /retry all/i }));
+
+    expect(retryLibraryIssuesServerFnMock).toHaveBeenCalled();
+  });
+
+  it("shows fallback error toast when retry fails with non-Error", async () => {
+    mockLoaderData = {
+      libraryRootId: "root-1",
+      issues: {
+        items: [
+          {
+            id: "fa-1",
+            relativePath: "author/book.epub",
+            mediaKind: "EPUB",
+            metadata: { status: "unparseable", warnings: ["Bad XML"] },
+            lastSeenAt: null,
+          },
+        ],
+        total: 1,
+      },
+    };
+    retryLibraryIssuesServerFnMock.mockRejectedValue("non-error rejection");
+    const mod = await import("./library-issues.$libraryRootId");
+    const { Route } = mod as unknown as { Route: MockRoute };
+    const Page = Route.options.component;
+    render(<Page />);
+
+    const user = userEvent.setup();
+    await user.click(screen.getByRole("button", { name: /retry all/i }));
+
+    expect(retryLibraryIssuesServerFnMock).toHaveBeenCalled();
   });
 });

--- a/apps/web/src/routes/_authenticated/settings/library-issues.$libraryRootId.tsx
+++ b/apps/web/src/routes/_authenticated/settings/library-issues.$libraryRootId.tsx
@@ -1,6 +1,9 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { ArrowLeft } from "lucide-react";
+import { useState } from "react";
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { ArrowLeft, Loader2, RefreshCw } from "lucide-react";
 import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
 import {
   Table,
   TableBody,
@@ -9,7 +12,10 @@ import {
   TableHeader,
   TableRow,
 } from "~/components/ui/table";
-import { getLibraryIssuesServerFn } from "~/lib/server-fns/library-roots";
+import {
+  getLibraryIssuesServerFn,
+  retryLibraryIssuesServerFn,
+} from "~/lib/server-fns/library-roots";
 
 interface IssueItem {
   id: string;
@@ -40,7 +46,28 @@ export const Route = createFileRoute(
 });
 
 function LibraryIssuesPage() {
-  const { issues } = Route.useLoaderData();
+  const { libraryRootId, issues } = Route.useLoaderData();
+  const router = useRouter();
+  const [retrying, setRetrying] = useState(false);
+
+  async function handleRetryAll() {
+    setRetrying(true);
+    try {
+      const result = await retryLibraryIssuesServerFn({
+        data: { libraryRootId },
+      });
+      toast.success(
+        `Re-parsed ${String(result.retriedCount)} file${result.retriedCount === 1 ? "" : "s"}`,
+      );
+      void router.invalidate();
+    } catch (error) {
+      toast.error(
+        error instanceof Error ? error.message : "Failed to retry issues",
+      );
+    } finally {
+      setRetrying(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -56,9 +83,31 @@ function LibraryIssuesPage() {
 
       <div className="flex items-center justify-between">
         <h1 className="text-2xl font-bold">Library Issues</h1>
-        <span className="text-sm text-muted-foreground">
-          {String(issues.total)} total issues
-        </span>
+        <div className="flex items-center gap-3">
+          {issues.total > 0 && (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => { void handleRetryAll(); }}
+              disabled={retrying}
+            >
+              {retrying ? (
+                <>
+                  <Loader2 className="size-4 animate-spin" />
+                  Retrying...
+                </>
+              ) : (
+                <>
+                  <RefreshCw className="size-4" />
+                  Retry All
+                </>
+              )}
+            </Button>
+          )}
+          <span className="text-sm text-muted-foreground">
+            {String(issues.total)} total issues
+          </span>
+        </div>
       </div>
 
       {issues.items.length === 0 ? (

--- a/packages/ingest/src/audiobook.test.ts
+++ b/packages/ingest/src/audiobook.test.ts
@@ -15,6 +15,7 @@ import {
   parseAudioId3Tags,
   type ParsedAudiobookMetadataJsonRaw,
   type ParsedAudioId3TagsRaw,
+  type ParseAudioId3Result,
 } from "./audiobook";
 
 const mockedReadFile = vi.mocked(readFile);
@@ -172,16 +173,19 @@ describe("parseAudioId3Tags", () => {
     const result = await parseAudioId3Tags("/books/chapter01.mp3");
 
     expect(result).toEqual({
-      title: "Chapter 01",
-      artist: "Andy Weir",
-      albumArtist: "Andy Weir",
-      album: "Project Hail Mary",
-      year: 2021,
-      genres: ["Science Fiction"],
-      comment: "A great audiobook",
-      trackNumber: 1,
-      trackTotal: 12,
-    } satisfies ParsedAudioId3TagsRaw);
+      tags: {
+        title: "Chapter 01",
+        artist: "Andy Weir",
+        albumArtist: "Andy Weir",
+        album: "Project Hail Mary",
+        year: 2021,
+        genres: ["Science Fiction"],
+        comment: "A great audiobook",
+        trackNumber: 1,
+        trackTotal: 12,
+      } satisfies ParsedAudioId3TagsRaw,
+      warnings: [],
+    } satisfies ParseAudioId3Result);
   });
 
   it("handles minimal metadata (all fields optional)", async () => {
@@ -195,16 +199,19 @@ describe("parseAudioId3Tags", () => {
     const result = await parseAudioId3Tags("/books/audio.m4b");
 
     expect(result).toEqual({
-      title: undefined,
-      artist: undefined,
-      albumArtist: undefined,
-      album: undefined,
-      year: undefined,
-      genres: [],
-      comment: undefined,
-      trackNumber: undefined,
-      trackTotal: undefined,
-    } satisfies ParsedAudioId3TagsRaw);
+      tags: {
+        title: undefined,
+        artist: undefined,
+        albumArtist: undefined,
+        album: undefined,
+        year: undefined,
+        genres: [],
+        comment: undefined,
+        trackNumber: undefined,
+        trackTotal: undefined,
+      } satisfies ParsedAudioId3TagsRaw,
+      warnings: [],
+    } satisfies ParseAudioId3Result);
   });
 
   it("takes first comment from array", async () => {
@@ -219,7 +226,7 @@ describe("parseAudioId3Tags", () => {
     } as never);
 
     const result = await parseAudioId3Tags("/books/audio.mp3");
-    expect(result.comment).toBe("first");
+    expect(result.tags.comment).toBe("first");
   });
 
   it("handles empty comment array", async () => {
@@ -234,7 +241,7 @@ describe("parseAudioId3Tags", () => {
     } as never);
 
     const result = await parseAudioId3Tags("/books/audio.mp3");
-    expect(result.comment).toBeUndefined();
+    expect(result.tags.comment).toBeUndefined();
   });
 
   it("handles missing track info", async () => {
@@ -248,15 +255,62 @@ describe("parseAudioId3Tags", () => {
     } as never);
 
     const result = await parseAudioId3Tags("/books/audio.mp3");
-    expect(result.trackNumber).toBeUndefined();
-    expect(result.trackTotal).toBeUndefined();
+    expect(result.tags.trackNumber).toBeUndefined();
+    expect(result.tags.trackTotal).toBeUndefined();
   });
 
-  it("propagates parse errors", async () => {
+  it("returns empty tags with warning for Unicode encoding errors", async () => {
+    mockedParseFile.mockRejectedValueOnce(new Error("unsupported Unicode escape sequence"));
+
+    const result = await parseAudioId3Tags("/books/audio.mp3");
+
+    expect(result).toEqual({
+      tags: {
+        title: undefined,
+        artist: undefined,
+        albumArtist: undefined,
+        album: undefined,
+        year: undefined,
+        genres: [],
+        comment: undefined,
+        trackNumber: undefined,
+        trackTotal: undefined,
+      },
+      warnings: ["unsupported Unicode escape sequence"],
+    });
+  });
+
+  it("returns empty tags with warning for 'invalid encoding' errors", async () => {
+    mockedParseFile.mockRejectedValueOnce(new Error("invalid encoding detected in ID3v2 tag"));
+
+    const result = await parseAudioId3Tags("/books/audio.mp3");
+
+    expect(result.tags.title).toBeUndefined();
+    expect(result.warnings).toEqual(["invalid encoding detected in ID3v2 tag"]);
+  });
+
+  it("returns empty tags with warning for 'unexpected character' errors", async () => {
+    mockedParseFile.mockRejectedValueOnce(new Error("unexpected character in tag data"));
+
+    const result = await parseAudioId3Tags("/books/audio.mp3");
+
+    expect(result.tags.title).toBeUndefined();
+    expect(result.warnings).toEqual(["unexpected character in tag data"]);
+  });
+
+  it("re-throws non-encoding errors", async () => {
     mockedParseFile.mockRejectedValueOnce(new Error("Unsupported format"));
 
     await expect(
       parseAudioId3Tags("/books/audio.wav"),
     ).rejects.toThrow("Unsupported format");
+  });
+
+  it("re-throws non-Error values", async () => {
+    mockedParseFile.mockRejectedValueOnce("string error");
+
+    await expect(
+      parseAudioId3Tags("/books/audio.wav"),
+    ).rejects.toBe("string error");
   });
 });

--- a/packages/ingest/src/audiobook.ts
+++ b/packages/ingest/src/audiobook.ts
@@ -84,21 +84,55 @@ export async function parseAudiobookMetadataJson(
   };
 }
 
+export interface ParseAudioId3Result {
+  tags: ParsedAudioId3TagsRaw;
+  warnings: string[];
+}
+
+function isEncodingError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  const msg = error.message.toLowerCase();
+  return msg.includes("unicode") || msg.includes("encoding") || msg.includes("unexpected character");
+}
+
 export async function parseAudioId3Tags(
   absolutePath: string,
-): Promise<ParsedAudioId3TagsRaw> {
-  const metadata = await parseFile(absolutePath);
-  const { common } = metadata;
+): Promise<ParseAudioId3Result> {
+  try {
+    const metadata = await parseFile(absolutePath);
+    const { common } = metadata;
 
-  return {
-    title: common.title,
-    artist: common.artist,
-    albumArtist: common.albumartist,
-    album: common.album,
-    year: common.year,
-    genres: common.genre ?? [],
-    comment: common.comment?.[0]?.text,
-    trackNumber: common.track.no ?? undefined,
-    trackTotal: common.track.of ?? undefined,
-  };
+    return {
+      tags: {
+        title: common.title,
+        artist: common.artist,
+        albumArtist: common.albumartist,
+        album: common.album,
+        year: common.year,
+        genres: common.genre ?? [],
+        comment: common.comment?.[0]?.text,
+        trackNumber: common.track.no ?? undefined,
+        trackTotal: common.track.of ?? undefined,
+      },
+      warnings: [],
+    };
+  } catch (error) {
+    if (isEncodingError(error)) {
+      return {
+        tags: {
+          title: undefined,
+          artist: undefined,
+          albumArtist: undefined,
+          album: undefined,
+          year: undefined,
+          genres: [],
+          comment: undefined,
+          trackNumber: undefined,
+          trackTotal: undefined,
+        },
+        warnings: [(error as Error).message],
+      };
+    }
+    throw error;
+  }
 }

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -40,6 +40,7 @@ export type {
   MatchFileAssetToEditionInput,
   MatchFileAssetToEditionResult,
   NormalizedBookMetadata,
+  ParseAudioId3Result,
   ParsedAudiobookMetadataJsonRaw,
   ParsedAudioId3TagsRaw,
   ParsedEpubMetadataRaw,

--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -1767,10 +1767,112 @@ describe("ingest services", () => {
       jobName: LIBRARY_JOB_NAMES.PROCESS_COVER,
       payload: { workId: work.id, fileAssetId: fileAsset.id },
     });
-    // Should NOT re-enqueue PARSE since EditionFile link already exists
+    // Should NOT re-enqueue PARSE since EditionFile link already exists (EPUB)
     expect(enqueuedJobs).not.toContainEqual(
       expect.objectContaining({ jobName: LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA }),
     );
+  });
+
+  it("re-enqueues PARSE for edition-linked AUDIO file with unparseable metadata", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-audio-unparseable-"));
+    tempDirectories.push(directory);
+
+    await mkdir(path.join(directory, "audiobook"));
+    await writeFile(path.join(directory, "audiobook", "chapter1.mp3"), "audio");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    // First scan creates stub with EditionFile link
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    // Simulate: HASH succeeded, PARSE failed with encoding error (unparseable), EditionFile link exists
+    const fileAsset = state.fileAssets.get(path.join(directory, "audiobook", "chapter1.mp3"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      source: "audio-id3",
+      status: "unparseable",
+      warnings: ["unsupported Unicode escape sequence"],
+    };
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "ENRICHED";
+    work.coverPath = "/covers/existing.jpg";
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(result.enqueuedRecoveryJobs).toContain(fileAsset.id);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA,
+      payload: { fileAssetId: fileAsset.id },
+    });
+  });
+
+  it("does not duplicate recovery entry for AUDIO with unparseable metadata and missing cover", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-recovery-audio-dedup-"));
+    tempDirectories.push(directory);
+
+    await mkdir(path.join(directory, "audiobook"));
+    await writeFile(path.join(directory, "audiobook", "chapter1.mp3"), "audio");
+
+    const state = createEmptyState(directory);
+    const enqueuedJobs: Array<{ jobName: LibraryJobName; payload: LibraryJobPayloads[LibraryJobName] }> = [];
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: (jobName, payload) => {
+        enqueuedJobs.push({ jobName, payload });
+        return Promise.resolve(undefined);
+      },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    const fileAsset = state.fileAssets.get(path.join(directory, "audiobook", "chapter1.mp3"));
+    if (!fileAsset) throw new Error("expected fileAsset");
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+    fileAsset.metadata = {
+      parsedAt: "2025-01-01T00:00:00.000Z",
+      parserVersion: 1,
+      source: "audio-id3",
+      status: "unparseable",
+      warnings: ["unsupported Unicode escape sequence"],
+    };
+
+    const work = [...state.works.values()][0];
+    if (!work) throw new Error("expected work");
+    work.enrichmentStatus = "ENRICHED";
+    work.coverPath = null; // Missing cover triggers PROCESS_COVER first
+
+    enqueuedJobs.length = 0;
+
+    const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    // File appears only once in recovery list despite triggering both PROCESS_COVER and PARSE
+    const occurrences = result.enqueuedRecoveryJobs.filter((id: string) => id === fileAsset.id);
+    expect(occurrences).toHaveLength(1);
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PROCESS_COVER,
+      payload: { workId: work.id, fileAssetId: fileAsset.id },
+    });
+    expect(enqueuedJobs).toContainEqual({
+      jobName: LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA,
+      payload: { fileAssetId: fileAsset.id },
+    });
   });
 
   it("re-enqueues PROCESS_COVER for PDF with null metadata but existing EditionFile link", async () => {
@@ -4968,15 +5070,18 @@ describe("ingest services", () => {
       parseAudioId3: vi.fn(async () => {
         await Promise.resolve();
         return {
-          title: "Chapter 01",
-          album: "PHM",
-          artist: "Weir",
-          genres: [],
-          albumArtist: undefined,
-          year: undefined,
-          comment: undefined,
-          trackNumber: 1,
-          trackTotal: 12,
+          tags: {
+            title: "Chapter 01",
+            album: "PHM",
+            artist: "Weir",
+            genres: [],
+            albumArtist: undefined,
+            year: undefined,
+            comment: undefined,
+            trackNumber: 1,
+            trackTotal: 12,
+          },
+          warnings: [],
         };
       }),
     });
@@ -5035,15 +5140,18 @@ describe("ingest services", () => {
       parseAudioId3: vi.fn(async () => {
         await Promise.resolve();
         return {
-          title: "Chapter 01",
-          album: "Project Hail Mary",
-          artist: "Andy Weir",
-          albumArtist: "Andy Weir",
-          year: 2021,
-          genres: ["Sci-Fi"],
-          comment: undefined,
-          trackNumber: 1,
-          trackTotal: 12,
+          tags: {
+            title: "Chapter 01",
+            album: "Project Hail Mary",
+            artist: "Andy Weir",
+            albumArtist: "Andy Weir",
+            year: 2021,
+            genres: ["Sci-Fi"],
+            comment: undefined,
+            trackNumber: 1,
+            trackTotal: 12,
+          },
+          warnings: [],
         };
       }),
     });
@@ -5127,15 +5235,18 @@ describe("ingest services", () => {
       parseAudioId3: vi.fn(async () => {
         await Promise.resolve();
         return {
-          title: "Chapter 01",
-          album: "Test",
-          artist: "Author",
-          albumArtist: undefined,
-          year: undefined,
-          genres: [],
-          comment: undefined,
-          trackNumber: undefined,
-          trackTotal: undefined,
+          tags: {
+            title: "Chapter 01",
+            album: "Test",
+            artist: "Author",
+            albumArtist: undefined,
+            year: undefined,
+            genres: [],
+            comment: undefined,
+            trackNumber: undefined,
+            trackTotal: undefined,
+          },
+          warnings: [],
         };
       }),
     });
@@ -5149,6 +5260,85 @@ describe("ingest services", () => {
       fileAssetId: "file-1",
       skipped: true,
     });
+  });
+
+  it("clears unparseable metadata on AUDIO file when sibling metadata.json is already parsed", async () => {
+    const state = createEmptyState("/tmp/root");
+    const audioAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/chapter01.mp3",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "chapter01.mp3",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "mp3",
+      fullHash: "hash",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.AUDIO,
+      metadata: {
+        parsedAt: "2025-01-01T00:00:00.000Z",
+        parserVersion: 1,
+        source: "audio-id3",
+        status: "unparseable",
+        warnings: ["unsupported Unicode escape sequence"],
+      } as unknown as FileAsset["metadata"],
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/chapter01.mp3",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(audioAsset.absolutePath, audioAsset);
+    state.fileAssetsById.set(audioAsset.id, audioAsset);
+
+    const sidecarAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.json",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.json",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "json",
+      fullHash: "sidecar-hash",
+      id: "file-sidecar",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: {
+        source: "audiobook-json",
+        status: "parsed",
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        warnings: [],
+        normalized: {
+          title: "Test",
+          authors: ["Author"],
+          identifiers: { unknown: [] },
+        },
+      } as unknown as FileAsset["metadata"],
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "sidecar-phash",
+      relativePath: "Author/Book/metadata.json",
+      sizeBytes: 2n,
+    };
+    state.fileAssets.set(sidecarAsset.absolutePath, sidecarAsset);
+    state.fileAssetsById.set(sidecarAsset.id, sidecarAsset);
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.parseFileAssetMetadata({
+      fileAssetId: "file-1",
+      now: new Date("2025-06-01T00:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      fileAssetId: "file-1",
+      skipped: true,
+    });
+
+    // The unparseable metadata should be cleared so the file no longer shows as a library issue
+    const updatedMetadata = state.fileAssetsById.get("file-1")?.metadata as Record<string, unknown> | null;
+    expect(updatedMetadata?.status).not.toBe("unparseable");
   });
 
   it("handles metadata.json ENOENT by marking file as MISSING", async () => {
@@ -5340,6 +5530,253 @@ describe("ingest services", () => {
     });
   });
 
+  it("re-throws transient ENOTCONN error from audio ID3 parsing instead of marking unparseable", async () => {
+    const state = createEmptyState("/tmp/root");
+    const audioAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/chapter01.mp3",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "chapter01.mp3",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "mp3",
+      fullHash: "hash",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.AUDIO,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/chapter01.mp3",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(audioAsset.absolutePath, audioAsset);
+    state.fileAssetsById.set(audioAsset.id, audioAsset);
+
+    const error = new Error("ENOTCONN: socket is not connected, close") as NodeJS.ErrnoException;
+    error.code = "ENOTCONN";
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      parseAudioId3: vi.fn(async () => {
+        await Promise.resolve();
+        throw error;
+      }),
+    });
+
+    await expect(
+      services.parseFileAssetMetadata({
+        fileAssetId: "file-1",
+        now: new Date("2025-01-01T00:00:00.000Z"),
+      }),
+    ).rejects.toThrow("ENOTCONN");
+
+    // Metadata should NOT be set to unparseable
+    expect(state.fileAssetsById.get("file-1")?.metadata).toBeNull();
+  });
+
+  it("re-throws transient EIO error from EPUB parsing instead of marking unparseable", async () => {
+    const state = createEmptyState("/tmp/root");
+    const epubAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/book.epub",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.epub",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "epub",
+      fullHash: "hash",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.EPUB,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/book.epub",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(epubAsset.absolutePath, epubAsset);
+    state.fileAssetsById.set(epubAsset.id, epubAsset);
+
+    const error = new Error("EIO: i/o error, read") as NodeJS.ErrnoException;
+    error.code = "EIO";
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      parseEpub: vi.fn(async () => {
+        await Promise.resolve();
+        throw error;
+      }),
+    });
+
+    await expect(
+      services.parseFileAssetMetadata({
+        fileAssetId: "file-1",
+        now: new Date("2025-01-01T00:00:00.000Z"),
+      }),
+    ).rejects.toThrow("EIO");
+
+    expect(state.fileAssetsById.get("file-1")?.metadata).toBeNull();
+  });
+
+  it("re-throws transient ECONNRESET error from OPF parsing instead of marking unparseable", async () => {
+    const state = createEmptyState("/tmp/root");
+    const opfAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.opf",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.opf",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "opf",
+      fullHash: "hash",
+      id: "file-opf",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.opf",
+      sizeBytes: 2n,
+    };
+    state.fileAssets.set(opfAsset.absolutePath, opfAsset);
+    state.fileAssetsById.set(opfAsset.id, opfAsset);
+
+    const error = new Error("ECONNRESET: connection reset by peer") as NodeJS.ErrnoException;
+    error.code = "ECONNRESET";
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      parseOpf: vi.fn(async () => {
+        await Promise.resolve();
+        throw error;
+      }),
+    });
+
+    await expect(
+      services.parseFileAssetMetadata({
+        fileAssetId: "file-opf",
+        now: new Date("2025-01-01T00:00:00.000Z"),
+      }),
+    ).rejects.toThrow("ECONNRESET");
+
+    expect(state.fileAssetsById.get("file-opf")?.metadata).toBeNull();
+  });
+
+  it("re-throws transient ETIMEDOUT error from audiobook metadata.json parsing instead of marking unparseable", async () => {
+    const state = createEmptyState("/tmp/root");
+    const jsonAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.json",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.json",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "json",
+      fullHash: "hash",
+      id: "file-json",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.json",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(jsonAsset.absolutePath, jsonAsset);
+    state.fileAssetsById.set(jsonAsset.id, jsonAsset);
+
+    const error = new Error("ETIMEDOUT: connection timed out") as NodeJS.ErrnoException;
+    error.code = "ETIMEDOUT";
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      parseAudiobookJson: vi.fn(async () => {
+        await Promise.resolve();
+        throw error;
+      }),
+    });
+
+    await expect(
+      services.parseFileAssetMetadata({
+        fileAssetId: "file-json",
+        now: new Date("2025-01-01T00:00:00.000Z"),
+      }),
+    ).rejects.toThrow("ETIMEDOUT");
+
+    expect(state.fileAssetsById.get("file-json")?.metadata).toBeNull();
+  });
+
+  it("handles encoding error on standalone audio as parsed with warnings", async () => {
+    const state = createEmptyState("/tmp/root");
+    const audioAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/chapter01.mp3",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "chapter01.mp3",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "mp3",
+      fullHash: "hash",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.AUDIO,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/chapter01.mp3",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(audioAsset.absolutePath, audioAsset);
+    state.fileAssetsById.set(audioAsset.id, audioAsset);
+
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+      parseAudioId3: vi.fn(async () => {
+        await Promise.resolve();
+        return {
+          tags: {
+            title: undefined,
+            album: undefined,
+            artist: undefined,
+            albumArtist: undefined,
+            year: undefined,
+            genres: [],
+            comment: undefined,
+            trackNumber: undefined,
+            trackTotal: undefined,
+          },
+          warnings: ["unsupported Unicode escape sequence"],
+        };
+      }),
+    });
+
+    const result = await services.parseFileAssetMetadata({
+      fileAssetId: "file-1",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    expect(result).toMatchObject({
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      fileAssetId: "file-1",
+      skipped: false,
+    });
+    expect(state.fileAssetsById.get("file-1")?.metadata).toMatchObject({
+      source: "audio-id3",
+      status: "parsed",
+      warnings: ["unsupported Unicode escape sequence"],
+    });
+    expect(enqueueLibraryJob).toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.MATCH_AUDIO,
+      { fileAssetId: "file-1" },
+    );
+    expect(enqueueLibraryJob).not.toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
+      expect.anything(),
+    );
+  });
+
   it("enqueues MATCH_AUDIO directly when audio ID3 has no title and no authors", async () => {
     const state = createEmptyState("/tmp/root");
     const audioAsset: TestFileAsset = {
@@ -5369,15 +5806,18 @@ describe("ingest services", () => {
       parseAudioId3: vi.fn(async () => {
         await Promise.resolve();
         return {
-          title: undefined,
-          album: undefined,
-          artist: undefined,
-          albumArtist: undefined,
-          year: undefined,
-          genres: [],
-          comment: undefined,
-          trackNumber: undefined,
-          trackTotal: undefined,
+          tags: {
+            title: undefined,
+            album: undefined,
+            artist: undefined,
+            albumArtist: undefined,
+            year: undefined,
+            genres: [],
+            comment: undefined,
+            trackNumber: undefined,
+            trackTotal: undefined,
+          },
+          warnings: [],
         };
       }),
     });
@@ -5430,15 +5870,18 @@ describe("ingest services", () => {
       parseAudioId3: vi.fn(async () => {
         await Promise.resolve();
         return {
-          title: undefined,
-          album: "Project Hail Mary",
-          artist: undefined,
-          albumArtist: undefined,
-          year: undefined,
-          genres: [],
-          comment: undefined,
-          trackNumber: undefined,
-          trackTotal: undefined,
+          tags: {
+            title: undefined,
+            album: "Project Hail Mary",
+            artist: undefined,
+            albumArtist: undefined,
+            year: undefined,
+            genres: [],
+            comment: undefined,
+            trackNumber: undefined,
+            trackTotal: undefined,
+          },
+          warnings: [],
         };
       }),
     });
@@ -6656,15 +7099,18 @@ describe("ingest services", () => {
       parseAudioId3: vi.fn(async () => {
         await Promise.resolve();
         return {
-          title: "Chapter 01",
-          album: "Test Book",
-          artist: "Author",
-          albumArtist: "Author",
-          year: 2021,
-          genres: [],
-          comment: undefined,
-          trackNumber: 1,
-          trackTotal: 5,
+          tags: {
+            title: "Chapter 01",
+            album: "Test Book",
+            artist: "Author",
+            albumArtist: "Author",
+            year: 2021,
+            genres: [],
+            comment: undefined,
+            trackNumber: 1,
+            trackTotal: 5,
+          },
+          warnings: [],
         };
       }),
     });
@@ -6709,15 +7155,18 @@ describe("ingest services", () => {
       parseAudioId3: vi.fn(async () => {
         await Promise.resolve();
         return {
-          title: undefined,
-          album: "The Book",
-          artist: "Artist Only",
-          albumArtist: undefined,
-          year: undefined,
-          genres: [],
-          comment: undefined,
-          trackNumber: undefined,
-          trackTotal: undefined,
+          tags: {
+            title: undefined,
+            album: "The Book",
+            artist: "Artist Only",
+            albumArtist: undefined,
+            year: undefined,
+            genres: [],
+            comment: undefined,
+            trackNumber: undefined,
+            trackTotal: undefined,
+          },
+          warnings: [],
         };
       }),
     });

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -456,6 +456,24 @@ function getErrorCode(error: unknown): string | undefined {
     : undefined;
 }
 
+/** Transient infrastructure errors that should be retried, not permanently stored as "unparseable". */
+const TRANSIENT_ERROR_CODES = new Set([
+  "ENOTCONN",    // socket not connected (NFS/network filesystem)
+  "ECONNRESET",  // connection reset by peer
+  "ECONNREFUSED",// connection refused
+  "ETIMEDOUT",   // operation timed out
+  "EIO",         // I/O error (disk/network issue)
+  "EPIPE",       // broken pipe
+  "ENETUNREACH", // network unreachable
+  "EHOSTUNREACH",// host unreachable
+  "ECONNABORTED",// connection aborted
+]);
+
+function isTransientError(error: unknown): boolean {
+  const code = getErrorCode(error);
+  return code !== undefined && TRANSIENT_ERROR_CODES.has(code);
+}
+
 function parseStoredMetadata(metadata: FileAsset["metadata"]): ParsedFileAssetMetadata | undefined {
   if (metadata === null || typeof metadata !== "object") {
     return undefined;
@@ -1302,6 +1320,22 @@ export function createIngestServices(
                 }
               }
             }
+
+            // Re-parse edition-linked AUDIO files with unparseable metadata
+            // (encoding errors are now handled gracefully, so re-parsing will succeed)
+            const editionLinkedMeta = parseStoredMetadata(upsertedFileAsset.metadata);
+            if (
+              upsertedFileAsset.mediaKind === MediaKind.AUDIO &&
+              editionLinkedMeta?.status === "unparseable"
+            ) {
+              logger.info({ fileAssetId: upsertedFileAsset.id, reason: "edition-linked audio with unparseable metadata" }, "Recovery: re-enqueueing PARSE");
+              await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
+                fileAssetId: upsertedFileAsset.id,
+              });
+              if (!enqueuedRecoveryJobs.includes(upsertedFileAsset.id)) {
+                enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+              }
+            }
           } else {
             // Not linked to an edition — recover from earlier in the pipeline
             const parsedMeta = parseStoredMetadata(upsertedFileAsset.metadata);
@@ -1757,6 +1791,10 @@ export function createIngestServices(
           return { availabilityStatus: AvailabilityStatus.MISSING, fileAssetId: fileAsset.id, skipped: false };
         }
 
+        if (isTransientError(error)) {
+          throw error;
+        }
+
         const warning = error instanceof Error ? error.message : "Unknown OPF parsing error";
         const metadata: ParsedFileAssetMetadata = {
           parsedAt: now.toISOString(),
@@ -1798,7 +1836,8 @@ export function createIngestServices(
         const firstAudioSibling = audioSiblings[0];
         if (firstAudioSibling) {
           try {
-            id3Raw = await parseAudioId3(firstAudioSibling.absolutePath);
+            const { tags } = await parseAudioId3(firstAudioSibling.absolutePath);
+            id3Raw = tags;
           } catch {
             // ID3 parsing failure is non-fatal for sidecar flow
           }
@@ -1848,6 +1887,10 @@ export function createIngestServices(
           return { availabilityStatus: AvailabilityStatus.MISSING, fileAssetId: fileAsset.id, skipped: false };
         }
 
+        if (isTransientError(error)) {
+          throw error;
+        }
+
         const warning = error instanceof Error ? error.message : "Unknown audiobook metadata.json parsing error";
         const metadata: ParsedFileAssetMetadata = {
           parsedAt: now.toISOString(),
@@ -1885,7 +1928,16 @@ export function createIngestServices(
       if (metadataJsonSibling !== undefined) {
         const siblingMetadata = parseStoredMetadata(metadataJsonSibling.metadata);
         if (siblingMetadata?.source === "audiobook-json" && siblingMetadata.status === "parsed") {
-          // Sidecar already parsed; skip this audio file
+          // Sidecar already parsed; skip this audio file's own ID3 parse.
+          // If the audio file was previously marked unparseable (e.g. encoding error),
+          // clear it so it no longer shows as a library issue.
+          const ownMetadata = parseStoredMetadata(fileAsset.metadata);
+          if (ownMetadata?.status === "unparseable") {
+            await ingestDb.fileAsset.update({
+              where: { id: fileAsset.id },
+              data: { metadata: null },
+            });
+          }
           return {
             availabilityStatus: fileAsset.availabilityStatus,
             fileAssetId: fileAsset.id,
@@ -1895,7 +1947,7 @@ export function createIngestServices(
       }
 
       try {
-        const id3Raw = await parseAudioId3(fileAsset.absolutePath);
+        const { tags: id3Raw, warnings: id3Warnings } = await parseAudioId3(fileAsset.absolutePath);
         const normalized = normalizeAudiobookMetadata(
           {
             title: id3Raw.album ?? id3Raw.title ?? "",
@@ -1918,7 +1970,7 @@ export function createIngestServices(
           raw: id3Raw,
           source: "audio-id3",
           status: "parsed",
-          warnings: [],
+          warnings: id3Warnings,
         };
 
         await ingestDb.fileAsset.update({
@@ -1960,6 +2012,10 @@ export function createIngestServices(
             },
           });
           return { availabilityStatus: AvailabilityStatus.MISSING, fileAssetId: fileAsset.id, skipped: false };
+        }
+
+        if (isTransientError(error)) {
+          throw error;
         }
 
         const warning = error instanceof Error ? error.message : "Unknown audio ID3 parsing error";
@@ -2040,6 +2096,10 @@ export function createIngestServices(
           fileAssetId: fileAsset.id,
           skipped: false,
         };
+      }
+
+      if (isTransientError(error)) {
+        throw error;
       }
 
       const warning = error instanceof Error ? error.message : "Unknown EPUB parsing error";
@@ -2588,7 +2648,7 @@ export const mergeWorksById = services.mergeWorksById;
 export { classifyMediaKind, deriveFormatFamily, getFileExtension, hashFileContents, isFileChanged, normalizeRelativePath, normalizeRootPath, walkRegularFiles };
 export { parseEpubMetadata } from "./epub";
 export { parseOpfSidecar } from "./opf";
-export { parseAudiobookMetadataJson, parseAudioId3Tags } from "./audiobook";
+export { parseAudiobookMetadataJson, parseAudioId3Tags, type ParseAudioId3Result } from "./audiobook";
 export {
   canonicalizeBookTitle,
   canonicalizeContributorName,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -59,6 +59,9 @@ importers:
       '@bookhouse/domain':
         specifier: workspace:*
         version: link:../../packages/domain
+      '@bookhouse/ingest':
+        specifier: workspace:*
+        version: link:../../packages/ingest
       '@bookhouse/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
## Summary

- **ID3 encoding errors**: `parseAudioId3Tags` now catches Unicode/encoding errors from `music-metadata` and returns empty tags with a warning instead of throwing, so audio files with malformed ID3 tags get `status: "parsed"` (with warnings) rather than `status: "unparseable"`
- **Retry All fix**: `retryLibraryIssuesServerFn` calls `parseFileAssetMetadata` directly and sequentially instead of enqueuing through BullMQ — eliminates the orphaned ImportJob stuck at QUEUED and avoids concurrent DB write issues
- **Scan recovery**: Edition-linked AUDIO files with stale `status: "unparseable"` metadata now get re-enqueued for PARSE during scan recovery, so a rescan also clears old issues

## Test plan

- Verified `parseAudioId3Tags` against real Zinn mp3 files — parses cleanly with zero warnings
- Verified `parseFileAssetMetadata` clears unparseable status when audiobook-json sidecar exists
- Set 27 Zinn files back to unparseable, clicked Retry All, all issues cleared immediately

Closes #96