### PR TITLE
Fix edition-level filters overwriting each other in library view

### DIFF
--- a/apps/web/src/lib/server-fns/library.test.ts
+++ b/apps/web/src/lib/server-fns/library.test.ts
@@ -305,7 +305,120 @@ describe("getFilteredLibraryWorksServerFn", () => {
     );
   });
 
-  it("combines multiple filters with AND logic", async () => {
+  it("combines format + authorId into a single editions filter with AND", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+    seriesCountMock.mockResolvedValue(0);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { format: ["EBOOK"], authorId: ["author-1"] },
+    });
+
+    const call = (findManyMock.mock.calls[0] as unknown[])[0] as { where: Record<string, unknown> };
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        editions: {
+          some: {
+            AND: [
+              { formatFamily: { in: ["EBOOK"] } },
+              {
+                contributors: {
+                  some: { contributorId: { in: ["author-1"] }, role: "AUTHOR" },
+                },
+              },
+            ],
+          },
+        },
+      }),
+    );
+  });
+
+  it("combines format + publisher into a single editions filter with AND", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+    seriesCountMock.mockResolvedValue(0);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { format: ["AUDIOBOOK"], publisher: ["Penguin"] },
+    });
+
+    const call = (findManyMock.mock.calls[0] as unknown[])[0] as { where: Record<string, unknown> };
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        editions: {
+          some: {
+            AND: [
+              { formatFamily: { in: ["AUDIOBOOK"] } },
+              { publisher: { in: ["Penguin"] } },
+            ],
+          },
+        },
+      }),
+    );
+  });
+
+  it("combines authorId + publisher into a single editions filter with AND", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+    seriesCountMock.mockResolvedValue(0);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { authorId: ["author-1"], publisher: ["Penguin"] },
+    });
+
+    const call = (findManyMock.mock.calls[0] as unknown[])[0] as { where: Record<string, unknown> };
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        editions: {
+          some: {
+            AND: [
+              {
+                contributors: {
+                  some: { contributorId: { in: ["author-1"] }, role: "AUTHOR" },
+                },
+              },
+              { publisher: { in: ["Penguin"] } },
+            ],
+          },
+        },
+      }),
+    );
+  });
+
+  it("combines format + authorId + publisher into a single editions filter with AND", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+    seriesCountMock.mockResolvedValue(0);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { format: ["EBOOK"], authorId: ["author-1"], publisher: ["Penguin"] },
+    });
+
+    const call = (findManyMock.mock.calls[0] as unknown[])[0] as { where: Record<string, unknown> };
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        editions: {
+          some: {
+            AND: [
+              { formatFamily: { in: ["EBOOK"] } },
+              {
+                contributors: {
+                  some: { contributorId: { in: ["author-1"] }, role: "AUTHOR" },
+                },
+              },
+              { publisher: { in: ["Penguin"] } },
+            ],
+          },
+        },
+      }),
+    );
+  });
+
+  it("combines edition-level and work-level filters with AND logic", async () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
@@ -314,6 +427,7 @@ describe("getFilteredLibraryWorksServerFn", () => {
     await getFilteredLibraryWorksServerFn({
       data: {
         format: ["EBOOK"],
+        authorId: ["author-1"],
         hasCover: true,
         q: "test",
       },
@@ -322,7 +436,18 @@ describe("getFilteredLibraryWorksServerFn", () => {
     const call = (findManyMock.mock.calls[0] as unknown[])[0] as { where: Record<string, unknown> };
     expect(call.where).toEqual(
       expect.objectContaining({
-        editions: { some: { formatFamily: { in: ["EBOOK"] } } },
+        editions: {
+          some: {
+            AND: [
+              { formatFamily: { in: ["EBOOK"] } },
+              {
+                contributors: {
+                  some: { contributorId: { in: ["author-1"] }, role: "AUTHOR" },
+                },
+              },
+            ],
+          },
+        },
         coverPath: { not: null },
         OR: [
           { titleDisplay: { contains: "test", mode: "insensitive" } },

--- a/apps/web/src/lib/server-fns/library.ts
+++ b/apps/web/src/lib/server-fns/library.ts
@@ -60,25 +60,31 @@ function buildWhere(data: z.infer<typeof filterSchema>): WhereClause {
     ];
   }
 
+  const editionConditions: Record<string, unknown>[] = [];
+
   if (data.format && data.format.length > 0) {
-    where.editions = { some: { formatFamily: { in: data.format } } };
+    editionConditions.push({ formatFamily: { in: data.format } });
   }
 
   if (data.authorId && data.authorId.length > 0) {
-    where.editions = {
-      some: {
-        contributors: {
-          some: {
-            contributorId: { in: data.authorId },
-            role: "AUTHOR",
-          },
+    editionConditions.push({
+      contributors: {
+        some: {
+          contributorId: { in: data.authorId },
+          role: "AUTHOR",
         },
       },
-    };
+    });
   }
 
   if (data.publisher && data.publisher.length > 0) {
-    where.editions = { some: { publisher: { in: data.publisher } } };
+    editionConditions.push({ publisher: { in: data.publisher } });
+  }
+
+  if (editionConditions.length === 1) {
+    where.editions = { some: editionConditions[0] };
+  } else if (editionConditions.length > 1) {
+    where.editions = { some: { AND: editionConditions } };
   }
 
   if (data.seriesId && data.seriesId.length > 0) {


### PR DESCRIPTION
## Summary

- Edition-level filters (format, authorId, publisher) were each assigning directly to `where.editions`, so only the last one applied survived — combining e.g. format + author produced wrong results or a blank screen crash
- Collect edition conditions into an array and combine with `AND` when multiple are active; single-filter case keeps the same shape
- Replaced the existing combination test (which only used one edition-level filter) with 5 tests covering all edition-level filter pairings and the triple combination

Closes #92