### PR TITLE
Implement scan mode defaults and manual full scan

### DIFF
--- a/apps/web/src/components/settings/add-library-root-dialog.test.tsx
+++ b/apps/web/src/components/settings/add-library-root-dialog.test.tsx
@@ -78,7 +78,7 @@ describe("AddLibraryRootDialog", () => {
           name: "My Books",
           path: "/home/books",
           kind: "EBOOKS",
-          scanMode: "INCREMENTAL",
+          scanMode: "FULL",
         },
       });
     });
@@ -191,39 +191,12 @@ describe("AddLibraryRootDialog", () => {
     });
   });
 
-  it("changes ScanMode select value via userEvent", async () => {
-    const user = userEvent.setup();
-    addLibraryRootServerFnMock.mockResolvedValue(undefined);
+  it("does not render a scan mode selector in the add dialog", () => {
     render(<AddLibraryRootDialog />);
     openDialog();
 
-    // Open the ScanMode select (second combobox)
-    const scanModeTrigger = screen.getAllByRole("combobox")[1];
-    if (!scanModeTrigger) throw new Error("scan mode combobox not found");
-    await user.click(scanModeTrigger);
-    // Select "Full" - there may be multiple "Full" texts, pick the one in the select listbox
-    const fullOptions = screen.getAllByText("Full");
-    // Click the last one (which should be the option in the dropdown listbox)
-    const lastFullOption = fullOptions[fullOptions.length - 1];
-    if (!lastFullOption) throw new Error("full option not found");
-    await user.click(lastFullOption);
-
-    // Submit to verify the scanMode value was changed
-    fireEvent.change(screen.getByPlaceholderText("My Library"), {
-      target: { value: "Test" },
-    });
-    fireEvent.change(screen.getByPlaceholderText("/path/to/books"), {
-      target: { value: "/test" },
-    });
-    const form = screen.getByPlaceholderText("My Library").closest("form");
-    if (!form) throw new Error("form not found");
-    fireEvent.submit(form);
-
-    await waitFor(() => {
-      expect(addLibraryRootServerFnMock).toHaveBeenCalledWith({
-        data: expect.objectContaining({ scanMode: "FULL" }) as unknown,
-      });
-    });
+    expect(screen.getAllByRole("combobox")).toHaveLength(1);
+    expect(screen.queryByText("Scan Mode")).toBeNull();
   });
 
   it("resetForm is called after successful submit (form resets to defaults)", async () => {

--- a/apps/web/src/components/settings/add-library-root-dialog.tsx
+++ b/apps/web/src/components/settings/add-library-root-dialog.tsx
@@ -28,21 +28,19 @@ export function AddLibraryRootDialog() {
   const [name, setName] = useState("");
   const [path, setPath] = useState("");
   const [kind, setKind] = useState<"EBOOKS" | "AUDIOBOOKS" | "MIXED">("EBOOKS");
-  const [scanMode, setScanMode] = useState<"FULL" | "INCREMENTAL">("INCREMENTAL");
   const [submitting, setSubmitting] = useState(false);
 
   function resetForm() {
     setName("");
     setPath("");
     setKind("EBOOKS");
-    setScanMode("INCREMENTAL");
   }
 
   async function handleSubmit(e: React.SubmitEvent) {
     e.preventDefault();
     setSubmitting(true);
     try {
-      await addLibraryRootServerFn({ data: { name, path, kind, scanMode } });
+      await addLibraryRootServerFn({ data: { name, path, kind, scanMode: "FULL" } });
       toast.success("Library root added");
       setOpen(false);
       resetForm();
@@ -110,18 +108,9 @@ export function AddLibraryRootDialog() {
                 </SelectContent>
               </Select>
             </div>
-            <div className="grid gap-2">
-              <label className="text-sm font-medium">Scan Mode</label>
-              <Select value={scanMode} onValueChange={(v) => { setScanMode(v as typeof scanMode); }}>
-                <SelectTrigger>
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="INCREMENTAL">Incremental</SelectItem>
-                  <SelectItem value="FULL">Full</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
+            <p className="text-sm text-muted-foreground">
+              New libraries start with a full scan. Later scans default to incremental, with a manual full scan option available from the library card.
+            </p>
           </div>
           <DialogFooter>
             <Button type="submit" disabled={submitting}>

--- a/apps/web/src/lib/server-fns/library-roots.test.ts
+++ b/apps/web/src/lib/server-fns/library-roots.test.ts
@@ -1,14 +1,29 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type * as SharedModule from "@bookhouse/shared";
+import type { ZodType } from "zod";
 
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {
-      inputValidator: () => Builder;
+      inputValidator: (validator: ZodType) => Builder;
       handler: (fn: (a: Record<string, unknown>) => unknown) => (a: Record<string, unknown>) => unknown;
     };
+    let validator: ZodType | null = null;
     const b: Builder = {
-      inputValidator: () => b,
-      handler: (fn) => (a) => fn(a),
+      inputValidator: (nextValidator) => {
+        validator = nextValidator;
+        return b;
+      },
+      handler: (fn) => (a) => {
+        const validatedData: unknown = validator?.parse((a as { data?: unknown }).data);
+        const parsed = validator === null
+          ? a
+          : {
+            ...a,
+            data: validatedData,
+          };
+        return fn(parsed);
+      },
     };
     return b;
   },
@@ -57,20 +72,26 @@ vi.mock("@bookhouse/db", () => ({
   },
 }));
 
-const enqueueLibraryJobMock = vi.fn();
-const getLibraryJobSnapshotMock = vi.fn();
-const getImportJobLiveActivityMock = vi.fn();
-const LIBRARY_JOB_NAMES = {
-  SCAN_LIBRARY_ROOT: "SCAN_LIBRARY_ROOT",
-  PARSE_FILE_ASSET_METADATA: "PARSE_FILE_ASSET_METADATA",
-};
-
-vi.mock("@bookhouse/shared", () => ({
-  enqueueLibraryJob: enqueueLibraryJobMock,
-  getImportJobLiveActivity: getImportJobLiveActivityMock,
-  getLibraryJobSnapshot: getLibraryJobSnapshotMock,
-  LIBRARY_JOB_NAMES,
+const {
+  enqueueLibraryJobMock,
+  getLibraryJobSnapshotMock,
+  getImportJobLiveActivityMock,
+} = vi.hoisted(() => ({
+  enqueueLibraryJobMock: vi.fn(),
+  getLibraryJobSnapshotMock: vi.fn(),
+  getImportJobLiveActivityMock: vi.fn(),
 }));
+
+vi.mock("@bookhouse/shared", async () => {
+  const actual = await vi.importActual<typeof SharedModule>("@bookhouse/shared");
+
+  return {
+    ...actual,
+    enqueueLibraryJob: enqueueLibraryJobMock,
+    getImportJobLiveActivity: getImportJobLiveActivityMock,
+    getLibraryJobSnapshot: getLibraryJobSnapshotMock,
+  };
+});
 
 const parseFileAssetMetadataMock = vi.fn();
 const createIngestServicesMock = vi.fn(() => ({
@@ -94,6 +115,7 @@ import {
   getLibraryIssuesServerFn,
   retryLibraryIssuesServerFn,
 } from "./library-roots";
+import { LIBRARY_JOB_NAMES } from "@bookhouse/shared";
 
 describe("getLibraryRootsServerFn", () => {
   beforeEach(() => {
@@ -131,7 +153,36 @@ describe("addLibraryRootServerFn", () => {
     libraryRootCreateMock.mockReset();
   });
 
-  it("calls db.libraryRoot.create with name, path, kind, scanMode and returns result", async () => {
+  it("defaults new library roots to FULL scan mode", async () => {
+    const fakeRoot = {
+      id: "root-new",
+      name: "Books",
+      path: "/books",
+      kind: "EBOOKS",
+      scanMode: "FULL",
+    };
+    libraryRootCreateMock.mockResolvedValue(fakeRoot);
+
+    const result = await addLibraryRootServerFn({
+      data: {
+        name: "Books",
+        path: "/books",
+        kind: "EBOOKS",
+      },
+    });
+
+    expect(libraryRootCreateMock).toHaveBeenCalledWith({
+      data: {
+        name: "Books",
+        path: "/books",
+        kind: "EBOOKS",
+        scanMode: "FULL",
+      },
+    });
+    expect(result).toBe(fakeRoot);
+  });
+
+  it("preserves an explicit incremental scan mode when provided", async () => {
     const fakeRoot = {
       id: "root-new",
       name: "Books",
@@ -253,6 +304,21 @@ describe("scanLibraryRootServerFn", () => {
     expect(enqueueLibraryJobMock).toHaveBeenCalledWith(
       LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT,
       { libraryRootId: "root-xyz", importJobId: "job-abc" },
+    );
+  });
+
+  it("passes through a manual FULL scan override", async () => {
+    importJobCreateMock.mockResolvedValue({ id: "job-abc" });
+    enqueueLibraryJobMock.mockResolvedValue("bull-job-123");
+    importJobUpdateMock.mockResolvedValue({});
+
+    await scanLibraryRootServerFn({
+      data: { libraryRootId: "root-xyz", scanMode: "FULL" },
+    });
+
+    expect(enqueueLibraryJobMock).toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT,
+      { libraryRootId: "root-xyz", importJobId: "job-abc", scanMode: "FULL" },
     );
   });
 

--- a/apps/web/src/lib/server-fns/library-roots.ts
+++ b/apps/web/src/lib/server-fns/library-roots.ts
@@ -59,7 +59,7 @@ const addLibraryRootSchema = z.object({
   name: z.string().min(1, "Name is required"),
   path: z.string().min(1, "Path is required"),
   kind: z.enum(["EBOOKS", "AUDIOBOOKS", "MIXED"]),
-  scanMode: z.enum(["FULL", "INCREMENTAL"]).default("INCREMENTAL"),
+  scanMode: z.enum(["FULL", "INCREMENTAL"]).default("FULL"),
 });
 
 export const addLibraryRootServerFn = createServerFn({
@@ -269,6 +269,7 @@ export const getLibraryIssuesServerFn = createServerFn({
 
 const scanLibraryRootSchema = z.object({
   libraryRootId: z.string().min(1),
+  scanMode: z.enum(["FULL", "INCREMENTAL"]).optional(),
 });
 
 export const scanLibraryRootServerFn = createServerFn({
@@ -292,7 +293,11 @@ export const scanLibraryRootServerFn = createServerFn({
 
     const jobId = await enqueueLibraryJob(
       LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT,
-      { libraryRootId: data.libraryRootId, importJobId: importJob.id },
+      {
+        libraryRootId: data.libraryRootId,
+        importJobId: importJob.id,
+        ...(data.scanMode ? { scanMode: data.scanMode } : {}),
+      },
     );
 
     await db.importJob.update({

--- a/apps/web/src/routes/_authenticated/settings/-libraries.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-libraries.test.tsx
@@ -159,7 +159,7 @@ describe("LibrariesPage", () => {
     expect(screen.queryByText("Never")).toBeNull();
   });
 
-  it("scan button calls scanLibraryRootServerFn", async () => {
+  it("scan button calls scanLibraryRootServerFn with the root default scan mode", async () => {
     scanLibraryRootServerFnMock.mockResolvedValue({ importJobId: "job-123" });
     mockLoaderData = { roots: [makeRoot()] };
     const { Route } = await import("./libraries");
@@ -171,8 +171,50 @@ describe("LibrariesPage", () => {
 
     await waitFor(() => {
       expect(scanLibraryRootServerFnMock).toHaveBeenCalledWith({
-        data: { libraryRootId: "root-1" },
+        data: { libraryRootId: "root-1", scanMode: "INCREMENTAL" },
       });
+    });
+  });
+
+  it("full scan button triggers a one-off FULL scan", async () => {
+    scanLibraryRootServerFnMock.mockResolvedValue({ importJobId: "job-123" });
+    mockLoaderData = { roots: [makeRoot({ scanMode: "INCREMENTAL" })] };
+    const { Route } = await import("./libraries");
+    const LibrariesPage = (Route.options.component as React.ComponentType);
+    render(<LibrariesPage />);
+
+    fireEvent.click(screen.getByText("Full Scan"));
+
+    await waitFor(() => {
+      expect(scanLibraryRootServerFnMock).toHaveBeenCalledWith({
+        data: { libraryRootId: "root-1", scanMode: "FULL" },
+      });
+    });
+  });
+
+  it("full scan button shows a starting state while the request is in flight", async () => {
+    let resolveScan!: (value: { importJobId: string }) => void;
+    scanLibraryRootServerFnMock.mockReturnValue(
+      new Promise<{ importJobId: string }>((resolve) => {
+        resolveScan = resolve;
+      }),
+    );
+    mockLoaderData = { roots: [makeRoot({ scanMode: "INCREMENTAL" })] };
+    const { Route } = await import("./libraries");
+    const LibrariesPage = (Route.options.component as React.ComponentType);
+    render(<LibrariesPage />);
+
+    const fullScanButton = screen.getByRole("button", { name: "Full Scan" });
+    fireEvent.click(fullScanButton);
+
+    await waitFor(() => {
+      expect(fullScanButton.textContent).toContain("Starting...");
+    });
+
+    resolveScan({ importJobId: "job-123" });
+
+    await waitFor(() => {
+      expect(fullScanButton.textContent).toContain("Full Scan");
     });
   });
 
@@ -199,13 +241,7 @@ describe("LibrariesPage", () => {
     const LibrariesPage = (Route.options.component as React.ComponentType);
     render(<LibrariesPage />);
 
-    // The delete button has a Trash2 icon - find by aria or role
-    // There are two buttons: "Scan Now" and the trash button
-    const buttons = screen.getAllByRole("button");
-    // Trash button is second
-    const trashBtn = buttons.find((b) => !b.textContent.includes("Scan") && !b.textContent.includes("Add"));
-    if (!trashBtn) throw new Error("trash button not found");
-    fireEvent.click(trashBtn);
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Remove Library Root")).toBeTruthy();
@@ -220,10 +256,7 @@ describe("LibrariesPage", () => {
     render(<LibrariesPage />);
 
     // Open delete dialog
-    const buttons = screen.getAllByRole("button");
-    const trashBtn = buttons.find((b) => !b.textContent.includes("Scan") && !b.textContent.includes("Add"));
-    if (!trashBtn) throw new Error("trash button not found");
-    fireEvent.click(trashBtn);
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Remove Library Root")).toBeTruthy();
@@ -282,10 +315,7 @@ describe("LibrariesPage", () => {
     render(<LibrariesPage />);
 
     // Open delete dialog
-    const buttons = screen.getAllByRole("button");
-    const trashBtn = buttons.find((b) => !b.textContent.includes("Scan") && !b.textContent.includes("Add"));
-    if (!trashBtn) throw new Error("trash button not found");
-    fireEvent.click(trashBtn);
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Remove Library Root")).toBeTruthy();
@@ -307,10 +337,7 @@ describe("LibrariesPage", () => {
     render(<LibrariesPage />);
 
     // Open delete dialog
-    const buttons = screen.getAllByRole("button");
-    const trashBtn = buttons.find((b) => !b.textContent.includes("Scan") && !b.textContent.includes("Add"));
-    if (!trashBtn) throw new Error("trash button not found");
-    fireEvent.click(trashBtn);
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Remove Library Root")).toBeTruthy();
@@ -332,10 +359,7 @@ describe("LibrariesPage", () => {
     render(<LibrariesPage />);
 
     // Open delete dialog
-    const buttons = screen.getAllByRole("button");
-    const trashBtn = buttons.find((b) => !b.textContent.includes("Scan") && !b.textContent.includes("Add"));
-    if (!trashBtn) throw new Error("trash button not found");
-    fireEvent.click(trashBtn);
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Remove Library Root")).toBeTruthy();
@@ -353,6 +377,7 @@ describe("LibrariesPage", () => {
   it("loader calls getLibraryRootsServerFn with progress and issue count per root", async () => {
     const mockRoots = [{ id: "root-1", name: "Loader Root", path: "/books", kind: "EBOOKS", scanMode: "INCREMENTAL", isEnabled: true, lastScannedAt: null }];
     getLibraryRootsServerFnMock.mockResolvedValueOnce(mockRoots);
+    getMissingFileBehaviorServerFnMock.mockResolvedValueOnce("manual");
     getScanProgressServerFnMock.mockResolvedValueOnce(null);
     getLibraryIssueCountServerFnMock.mockResolvedValueOnce(0);
     const { Route } = await import("./libraries");
@@ -360,7 +385,10 @@ describe("LibrariesPage", () => {
     expect(getLibraryRootsServerFnMock).toHaveBeenCalled();
     expect(getScanProgressServerFnMock).toHaveBeenCalledWith({ data: { libraryRootId: "root-1" } });
     expect(getLibraryIssueCountServerFnMock).toHaveBeenCalledWith({ data: { libraryRootId: "root-1" } });
-    expect(result).toEqual({ roots: [{ ...mockRoots[0], scanProgress: null, issueCount: 0 }] });
+    expect(result).toEqual({
+      roots: [{ ...mockRoots[0], scanProgress: null, issueCount: 0 }],
+      missingFileBehavior: "manual",
+    });
   });
 
   it("cancel button in delete dialog closes the dialog", async () => {
@@ -370,10 +398,7 @@ describe("LibrariesPage", () => {
     render(<LibrariesPage />);
 
     // Open delete dialog
-    const buttons = screen.getAllByRole("button");
-    const trashBtn = buttons.find((b) => !b.textContent.includes("Scan") && !b.textContent.includes("Add"));
-    if (!trashBtn) throw new Error("trash button not found");
-    fireEvent.click(trashBtn);
+    fireEvent.click(screen.getByRole("button", { name: /remove/i }));
 
     await waitFor(() => {
       expect(screen.getByText("Remove Library Root")).toBeTruthy();

--- a/apps/web/src/routes/_authenticated/settings/libraries.tsx
+++ b/apps/web/src/routes/_authenticated/settings/libraries.tsx
@@ -187,11 +187,18 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [scanning, setScanning] = useState(false);
+  const [startingScanButton, setStartingScanButton] = useState<"default" | "full" | null>(null);
 
-  async function handleScan() {
+  async function handleScan(
+    scanMode: "FULL" | "INCREMENTAL",
+    startingButton: "default" | "full",
+  ) {
+    setStartingScanButton(startingButton);
     setScanning(true);
     try {
-      const result = await scanLibraryRootServerFn({ data: { libraryRootId: root.id } });
+      const result = await scanLibraryRootServerFn({
+        data: { libraryRootId: root.id, scanMode },
+      });
       toast.success(`Scan started for "${root.name}"`, {
         action: {
           label: "View Job",
@@ -210,6 +217,7 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
       );
     } finally {
       setScanning(false);
+      setStartingScanButton(null);
     }
   }
 
@@ -253,7 +261,7 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
               <Button
                 variant="outline"
                 size="sm"
-                onClick={() => { void handleScan(); }}
+                onClick={() => { void handleScan(root.scanMode, "default"); }}
                 disabled={scanning || root.scanProgress !== null}
               >
                 {root.scanProgress ? (
@@ -268,7 +276,7 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
                       Scanning...
                     </>
                   )
-                ) : scanning ? (
+                ) : scanning && startingScanButton === "default" ? (
                   <>
                     <Loader2 className="size-4 animate-spin" />
                     Starting...
@@ -283,6 +291,25 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
               <Button
                 variant="outline"
                 size="sm"
+                onClick={() => { void handleScan("FULL", "full"); }}
+                disabled={scanning || root.scanProgress !== null}
+              >
+                {scanning && startingScanButton === "full" ? (
+                  <>
+                    <Loader2 className="size-4 animate-spin" />
+                    Starting...
+                  </>
+                ) : (
+                  <>
+                    <Play className="size-4" />
+                    Full Scan
+                  </>
+                )}
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                aria-label={`Remove ${root.name}`}
                 onClick={() => { setDeleteOpen(true); }}
               >
                 <Trash2 className="size-4" />
@@ -297,7 +324,7 @@ function LibraryRootCard({ root }: { root: LibraryRootWithExtras }) {
               <Badge variant="outline">{root.kind}</Badge>
             </div>
             <div className="flex items-center gap-1.5">
-              <span className="text-muted-foreground">Scan Mode:</span>
+              <span className="text-muted-foreground">Default Scan:</span>
               <Badge variant="outline">{root.scanMode}</Badge>
             </div>
             <div className="flex items-center gap-1.5">

--- a/packages/ingest/src/services.runtime.test.ts
+++ b/packages/ingest/src/services.runtime.test.ts
@@ -1,37 +1,56 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+type RuntimeLibraryRoot = {
+  id: string;
+  lastScannedAt: Date | null;
+  path: string;
+  scanMode: "FULL" | "INCREMENTAL";
+};
+
 const enqueueLibraryJobMock = vi.fn(() => Promise.resolve("job-1"));
 const fileAssetFindManyMock = vi.fn(() => Promise.resolve([]));
+const fileAssetUpdateManyMock = vi.fn(() => Promise.resolve({ count: 0 }));
+const fileAssetUpsertMock = vi.fn(() => Promise.resolve({
+  absolutePath: "/tmp/runtime-root/book.epub",
+  availabilityStatus: "PRESENT",
+  fullHash: null,
+  id: "file-1",
+  mtime: new Date("2025-01-01T00:00:00.000Z"),
+  partialHash: null,
+  sizeBytes: 5n,
+}));
+const editionFindManyMock = vi.fn(() => Promise.resolve([]));
+const editionFileFindManyMock = vi.fn(() => Promise.resolve([]));
 const editionUpdateMock = vi.fn(() => Promise.reject(new Error("not used")));
+let runtimeLibraryRoot: RuntimeLibraryRoot = {
+  id: "root-1",
+  lastScannedAt: null,
+  path: "/tmp/runtime-root",
+  scanMode: "INCREMENTAL",
+};
+const libraryRootFindUniqueMock = vi.fn(() => Promise.resolve(runtimeLibraryRoot));
 const workUpdateMock = vi.fn(() => Promise.reject(new Error("not used")));
+const workFindManyMock = vi.fn(() => Promise.resolve([]));
 const seriesCreateMock = vi.fn(() => Promise.resolve({ id: "series-1", name: "test" }));
 
 vi.mock("@bookhouse/db", () => ({
   db: {
     libraryRoot: {
-      findUnique: vi.fn(() => Promise.resolve({
-        id: "root-1",
-        lastScannedAt: null,
-        path: "/tmp/runtime-root",
-      })),
-      update: vi.fn(({ data }: { data: { lastScannedAt: Date } }) => Promise.resolve({
-        id: "root-1",
-        lastScannedAt: data.lastScannedAt,
-        path: "/tmp/runtime-root",
-      })),
+      findUnique: libraryRootFindUniqueMock,
+      update: vi.fn(({ data }: { data: { lastScannedAt: Date; scanMode?: "FULL" | "INCREMENTAL" } }) => {
+        runtimeLibraryRoot = {
+          ...runtimeLibraryRoot,
+          lastScannedAt: data.lastScannedAt,
+          scanMode: data.scanMode ?? runtimeLibraryRoot.scanMode,
+        };
+        return Promise.resolve(runtimeLibraryRoot);
+      }),
     },
     fileAsset: {
       findByDirectory: vi.fn(() => Promise.resolve([])),
       findMany: fileAssetFindManyMock,
-      upsert: vi.fn(() => Promise.resolve({
-        absolutePath: "/tmp/runtime-root/book.epub",
-        availabilityStatus: "PRESENT",
-        fullHash: null,
-        id: "file-1",
-        mtime: new Date("2025-01-01T00:00:00.000Z"),
-        partialHash: null,
-        sizeBytes: 5n,
-      })),
+      updateMany: fileAssetUpdateManyMock,
+      upsert: fileAssetUpsertMock,
       findUnique: vi.fn(() => Promise.resolve(null)),
       update: vi.fn(() => Promise.reject(new Error("not used"))),
     },
@@ -41,6 +60,7 @@ vi.mock("@bookhouse/db", () => ({
     },
     edition: {
       create: vi.fn(() => Promise.reject(new Error("not used"))),
+      findMany: editionFindManyMock,
       findFirst: vi.fn(() => Promise.resolve(null)),
       findUnique: vi.fn(() => Promise.resolve(null)),
       update: editionUpdateMock,
@@ -51,11 +71,12 @@ vi.mock("@bookhouse/db", () => ({
     },
     editionFile: {
       create: vi.fn(() => Promise.reject(new Error("not used"))),
+      findMany: editionFileFindManyMock,
       findFirst: vi.fn(() => Promise.resolve(null)),
     },
     work: {
       create: vi.fn(() => Promise.reject(new Error("not used"))),
-      findMany: vi.fn(() => Promise.resolve([])),
+      findMany: workFindManyMock,
       findUnique: vi.fn(() => Promise.resolve(null)),
       update: workUpdateMock,
     },
@@ -89,6 +110,10 @@ vi.mock("@bookhouse/domain", () => ({
     PDF: "PDF",
     SIDECAR: "SIDECAR",
   },
+  ScanMode: {
+    FULL: "FULL",
+    INCREMENTAL: "INCREMENTAL",
+  },
 }));
 
 vi.mock("@bookhouse/shared", async () => {
@@ -101,7 +126,35 @@ vi.mock("@bookhouse/shared", async () => {
 });
 
 beforeEach(() => {
+  runtimeLibraryRoot = {
+    id: "root-1",
+    lastScannedAt: null,
+    path: "/tmp/runtime-root",
+    scanMode: "INCREMENTAL",
+  };
   enqueueLibraryJobMock.mockClear();
+  editionFileFindManyMock.mockReset();
+  editionFileFindManyMock.mockResolvedValue([]);
+  editionFindManyMock.mockReset();
+  editionFindManyMock.mockResolvedValue([]);
+  fileAssetFindManyMock.mockReset();
+  fileAssetFindManyMock.mockResolvedValue([]);
+  fileAssetUpdateManyMock.mockReset();
+  fileAssetUpdateManyMock.mockResolvedValue({ count: 0 });
+  fileAssetUpsertMock.mockReset();
+  fileAssetUpsertMock.mockResolvedValue({
+    absolutePath: "/tmp/runtime-root/book.epub",
+    availabilityStatus: "PRESENT",
+    fullHash: null,
+    id: "file-1",
+    mtime: new Date("2025-01-01T00:00:00.000Z"),
+    partialHash: null,
+    sizeBytes: 5n,
+  });
+  libraryRootFindUniqueMock.mockReset();
+  libraryRootFindUniqueMock.mockImplementation(() => Promise.resolve(runtimeLibraryRoot));
+  workFindManyMock.mockReset();
+  workFindManyMock.mockResolvedValue([]);
 });
 
 describe("ingest runtime defaults", () => {
@@ -194,7 +247,7 @@ describe("ingest runtime defaults", () => {
     expect(seriesCreateMock).toHaveBeenCalledTimes(1);
   });
 
-  it("uses the default queue enqueuer when no override is provided", async () => {
+  it("uses FULL once for a new root, then requires an explicit override for later full scans", async () => {
     vi.resetModules();
     const { createIngestServices } = await import("./services");
     const services = createIngestServices({
@@ -217,13 +270,177 @@ describe("ingest runtime defaults", () => {
         } as never)),
     });
 
+    runtimeLibraryRoot = {
+      id: "root-1",
+      lastScannedAt: null,
+      path: "/tmp/runtime-root",
+      scanMode: "FULL",
+    };
+    fileAssetFindManyMock
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([{
+        absolutePath: "/tmp/runtime-root/book.epub",
+        availabilityStatus: "PRESENT",
+        basename: "book.epub",
+        ctime: new Date("2025-01-01T00:00:00.000Z"),
+        extension: "epub",
+        fullHash: "full",
+        id: "file-1",
+        lastSeenAt: new Date("2025-01-01T00:00:00.000Z"),
+        libraryRootId: "root-1",
+        mediaKind: "EPUB",
+        metadata: null,
+        mtime: new Date("2025-01-01T00:00:00.000Z"),
+        partialHash: "partial",
+        relativePath: "book.epub",
+        sizeBytes: 5n,
+      }] as never);
+    fileAssetUpsertMock.mockResolvedValue({
+      absolutePath: "/tmp/runtime-root/book.epub",
+      availabilityStatus: "PRESENT",
+      fullHash: "full",
+      id: "file-1",
+      mtime: new Date("2025-01-01T00:00:00.000Z"),
+      partialHash: "partial",
+      sizeBytes: 5n,
+    } as never);
+
     const result = await services.scanLibraryRoot({ libraryRootId: "root-1" });
     const secondResult = await services.scanLibraryRoot({ libraryRootId: "root-1" });
+    const thirdResult = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      scanMode: "FULL",
+    });
 
     expect(result.enqueuedHashJobs).toEqual(["file-1"]);
-    expect(secondResult.enqueuedHashJobs).toEqual(["file-1"]);
+    expect(secondResult.enqueuedHashJobs).toEqual([]);
+    expect(thirdResult.enqueuedHashJobs).toEqual(["file-1"]);
     expect(enqueueLibraryJobMock).toHaveBeenCalledWith("hash-file-asset", {
       fileAssetId: "file-1",
+    });
+  });
+
+  it("uses the default adapter bulk update for unchanged incremental files", async () => {
+    vi.resetModules();
+    const { createIngestServices } = await import("./services");
+    const services = createIngestServices({
+      listDirectory: (() =>
+        Promise.resolve([
+          {
+            isDirectory: () => false,
+            isFile: () => true,
+            isSymbolicLink: () => false,
+            name: "book.epub",
+          },
+        ] as never)),
+      readStats: (() =>
+        Promise.resolve({
+          ctime: new Date("2025-01-01T00:00:00.000Z"),
+          isFile: () => true,
+          isSymbolicLink: () => false,
+          mtime: new Date("2025-01-01T00:00:00.000Z"),
+          size: 5,
+        } as never)),
+    });
+
+    const unchangedAsset = {
+      absolutePath: "/tmp/runtime-root/book.epub",
+      availabilityStatus: "PRESENT",
+      basename: "book.epub",
+      ctime: new Date("2025-01-01T00:00:00.000Z"),
+      extension: "epub",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: new Date("2024-12-31T00:00:00.000Z"),
+      libraryRootId: "root-1",
+      mediaKind: "EPUB",
+      metadata: null,
+      mtime: new Date("2025-01-01T00:00:00.000Z"),
+      partialHash: "partial",
+      relativePath: "book.epub",
+      sizeBytes: 5n,
+    };
+
+    runtimeLibraryRoot = {
+      id: "root-1",
+      lastScannedAt: null,
+      path: "/tmp/runtime-root",
+      scanMode: "INCREMENTAL",
+    };
+    fileAssetFindManyMock.mockResolvedValue([unchangedAsset] as never);
+
+    const result = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      now: new Date("2025-01-01T00:10:00.000Z"),
+    });
+
+    expect(result.enqueuedHashJobs).toEqual([]);
+    expect(fileAssetUpsertMock).not.toHaveBeenCalled();
+    expect(fileAssetUpdateManyMock).toHaveBeenCalledWith({
+      where: { id: { in: ["file-1"] } },
+      data: { lastSeenAt: new Date("2025-01-01T00:10:00.000Z") },
+    });
+  });
+
+  it("uses default adapter preload queries for unchanged recovery paths", async () => {
+    vi.resetModules();
+    const { createIngestServices } = await import("./services");
+    const services = createIngestServices({
+      listDirectory: (() =>
+        Promise.resolve([
+          {
+            isDirectory: () => false,
+            isFile: () => true,
+            isSymbolicLink: () => false,
+            name: "book.epub",
+          },
+        ] as never)),
+      readStats: (() =>
+        Promise.resolve({
+          ctime: new Date("2025-01-01T00:00:00.000Z"),
+          isFile: () => true,
+          isSymbolicLink: () => false,
+          mtime: new Date("2025-01-01T00:00:00.000Z"),
+          size: 5,
+        } as never)),
+    });
+
+    fileAssetFindManyMock.mockResolvedValue([{
+      absolutePath: "/tmp/runtime-root/book.epub",
+      availabilityStatus: "PRESENT",
+      basename: "book.epub",
+      ctime: new Date("2025-01-01T00:00:00.000Z"),
+      extension: "epub",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: new Date("2024-12-31T00:00:00.000Z"),
+      libraryRootId: "root-1",
+      mediaKind: "EPUB",
+      metadata: null,
+      mtime: new Date("2025-01-01T00:00:00.000Z"),
+      partialHash: "partial",
+      relativePath: "book.epub",
+      sizeBytes: 5n,
+    }] as never);
+    editionFileFindManyMock.mockResolvedValue([{ editionId: "edition-1", fileAssetId: "file-1", id: "ef-1", role: "PRIMARY" }] as never);
+    editionFindManyMock.mockResolvedValue([{ formatFamily: "EBOOK", id: "edition-1", workId: "work-1", asin: null, isbn10: null, isbn13: null, publishedAt: null, publisher: null }] as never);
+    workFindManyMock.mockResolvedValue([{ coverPath: null, description: null, enrichmentStatus: "STUB", id: "work-1", language: null, seriesId: null, seriesPosition: null, sortTitle: null, titleCanonical: "book", titleDisplay: "Book" }] as never);
+
+    const result = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      now: new Date("2025-01-01T00:10:00.000Z"),
+    });
+
+    expect(result.enqueuedHashJobs).toEqual([]);
+    expect(result.enqueuedRecoveryJobs).toEqual(["file-1"]);
+    expect(editionFileFindManyMock).toHaveBeenCalledWith({
+      where: { fileAssetId: { in: ["file-1"] } },
+    });
+    expect(workFindManyMock).toHaveBeenCalledWith({
+      where: { id: { in: ["work-1"] } },
+    });
+    expect(editionFindManyMock).toHaveBeenCalledWith({
+      where: { id: { in: ["edition-1"] } },
     });
   });
 });

--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -76,6 +76,7 @@ interface TestState {
   fileAssetsById: Map<string, TestFileAsset>;
   lastScannedAt: Date | null;
   rootPath: string;
+  scanMode: "FULL" | "INCREMENTAL";
   works: Map<string, TestWork>;
 }
 
@@ -123,7 +124,7 @@ interface TestEditionContributor {
   role: ContributorRole;
 }
 
-function createEmptyState(rootPath = "/tmp/root"): TestState {
+function createEmptyState(rootPath = "/tmp/root", scanMode: "FULL" | "INCREMENTAL" = "INCREMENTAL"): TestState {
   return {
     matchSuggestions: new Map(),
     contributors: new Map(),
@@ -136,6 +137,7 @@ function createEmptyState(rootPath = "/tmp/root"): TestState {
     fileAssetsById: new Map(),
     lastScannedAt: null,
     rootPath,
+    scanMode,
     works: new Map(),
   };
 }
@@ -170,6 +172,7 @@ function createTestDb(state: TestState): IngestDb {
           id: "root-1",
           lastScannedAt: state.lastScannedAt,
           path: state.rootPath,
+          scanMode: state.scanMode,
         };
       },
       async update({ data, where }) {
@@ -179,10 +182,14 @@ function createTestDb(state: TestState): IngestDb {
         }
 
         state.lastScannedAt = data.lastScannedAt;
+        if (data.scanMode !== undefined) {
+          state.scanMode = data.scanMode;
+        }
         return {
           id: "root-1",
           lastScannedAt: state.lastScannedAt,
           path: state.rootPath,
+          scanMode: state.scanMode,
         };
       },
     },
@@ -222,6 +229,21 @@ function createTestDb(state: TestState): IngestDb {
         state.fileAssets.set(updated.absolutePath, updated);
         state.fileAssetsById.set(updated.id, updated);
         return updated;
+      },
+      async updateMany({ data, where }) {
+        await Promise.resolve();
+        let count = 0;
+        for (const id of where.id.in) {
+          const existing = state.fileAssetsById.get(id);
+          if (existing === undefined) {
+            continue;
+          }
+          const updated = { ...existing, ...data };
+          state.fileAssets.set(updated.absolutePath, updated);
+          state.fileAssetsById.set(updated.id, updated);
+          count += 1;
+        }
+        return { count };
       },
       async upsert({ create, update, where }) {
         await Promise.resolve();
@@ -271,6 +293,12 @@ function createTestDb(state: TestState): IngestDb {
       async findUnique({ where }) {
         await Promise.resolve();
         return state.works.get(where.id) ?? null;
+      },
+      async findManyByIds({ ids }) {
+        await Promise.resolve();
+        return ids
+          .map((id) => state.works.get(id))
+          .filter((work): work is TestWork => work !== undefined);
       },
       async update({ data, where }) {
         await Promise.resolve();
@@ -338,6 +366,12 @@ function createTestDb(state: TestState): IngestDb {
         await Promise.resolve();
         return state.editions.get(where.id) ?? null;
       },
+      async findManyByIds({ ids }) {
+        await Promise.resolve();
+        return ids
+          .map((id) => state.editions.get(id))
+          .filter((edition): edition is TestEdition => edition !== undefined);
+      },
       async update({ data, where }) {
         await Promise.resolve();
         const existing = state.editions.get(where.id);
@@ -386,7 +420,10 @@ function createTestDb(state: TestState): IngestDb {
         await Promise.resolve();
         return [...state.editionFiles.values()].filter(
           (editionFile) =>
-            (where.fileAssetId === undefined || editionFile.fileAssetId === where.fileAssetId) &&
+            (where.fileAssetId === undefined
+              || (typeof where.fileAssetId === "object"
+                ? where.fileAssetId.in.includes(editionFile.fileAssetId)
+                : editionFile.fileAssetId === where.fileAssetId)) &&
             (where.editionId === undefined || editionFile.editionId === where.editionId),
         );
       },
@@ -893,6 +930,254 @@ describe("ingest services", () => {
     expect(state.fileAssets.get(path.join(directory, "author", "cover.jpg"))?.availabilityStatus).toBe(
       AvailabilityStatus.MISSING,
     );
+  });
+
+  it("uses FULL for the first scan, then defaults later scans back to incremental", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-scan-full-"));
+    tempDirectories.push(directory);
+
+    await writeFile(path.join(directory, "book.epub"), "first");
+
+    const state = createEmptyState(directory, "FULL");
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const firstScan = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+    expect(firstScan.enqueuedHashJobs).toEqual(["file-1"]);
+    expect(state.scanMode).toBe("INCREMENTAL");
+
+    const fileAsset = state.fileAssetsById.get("file-1");
+    if (fileAsset === undefined) {
+      throw new Error("Expected FULL scan to create file asset");
+    }
+    fileAsset.partialHash = "partial";
+    fileAsset.fullHash = "full";
+
+    const secondScan = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      now: new Date("2025-01-01T00:10:00.000Z"),
+    });
+
+    expect(secondScan.enqueuedHashJobs).toEqual([]);
+
+    const thirdScan = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      scanMode: "FULL",
+      now: new Date("2025-01-01T00:20:00.000Z"),
+    });
+
+    expect(thirdScan.enqueuedHashJobs).toEqual(["file-1"]);
+    expect(state.scanMode).toBe("INCREMENTAL");
+  });
+
+  it("skips per-file upserts for unchanged hashed files in incremental mode and bulk-refreshes lastSeenAt", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-scan-incremental-"));
+    tempDirectories.push(directory);
+
+    const absolutePath = path.join(directory, "book.epub");
+    await writeFile(absolutePath, "first");
+    const timestamp = new Date("2025-01-01T00:00:00.000Z");
+    await utimes(absolutePath, timestamp, timestamp);
+
+    const state = createEmptyState(directory, "INCREMENTAL");
+    const existingFileAsset: TestFileAsset = {
+      absolutePath,
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.epub",
+      ctime: timestamp,
+      extension: "epub",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: new Date("2024-12-31T00:00:00.000Z"),
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.EPUB,
+      metadata: null,
+      mtime: timestamp,
+      partialHash: "partial",
+      relativePath: "book.epub",
+      sizeBytes: BigInt("first".length),
+    };
+    state.fileAssets.set(existingFileAsset.absolutePath, existingFileAsset);
+    state.fileAssetsById.set(existingFileAsset.id, existingFileAsset);
+
+    const db = createTestDb(state);
+    const upsertSpy = vi.spyOn(db.fileAsset, "upsert");
+    const updateManySpy = vi.spyOn(db.fileAsset, "updateMany");
+    const services = createIngestServices({
+      db,
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+    const scanAt = new Date("2025-01-01T00:10:00.000Z");
+
+    const result = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      now: scanAt,
+    });
+
+    expect(result.scannedFileAssetIds).toEqual(["file-1"]);
+    expect(result.enqueuedHashJobs).toEqual([]);
+    expect(upsertSpy).not.toHaveBeenCalled();
+    expect(updateManySpy).toHaveBeenCalledWith({
+      where: { id: { in: ["file-1"] } },
+      data: { lastSeenAt: scanAt },
+    });
+    expect(state.fileAssetsById.get("file-1")?.lastSeenAt).toEqual(scanAt);
+  });
+
+  it("marks missing files with a bulk update", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-scan-missing-"));
+    tempDirectories.push(directory);
+
+    const state = createEmptyState(directory, "INCREMENTAL");
+    const missingFileAsset: TestFileAsset = {
+      absolutePath: path.join(directory, "missing.epub"),
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "missing.epub",
+      ctime: new Date("2025-01-01T00:00:00.000Z"),
+      extension: "epub",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: new Date("2024-12-31T00:00:00.000Z"),
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.EPUB,
+      metadata: null,
+      mtime: new Date("2025-01-01T00:00:00.000Z"),
+      partialHash: "partial",
+      relativePath: "missing.epub",
+      sizeBytes: 5n,
+    };
+    state.fileAssets.set(missingFileAsset.absolutePath, missingFileAsset);
+    state.fileAssetsById.set(missingFileAsset.id, missingFileAsset);
+
+    const db = createTestDb(state);
+    const updateSpy = vi.spyOn(db.fileAsset, "update");
+    const updateManySpy = vi.spyOn(db.fileAsset, "updateMany");
+    const services = createIngestServices({
+      db,
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      now: new Date("2025-01-01T00:10:00.000Z"),
+    });
+
+    expect(result.missingFileAssetIds).toEqual(["file-1"]);
+    expect(updateSpy).not.toHaveBeenCalled();
+    expect(updateManySpy).toHaveBeenCalledWith({
+      where: { id: { in: ["file-1"] } },
+      data: { availabilityStatus: AvailabilityStatus.MISSING },
+    });
+    expect(state.fileAssetsById.get("file-1")?.availabilityStatus).toBe(AvailabilityStatus.MISSING);
+  });
+
+  it("skips recovery for unchanged hashed files without a recoverable format family", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-scan-cover-"));
+    tempDirectories.push(directory);
+
+    const absolutePath = path.join(directory, "cover.jpg");
+    await writeFile(absolutePath, "cover");
+    const timestamp = new Date("2025-01-01T00:00:00.000Z");
+    await utimes(absolutePath, timestamp, timestamp);
+
+    const state = createEmptyState(directory, "INCREMENTAL");
+    const existingFileAsset: TestFileAsset = {
+      absolutePath,
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "cover.jpg",
+      ctime: timestamp,
+      extension: "jpg",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: new Date("2024-12-31T00:00:00.000Z"),
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.COVER,
+      metadata: null,
+      mtime: timestamp,
+      partialHash: "partial",
+      relativePath: "cover.jpg",
+      sizeBytes: BigInt("cover".length),
+    };
+    state.fileAssets.set(existingFileAsset.absolutePath, existingFileAsset);
+    state.fileAssetsById.set(existingFileAsset.id, existingFileAsset);
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      now: new Date("2025-01-01T00:10:00.000Z"),
+    });
+
+    expect(result.enqueuedHashJobs).toEqual([]);
+    expect(result.enqueuedRecoveryJobs).toEqual([]);
+  });
+
+  it("skips unchanged recovery when an edition link exists but the linked work is missing", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-scan-missing-work-"));
+    tempDirectories.push(directory);
+
+    const absolutePath = path.join(directory, "book.epub");
+    await writeFile(absolutePath, "book");
+    const timestamp = new Date("2025-01-01T00:00:00.000Z");
+    await utimes(absolutePath, timestamp, timestamp);
+
+    const state = createEmptyState(directory, "INCREMENTAL");
+    const existingFileAsset: TestFileAsset = {
+      absolutePath,
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.epub",
+      ctime: timestamp,
+      extension: "epub",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: new Date("2024-12-31T00:00:00.000Z"),
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.EPUB,
+      metadata: null,
+      mtime: timestamp,
+      partialHash: "partial",
+      relativePath: "book.epub",
+      sizeBytes: BigInt("book".length),
+    };
+    state.fileAssets.set(existingFileAsset.absolutePath, existingFileAsset);
+    state.fileAssetsById.set(existingFileAsset.id, existingFileAsset);
+    state.editions.set("edition-1", {
+      asin: null,
+      formatFamily: FormatFamily.EBOOK,
+      id: "edition-1",
+      isbn10: null,
+      isbn13: null,
+      publishedAt: null,
+      publisher: null,
+      workId: "missing-work",
+    });
+    state.editionFiles.set(getEditionFileKey("edition-1", "file-1"), {
+      editionId: "edition-1",
+      fileAssetId: "file-1",
+      id: "edition-file-1",
+      role: EditionFileRole.PRIMARY,
+    });
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+      now: new Date("2025-01-01T00:10:00.000Z"),
+    });
+
+    expect(result.enqueuedHashJobs).toEqual([]);
+    expect(result.enqueuedRecoveryJobs).toEqual([]);
   });
 
   it("skips entries that disappear during scanning", async () => {

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -12,6 +12,7 @@ import {
   type FileAsset,
   MediaKind,
   type LibraryRoot,
+  ScanMode,
   type Work,
 } from "@bookhouse/domain";
 import { db, type EditionContributor } from "@bookhouse/db";
@@ -71,7 +72,7 @@ type FileAssetRecord = Pick<
   | "sizeBytes"
 >;
 
-type LibraryRootRecord = Pick<LibraryRoot, "id" | "lastScannedAt" | "path">;
+type LibraryRootRecord = Pick<LibraryRoot, "id" | "lastScannedAt" | "path" | "scanMode">;
 type WorkRecord = Pick<Work, "coverPath" | "description" | "enrichmentStatus" | "id" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">;
 type EditionRecord = Pick<
   Edition,
@@ -189,6 +190,11 @@ interface FileAssetUpdateArgs {
   data: Partial<FileAssetUpdateInput>;
 }
 
+interface FileAssetUpdateManyArgs {
+  where: { id: { in: string[] } };
+  data: Partial<FileAssetUpdateInput>;
+}
+
 interface WorkFindManyArgs {
   where: { titleCanonical: string } | { NOT: { id: string } };
   include: {
@@ -238,7 +244,7 @@ interface EditionFileCreateArgs {
 }
 
 interface EditionFileFindManyArgs {
-  where: { fileAssetId?: string; editionId?: string };
+  where: { fileAssetId?: string | { in: string[] }; editionId?: string };
 }
 
 interface EditionFileUpdateArgs {
@@ -264,7 +270,7 @@ interface EditionContributorCreateArgs {
 
 interface LibraryRootUpdateArgs {
   where: { id: string };
-  data: { lastScannedAt: Date };
+  data: { lastScannedAt: Date; scanMode?: ScanMode };
 }
 
 export interface IngestDb {
@@ -277,12 +283,14 @@ export interface IngestDb {
     findMany(args: FileAssetFindManyArgs): Promise<FileAssetRecord[]>;
     findUnique(args: { where: { id: string } }): Promise<FileAssetRecord | null>;
     update(args: FileAssetUpdateArgs): Promise<FileAssetRecord>;
+    updateMany(args: FileAssetUpdateManyArgs): Promise<{ count: number }>;
     upsert(args: FileAssetUpsertArgs): Promise<FileAssetRecord>;
   };
   work: {
     create(args: WorkCreateArgs): Promise<WorkRecord>;
     delete(args: { where: { id: string } }): Promise<void>;
     findMany(args: WorkFindManyArgs): Promise<WorkMatchRecord[]>;
+    findManyByIds(args: { ids: string[] }): Promise<WorkRecord[]>;
     findUnique(args: { where: { id: string } }): Promise<WorkRecord | null>;
     update(args: { where: { id: string }; data: Partial<Pick<Work, "coverPath" | "description" | "enrichmentStatus" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">> }): Promise<WorkRecord>;
   };
@@ -290,6 +298,7 @@ export interface IngestDb {
     create(args: EditionCreateArgs): Promise<EditionRecord>;
     findFirst(args: EditionFindFirstArgs): Promise<EditionRecord | null>;
     findMany(args: EditionFindManyArgs): Promise<EditionRecord[]>;
+    findManyByIds(args: { ids: string[] }): Promise<EditionRecord[]>;
     findUnique(args: { where: { id: string } }): Promise<EditionRecord | null>;
     update(args: { where: { id: string }; data: Partial<Pick<Edition, "asin" | "isbn10" | "isbn13" | "publisher" | "publishedAt" | "workId">> }): Promise<EditionRecord>;
     updateMany(args: { where: { workId: string }; data: { workId: string } }): Promise<{ count: number }>;
@@ -351,6 +360,7 @@ export interface ScanProgressData {
 
 export interface ScanLibraryRootInput {
   libraryRootId: string;
+  scanMode?: ScanMode;
   now?: Date;
   reportProgress?: (data: ScanProgressData) => Promise<void>;
 }
@@ -430,6 +440,7 @@ const OPF_PARSER_VERSION = 1;
 const AUDIOBOOK_JSON_PARSER_VERSION = 1;
 const AUDIO_ID3_PARSER_VERSION = 1;
 export const SCAN_PROGRESS_INTERVAL = 50;
+const SCAN_STAT_CONCURRENCY = 8;
 
 
 function isFileChanged(existingFileAsset: FileAssetRecord | undefined, nextFileState: { mtime: Date; sizeBytes: bigint }): boolean {
@@ -446,6 +457,83 @@ function isFileChanged(existingFileAsset: FileAssetRecord | undefined, nextFileS
   }
 
   return existingFileAsset.partialHash === null || existingFileAsset.fullHash === null;
+}
+
+function didFileStatsChange(existingFileAsset: FileAssetRecord | undefined, nextFileState: { mtime: Date; sizeBytes: bigint }): boolean {
+  if (existingFileAsset === undefined) {
+    return true;
+  }
+
+  if (existingFileAsset.sizeBytes !== nextFileState.sizeBytes) {
+    return true;
+  }
+
+  return existingFileAsset.mtime?.getTime() !== nextFileState.mtime.getTime();
+}
+
+interface ScanPathStatsResult {
+  absolutePath: string;
+  fileStats?: Stats;
+  statFailed: boolean;
+}
+
+async function collectScanPathStats(
+  discoveredPaths: string[],
+  readStats: ReadStatsFn,
+): Promise<ScanPathStatsResult[]> {
+  const results = new Array<ScanPathStatsResult>(discoveredPaths.length);
+  let nextIndex = 0;
+
+  async function worker(): Promise<void> {
+    while (nextIndex < discoveredPaths.length) {
+      const currentIndex = nextIndex;
+      nextIndex += 1;
+      const absolutePath = discoveredPaths[currentIndex] as string;
+
+      try {
+        results[currentIndex] = {
+          absolutePath,
+          fileStats: await readStats(absolutePath),
+          statFailed: false,
+        };
+      } catch {
+        results[currentIndex] = {
+          absolutePath,
+          statFailed: true,
+        };
+      }
+    }
+  }
+
+  const workerCount = Math.min(SCAN_STAT_CONCURRENCY, discoveredPaths.length);
+  await Promise.all(Array.from({ length: workerCount }, () => worker()));
+  return results;
+}
+
+function buildFileAssetsByDirectory(fileAssets: FileAssetRecord[]): Map<string, FileAssetRecord[]> {
+  const fileAssetsByDirectory = new Map<string, FileAssetRecord[]>();
+
+  for (const fileAsset of fileAssets) {
+    const directoryPath = path.dirname(fileAsset.absolutePath);
+    const directoryAssets = fileAssetsByDirectory.get(directoryPath) ?? [];
+    directoryAssets.push(fileAsset);
+    fileAssetsByDirectory.set(directoryPath, directoryAssets);
+  }
+
+  return fileAssetsByDirectory;
+}
+
+function setDirectoryFileAsset(
+  fileAssetsByDirectory: Map<string, FileAssetRecord[]>,
+  fileAsset: FileAssetRecord,
+): void {
+  const directoryPath = path.dirname(fileAsset.absolutePath);
+  const directoryAssets = fileAssetsByDirectory.get(directoryPath) ?? [];
+  const nextDirectoryAssets = directoryAssets.filter(
+    (directoryAsset) => directoryAsset.id !== fileAsset.id && directoryAsset.absolutePath !== fileAsset.absolutePath,
+  );
+  nextDirectoryAssets.push(fileAsset);
+  fileAssetsByDirectory.set(directoryPath, nextDirectoryAssets);
 }
 
 function getErrorCode(error: unknown): string | undefined {
@@ -713,15 +801,28 @@ function createDefaultIngestDb(): IngestDb {
           },
         }) as unknown as Promise<FileAssetRecord[]>;
       },
+      async updateMany(args: FileAssetUpdateManyArgs) {
+        return prisma.fileAsset.updateMany(args as never) as unknown as Promise<{ count: number }>;
+      },
     },
     work: {
-      ...(prisma.work as unknown as Omit<IngestDb["work"], "update">),
+      ...(prisma.work as unknown as Omit<IngestDb["work"], "findManyByIds" | "update">),
+      async findManyByIds(args: { ids: string[] }) {
+        return prisma.work.findMany({
+          where: { id: { in: args.ids } },
+        }) as unknown as Promise<WorkRecord[]>;
+      },
       async update(args: { where: { id: string }; data: Partial<Pick<Work, "coverPath" | "description" | "enrichmentStatus" | "language" | "seriesId" | "seriesPosition" | "sortTitle" | "titleCanonical" | "titleDisplay">> }) {
         return prisma.work.update(args) as unknown as Promise<WorkRecord>;
       },
     },
     edition: {
-      ...(prisma.edition as unknown as Omit<IngestDb["edition"], "update">),
+      ...(prisma.edition as unknown as Omit<IngestDb["edition"], "findManyByIds" | "update">),
+      async findManyByIds(args: { ids: string[] }) {
+        return prisma.edition.findMany({
+          where: { id: { in: args.ids } },
+        }) as unknown as Promise<EditionRecord[]>;
+      },
       async update(args: { where: { id: string }; data: Partial<Pick<Edition, "asin" | "isbn10" | "isbn13" | "publisher" | "publishedAt" | "workId">> }) {
         return prisma.edition.update(args) as unknown as Promise<EditionRecord>;
       },
@@ -740,6 +841,137 @@ function createDefaultIngestDb(): IngestDb {
     duplicateCandidate: prisma.duplicateCandidate as unknown as IngestDb["duplicateCandidate"],
     matchSuggestion: prisma.matchSuggestion as unknown as IngestDb["matchSuggestion"],
   };
+}
+
+interface ScanRecoveryContext {
+  editionById: Map<string, EditionRecord>;
+  editionFileByFileAssetId: Map<string, EditionFileRecord>;
+  fileAssetsByDirectory: Map<string, FileAssetRecord[]>;
+  workById: Map<string, WorkRecord>;
+}
+
+function addRecoveryJobIdOnce(enqueuedRecoveryJobs: string[], fileAssetId: string): void {
+  if (!enqueuedRecoveryJobs.includes(fileAssetId)) {
+    enqueuedRecoveryJobs.push(fileAssetId);
+  }
+}
+
+async function recoverUnchangedFile(
+  upsertedFileAsset: FileAssetRecord,
+  recoveryContext: ScanRecoveryContext,
+  logger: IngestLogger,
+  enqueueJob: <TName extends LibraryJobName>(jobName: TName, payload: LibraryJobPayload<TName>) => Promise<unknown>,
+  enqueuedRecoveryJobs: string[],
+): Promise<void> {
+  const recoveryFormatFamily = deriveFormatFamily(upsertedFileAsset.mediaKind);
+  if (recoveryFormatFamily !== null && upsertedFileAsset.fullHash !== null) {
+    const editionFileLink = recoveryContext.editionFileByFileAssetId.get(upsertedFileAsset.id) ?? null;
+
+    if (editionFileLink !== null) {
+      const edition = recoveryContext.editionById.get(editionFileLink.editionId) ?? null;
+      if (edition) {
+        const work = recoveryContext.workById.get(edition.workId) ?? null;
+        if (work && work.enrichmentStatus === "STUB") {
+          if (
+            upsertedFileAsset.mediaKind === MediaKind.PDF ||
+            upsertedFileAsset.mediaKind === MediaKind.CBZ
+          ) {
+            const directory = path.dirname(upsertedFileAsset.absolutePath);
+            const sidecarSiblings = (recoveryContext.fileAssetsByDirectory.get(directory) as FileAssetRecord[]).filter(
+              (fileAsset) => fileAsset.mediaKind === MediaKind.SIDECAR,
+            );
+            const opfSibling = sidecarSiblings.find(
+              (fileAsset) => getFileExtension(fileAsset.absolutePath) === "opf",
+            );
+            if (opfSibling && opfSibling.fullHash !== null) {
+              logger.info({ fileAssetId: upsertedFileAsset.id, opfFileAssetId: opfSibling.id, workId: work.id, reason: "STUB work with OPF sibling" }, "Recovery: re-enqueueing OPF PARSE");
+              await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
+                fileAssetId: opfSibling.id,
+              });
+              enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+            } else {
+              logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "work stuck at STUB (no OPF)" }, "Recovery: re-enqueueing MATCH");
+              await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
+                fileAssetId: upsertedFileAsset.id,
+              });
+              enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+            }
+          } else {
+            logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "work stuck at STUB" }, "Recovery: re-enqueueing MATCH");
+            await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
+              fileAssetId: upsertedFileAsset.id,
+            });
+            enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+          }
+        }
+        if (work && work.coverPath === null) {
+          logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "missing cover" }, "Recovery: re-enqueueing PROCESS_COVER");
+          await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
+            workId: work.id,
+            fileAssetId: upsertedFileAsset.id,
+          });
+          addRecoveryJobIdOnce(enqueuedRecoveryJobs, upsertedFileAsset.id);
+        }
+      }
+
+      const editionLinkedMeta = parseStoredMetadata(upsertedFileAsset.metadata);
+      if (
+        upsertedFileAsset.mediaKind === MediaKind.AUDIO &&
+        editionLinkedMeta?.status === "unparseable"
+      ) {
+        logger.info({ fileAssetId: upsertedFileAsset.id, reason: "edition-linked audio with unparseable metadata" }, "Recovery: re-enqueueing PARSE");
+        await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
+          fileAssetId: upsertedFileAsset.id,
+        });
+        addRecoveryJobIdOnce(enqueuedRecoveryJobs, upsertedFileAsset.id);
+      }
+
+      if (
+        upsertedFileAsset.mediaKind === MediaKind.AUDIO &&
+        edition &&
+        edition.formatFamily === FormatFamily.AUDIOBOOK
+      ) {
+        await enqueueJob(LIBRARY_JOB_NAMES.MATCH_SUGGESTIONS, {
+          fileAssetId: upsertedFileAsset.id,
+        });
+        addRecoveryJobIdOnce(enqueuedRecoveryJobs, upsertedFileAsset.id);
+      }
+    } else {
+      const parsedMeta = parseStoredMetadata(upsertedFileAsset.metadata);
+
+      if (!parsedMeta || parsedMeta.status !== "parsed") {
+        if (
+          upsertedFileAsset.mediaKind === MediaKind.EPUB ||
+          upsertedFileAsset.mediaKind === MediaKind.AUDIO
+        ) {
+          logger.info({ fileAssetId: upsertedFileAsset.id, reason: "missing or failed metadata" }, "Recovery: re-enqueueing PARSE");
+          await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
+            fileAssetId: upsertedFileAsset.id,
+          });
+          enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+        }
+      } else {
+        logger.info({ fileAssetId: upsertedFileAsset.id, reason: "parsed but unmatched" }, "Recovery: re-enqueueing MATCH");
+        await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
+          fileAssetId: upsertedFileAsset.id,
+        });
+        enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+      }
+    }
+  }
+
+  const isOpfSidecar = upsertedFileAsset.mediaKind === MediaKind.SIDECAR
+    && getFileExtension(upsertedFileAsset.absolutePath) === "opf";
+  if (isOpfSidecar && upsertedFileAsset.fullHash !== null) {
+    const opfMeta = parseStoredMetadata(upsertedFileAsset.metadata);
+    if (!opfMeta || opfMeta.status !== "parsed") {
+      logger.info({ fileAssetId: upsertedFileAsset.id, reason: "OPF hashed but not parsed" }, "Recovery: re-enqueueing OPF PARSE");
+      await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
+        fileAssetId: upsertedFileAsset.id,
+      });
+      enqueuedRecoveryJobs.push(upsertedFileAsset.id);
+    }
+  }
 }
 
 const SIMILARITY_THRESHOLD = 0.85;
@@ -1166,6 +1398,7 @@ export function createIngestServices(
     const now = input.now ?? new Date();
     const reportProgress = input.reportProgress;
     const libraryRoot = await getExistingLibraryRootOrThrow(ingestDb, input.libraryRootId);
+    const effectiveScanMode = input.scanMode ?? libraryRoot.scanMode;
     const normalizedRootPath = normalizeRootPath(libraryRoot.path);
     const existingFileAssets = await ingestDb.fileAsset.findMany({
       where: { libraryRootId: libraryRoot.id },
@@ -1173,13 +1406,43 @@ export function createIngestServices(
     const existingByPath = new Map(
       existingFileAssets.map((fileAsset) => [fileAsset.absolutePath, fileAsset]),
     );
+    const fileAssetsByDirectory = buildFileAssetsByDirectory(existingFileAssets);
+    const existingEditionFiles = existingFileAssets.length === 0
+      ? []
+      : await ingestDb.editionFile.findMany({
+        where: {
+          fileAssetId: { in: existingFileAssets.map((fileAsset) => fileAsset.id) },
+        },
+      });
+    const editionFileByFileAssetId = new Map<string, EditionFileRecord>();
+    for (const editionFile of [...existingEditionFiles].reverse()) {
+      editionFileByFileAssetId.set(editionFile.fileAssetId, editionFile);
+    }
+    const existingEditions = existingEditionFiles.length === 0
+      ? []
+      : await ingestDb.edition.findManyByIds({
+        ids: [...new Set(existingEditionFiles.map((editionFile) => editionFile.editionId))],
+      });
+    const editionById = new Map(
+      existingEditions.map((edition) => [edition.id, edition]),
+    );
+    const existingWorks = existingEditions.length === 0
+      ? []
+      : await ingestDb.work.findManyByIds({
+        ids: [...new Set(existingEditions.map((edition) => edition.workId))],
+      });
+    const workById = new Map(
+      existingWorks.map((work) => [work.id, work]),
+    );
     const discoveredPaths = await walkRegularFiles(normalizedRootPath, listDirectory, readStats);
+    const scanPathStats = await collectScanPathStats(discoveredPaths, readStats);
     const seenPaths = new Set<string>();
     const scannedFileAssetIds: string[] = [];
     const enqueuedHashJobs: string[] = [];
     const enqueuedRecoveryJobs: string[] = [];
     const createdStubWorkIds: string[] = [];
     const seenAudioDirs = new Map<string, { workId: string; editionId: string }>();
+    const unchangedSeenFileAssetIds: string[] = [];
 
     if (reportProgress) {
       await reportProgress({ totalFiles: discoveredPaths.length, scanStage: "DISCOVERY" });
@@ -1188,12 +1451,8 @@ export function createIngestServices(
     let processedFiles = 0;
     let errorCount = 0;
 
-    for (const absolutePath of discoveredPaths) {
-      let fileStats;
-
-      try {
-        fileStats = await readStats(absolutePath);
-      } catch {
+    for (const pathStats of scanPathStats) {
+      if (pathStats.statFailed || pathStats.fileStats === undefined) {
         processedFiles++;
         errorCount++;
         if (reportProgress && processedFiles % SCAN_PROGRESS_INTERVAL === 0) {
@@ -1202,6 +1461,7 @@ export function createIngestServices(
         continue;
       }
 
+      const { absolutePath, fileStats } = pathStats;
       if (!fileStats.isFile() || fileStats.isSymbolicLink()) {
         processedFiles++;
         if (reportProgress && processedFiles % SCAN_PROGRESS_INTERVAL === 0) {
@@ -1212,188 +1472,78 @@ export function createIngestServices(
 
       const relativePath = normalizeRelativePath(normalizedRootPath, absolutePath);
       const existingFileAsset = existingByPath.get(absolutePath);
-      const upsertedFileAsset = await ingestDb.fileAsset.upsert({
-        where: { absolutePath },
-        create: {
-          absolutePath,
-          availabilityStatus: AvailabilityStatus.PRESENT,
-          basename: path.basename(absolutePath),
-          ctime: fileStats.ctime,
-          extension: getFileExtension(absolutePath),
-          lastSeenAt: now,
-          libraryRootId: libraryRoot.id,
-          mediaKind: classifyMediaKind(absolutePath),
-          metadata: null,
-          mtime: fileStats.mtime,
-          relativePath,
-          sizeBytes: BigInt(fileStats.size),
-        },
-        update: {
-          availabilityStatus: AvailabilityStatus.PRESENT,
-          basename: path.basename(absolutePath),
-          ctime: fileStats.ctime,
-          extension: getFileExtension(absolutePath),
-          lastSeenAt: now,
-          mediaKind: classifyMediaKind(absolutePath),
-          mtime: fileStats.mtime,
-          relativePath,
-          sizeBytes: BigInt(fileStats.size),
-        },
-      });
+      const nextFileState = {
+        mtime: fileStats.mtime,
+        sizeBytes: BigInt(fileStats.size),
+      };
+      const fileStatsChanged = didFileStatsChange(existingFileAsset, nextFileState);
+      const shouldEnqueueHash = effectiveScanMode === ScanMode.FULL
+        || isFileChanged(existingFileAsset, nextFileState);
+      const shouldUpsert = effectiveScanMode === ScanMode.FULL
+        || existingFileAsset === undefined
+        || existingFileAsset.availabilityStatus === AvailabilityStatus.MISSING
+        || fileStatsChanged;
+      let upsertedFileAsset: FileAssetRecord;
+      if (shouldUpsert) {
+        upsertedFileAsset = await ingestDb.fileAsset.upsert({
+          where: { absolutePath },
+          create: {
+            absolutePath,
+            availabilityStatus: AvailabilityStatus.PRESENT,
+            basename: path.basename(absolutePath),
+            ctime: fileStats.ctime,
+            extension: getFileExtension(absolutePath),
+            lastSeenAt: now,
+            libraryRootId: libraryRoot.id,
+            mediaKind: classifyMediaKind(absolutePath),
+            metadata: null,
+            mtime: fileStats.mtime,
+            relativePath,
+            sizeBytes: BigInt(fileStats.size),
+          },
+          update: {
+            availabilityStatus: AvailabilityStatus.PRESENT,
+            basename: path.basename(absolutePath),
+            ctime: fileStats.ctime,
+            extension: getFileExtension(absolutePath),
+            lastSeenAt: now,
+            mediaKind: classifyMediaKind(absolutePath),
+            mtime: fileStats.mtime,
+            relativePath,
+            sizeBytes: BigInt(fileStats.size),
+          },
+        });
+      } else {
+        upsertedFileAsset = existingFileAsset;
+      }
 
       seenPaths.add(absolutePath);
       scannedFileAssetIds.push(upsertedFileAsset.id);
+      if (shouldUpsert) {
+        existingByPath.set(absolutePath, upsertedFileAsset);
+        setDirectoryFileAsset(fileAssetsByDirectory, upsertedFileAsset);
+      } else {
+        unchangedSeenFileAssetIds.push(upsertedFileAsset.id);
+      }
 
-      if (
-        isFileChanged(existingFileAsset, {
-          mtime: fileStats.mtime,
-          sizeBytes: BigInt(fileStats.size),
-        })
-      ) {
+      if (shouldEnqueueHash) {
         await enqueueJob(LIBRARY_JOB_NAMES.HASH_FILE_ASSET, {
           fileAssetId: upsertedFileAsset.id,
         });
         enqueuedHashJobs.push(upsertedFileAsset.id);
       } else {
-        // Recovery: re-enqueue jobs for existing unchanged files with incomplete processing
-        const recoveryFormatFamily = deriveFormatFamily(upsertedFileAsset.mediaKind);
-        if (recoveryFormatFamily !== null && upsertedFileAsset.fullHash !== null) {
-          // Check EditionFile link FIRST — if matched, skip metadata check and go to work/cover recovery
-          const editionFileLink = await ingestDb.editionFile.findFirst({
-            where: { fileAssetId: upsertedFileAsset.id },
-          });
-
-          if (editionFileLink !== null) {
-            // Already linked to an edition — check work status and cover
-            const edition = await ingestDb.edition.findUnique({
-              where: { id: editionFileLink.editionId },
-            });
-            if (edition) {
-              const work = await ingestDb.work.findUnique({
-                where: { id: edition.workId },
-              });
-              if (work && work.enrichmentStatus === "STUB") {
-                // Work stuck at STUB — for PDF/CBZ, look for OPF sidecar to trigger enrichment
-                if (
-                  upsertedFileAsset.mediaKind === MediaKind.PDF ||
-                  upsertedFileAsset.mediaKind === MediaKind.CBZ
-                ) {
-                  const directory = path.dirname(upsertedFileAsset.absolutePath);
-                  const sidecarSiblings = await ingestDb.fileAsset.findByDirectory({
-                    directoryPath: directory,
-                    mediaKinds: [MediaKind.SIDECAR],
-                  });
-                  const opfSibling = sidecarSiblings.find(
-                    (fa) => getFileExtension(fa.absolutePath) === "opf",
-                  );
-                  if (opfSibling && opfSibling.fullHash !== null) {
-                    logger.info({ fileAssetId: upsertedFileAsset.id, opfFileAssetId: opfSibling.id, workId: work.id, reason: "STUB work with OPF sibling" }, "Recovery: re-enqueueing OPF PARSE");
-                    await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
-                      fileAssetId: opfSibling.id,
-                    });
-                    enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-                  } else {
-                    // No OPF sidecar — fall back to MATCH
-                    logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "work stuck at STUB (no OPF)" }, "Recovery: re-enqueueing MATCH");
-                    await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
-                      fileAssetId: upsertedFileAsset.id,
-                    });
-                    enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-                  }
-                } else {
-                  // EPUB/AUDIO — MATCH can use their own parsed metadata
-                  logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "work stuck at STUB" }, "Recovery: re-enqueueing MATCH");
-                  await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
-                    fileAssetId: upsertedFileAsset.id,
-                  });
-                  enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-                }
-              }
-              // Separately check for missing covers — runs for both STUB and ENRICHED works
-              if (work && work.coverPath === null) {
-                logger.info({ fileAssetId: upsertedFileAsset.id, workId: work.id, reason: "missing cover" }, "Recovery: re-enqueueing PROCESS_COVER");
-                await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
-                  workId: work.id,
-                  fileAssetId: upsertedFileAsset.id,
-                });
-                if (!enqueuedRecoveryJobs.includes(upsertedFileAsset.id)) {
-                  enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-                }
-              }
-            }
-
-            // Re-parse edition-linked AUDIO files with unparseable metadata
-            // (encoding errors are now handled gracefully, so re-parsing will succeed)
-            const editionLinkedMeta = parseStoredMetadata(upsertedFileAsset.metadata);
-            if (
-              upsertedFileAsset.mediaKind === MediaKind.AUDIO &&
-              editionLinkedMeta?.status === "unparseable"
-            ) {
-              logger.info({ fileAssetId: upsertedFileAsset.id, reason: "edition-linked audio with unparseable metadata" }, "Recovery: re-enqueueing PARSE");
-              await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
-                fileAssetId: upsertedFileAsset.id,
-              });
-              if (!enqueuedRecoveryJobs.includes(upsertedFileAsset.id)) {
-                enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-              }
-            }
-
-            // Re-enqueue MATCH_SUGGESTIONS for AUDIO files in AUDIOBOOK editions.
-            // matchSuggestionsImpl is safe to re-run: it skips pairs that already have suggestions.
-            // This ensures match suggestions are generated even when the edition link was
-            // created before MATCH_SUGGESTIONS enqueuing was added.
-            if (
-              upsertedFileAsset.mediaKind === MediaKind.AUDIO &&
-              edition &&
-              edition.formatFamily === FormatFamily.AUDIOBOOK
-            ) {
-              await enqueueJob(LIBRARY_JOB_NAMES.MATCH_SUGGESTIONS, {
-                fileAssetId: upsertedFileAsset.id,
-              });
-              if (!enqueuedRecoveryJobs.includes(upsertedFileAsset.id)) {
-                enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-              }
-            }
-          } else {
-            // Not linked to an edition — recover from earlier in the pipeline
-            const parsedMeta = parseStoredMetadata(upsertedFileAsset.metadata);
-
-            if (!parsedMeta || parsedMeta.status !== "parsed") {
-              // Missing or failed metadata parse — only EPUB and AUDIO are parseable
-              if (
-                upsertedFileAsset.mediaKind === MediaKind.EPUB ||
-                upsertedFileAsset.mediaKind === MediaKind.AUDIO
-              ) {
-                logger.info({ fileAssetId: upsertedFileAsset.id, reason: "missing or failed metadata" }, "Recovery: re-enqueueing PARSE");
-                await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
-                  fileAssetId: upsertedFileAsset.id,
-                });
-                enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-              }
-            } else {
-              // Parsed but not matched to edition
-              logger.info({ fileAssetId: upsertedFileAsset.id, reason: "parsed but unmatched" }, "Recovery: re-enqueueing MATCH");
-              await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
-                fileAssetId: upsertedFileAsset.id,
-              });
-              enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-            }
-          }
-        }
-
-        // Recovery for OPF sidecars: re-enqueue PARSE if hashed but not parsed
-        const isOpfSidecar = upsertedFileAsset.mediaKind === MediaKind.SIDECAR
-          && getFileExtension(upsertedFileAsset.absolutePath) === "opf";
-        if (isOpfSidecar && upsertedFileAsset.fullHash !== null) {
-          const opfMeta = parseStoredMetadata(upsertedFileAsset.metadata);
-          if (!opfMeta || opfMeta.status !== "parsed") {
-            logger.info({ fileAssetId: upsertedFileAsset.id, reason: "OPF hashed but not parsed" }, "Recovery: re-enqueueing OPF PARSE");
-            await enqueueJob(LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA, {
-              fileAssetId: upsertedFileAsset.id,
-            });
-            enqueuedRecoveryJobs.push(upsertedFileAsset.id);
-          }
-        }
+        await recoverUnchangedFile(
+          upsertedFileAsset,
+          {
+            editionById,
+            editionFileByFileAssetId,
+            fileAssetsByDirectory,
+            workById,
+          },
+          logger,
+          enqueueJob,
+          enqueuedRecoveryJobs,
+        );
       }
 
       // Create stub Work/Edition/EditionFile for new files with a content format
@@ -1508,24 +1658,31 @@ export function createIngestServices(
     }
 
     const missingFileAssetIds: string[] = [];
-
     for (const existingFileAsset of existingFileAssets) {
-      if (seenPaths.has(existingFileAsset.absolutePath)) {
-        continue;
+      if (!seenPaths.has(existingFileAsset.absolutePath)) {
+        missingFileAssetIds.push(existingFileAsset.id);
       }
+    }
 
-      await ingestDb.fileAsset.update({
-        where: { id: existingFileAsset.id },
+    if (unchangedSeenFileAssetIds.length > 0) {
+      await ingestDb.fileAsset.updateMany({
+        where: { id: { in: unchangedSeenFileAssetIds } },
+        data: { lastSeenAt: now },
+      });
+    }
+
+    if (missingFileAssetIds.length > 0) {
+      await ingestDb.fileAsset.updateMany({
+        where: { id: { in: missingFileAssetIds } },
         data: {
           availabilityStatus: AvailabilityStatus.MISSING,
         },
       });
-      missingFileAssetIds.push(existingFileAsset.id);
     }
 
     await ingestDb.libraryRoot.update({
       where: { id: libraryRoot.id },
-      data: { lastScannedAt: now },
+      data: { lastScannedAt: now, scanMode: ScanMode.INCREMENTAL },
     });
 
     return {

--- a/packages/shared/src/queues.ts
+++ b/packages/shared/src/queues.ts
@@ -20,6 +20,7 @@ export interface BaseJobPayload {
 
 export interface ScanLibraryRootJobPayload extends BaseJobPayload {
   libraryRootId: string;
+  scanMode?: "FULL" | "INCREMENTAL";
 }
 
 export interface HashFileAssetJobPayload extends BaseJobPayload {

--- a/workers/library-worker/src/index.test.ts
+++ b/workers/library-worker/src/index.test.ts
@@ -267,6 +267,32 @@ describe("library worker", () => {
     });
   });
 
+  it("passes a scan mode override through to ingest scanLibraryRoot", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      enrichWork: enrichWorkMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+
+    scanLibraryRootMock.mockResolvedValueOnce({ missingFileAssetIds: [] });
+
+    await processor(createMockJob({
+      data: { libraryRootId: "root-1", scanMode: "FULL" },
+      name: "scan-library-root",
+    }) as never);
+
+    expect(scanLibraryRootMock).toHaveBeenCalledWith({
+      libraryRootId: "root-1",
+      scanMode: "FULL",
+    });
+  });
+
   it("uses /data/covers as the production fallback when COVER_CACHE_DIR is unset", async () => {
     process.env.NODE_ENV = "production";
 


### PR DESCRIPTION
## Summary
- default new library roots to a first full scan, then flip future scans back to incremental
- add a manual Full Scan action and carry one-off scan mode overrides through the job pipeline
- speed up incremental scans by avoiding unchanged upserts, batching updates, and preloading recovery context

## Testing
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build