### PR TITLE
Fix scan completion tracking and add library filter presets

### DIFF
--- a/apps/web/src/components/library-filters.test.tsx
+++ b/apps/web/src/components/library-filters.test.tsx
@@ -11,7 +11,10 @@ const defaultFacetCounts: FacetCounts = {
     { formatFamily: "AUDIOBOOK", _count: { _all: 5 } },
   ],
   hasCover: { withCover: 12, withoutCover: 3 },
-  series: 4,
+  enrichment: { enriched: 8, unenriched: 7 },
+  description: { withDescription: 6, withoutDescription: 9 },
+  series: { inSeries: 4, standalone: 11 },
+  isbn: { withIsbn: 10, withoutIsbn: 5 },
 };
 
 const defaultProps = {
@@ -123,6 +126,111 @@ describe("LibraryFilters", () => {
     render(<LibraryFilters {...defaultProps} />);
     expect(screen.getByText("Format")).toBeTruthy();
     expect(screen.getByText("Cover")).toBeTruthy();
+    expect(screen.getByText("Enrichment")).toBeTruthy();
+    expect(screen.getByText("Description")).toBeTruthy();
+    expect(screen.getByText("Series")).toBeTruthy();
+    expect(screen.getByText("ISBN")).toBeTruthy();
+  });
+
+  it("renders enrichment filter buttons with counts", () => {
+    render(<LibraryFilters {...defaultProps} />);
+    expect(screen.getByText("Enriched (8)")).toBeTruthy();
+    expect(screen.getByText("Unenriched (7)")).toBeTruthy();
+  });
+
+  it("toggles enriched filter", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("Enriched (8)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ enriched: true }));
+  });
+
+  it("toggles unenriched filter", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("Unenriched (7)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ enriched: false }));
+  });
+
+  it("deselects enriched when already selected", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} filters={{ enriched: true }} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("Enriched (8)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ enriched: undefined }));
+  });
+
+  it("renders description filter buttons with counts", () => {
+    render(<LibraryFilters {...defaultProps} />);
+    expect(screen.getByText("Has Description (6)")).toBeTruthy();
+    expect(screen.getByText("No Description (9)")).toBeTruthy();
+  });
+
+  it("toggles hasDescription filter", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("Has Description (6)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ hasDescription: true }));
+  });
+
+  it("toggles no description filter", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("No Description (9)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ hasDescription: false }));
+  });
+
+  it("renders series filter buttons with counts", () => {
+    render(<LibraryFilters {...defaultProps} />);
+    expect(screen.getByText("In Series (4)")).toBeTruthy();
+    expect(screen.getByText("Standalone (11)")).toBeTruthy();
+  });
+
+  it("toggles inSeries filter", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("In Series (4)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ inSeries: true }));
+  });
+
+  it("toggles standalone filter", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("Standalone (11)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ inSeries: false }));
+  });
+
+  it("renders ISBN filter buttons with counts", () => {
+    render(<LibraryFilters {...defaultProps} />);
+    expect(screen.getByText("Has ISBN (10)")).toBeTruthy();
+    expect(screen.getByText("No ISBN (5)")).toBeTruthy();
+  });
+
+  it("toggles hasIsbn filter", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("Has ISBN (10)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ hasIsbn: true }));
+  });
+
+  it("toggles no ISBN filter", async () => {
+    const onFiltersChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryFilters {...defaultProps} onFiltersChange={onFiltersChange} />);
+    await user.click(screen.getByText("No ISBN (5)"));
+    expect(onFiltersChange).toHaveBeenCalledWith(expect.objectContaining({ hasIsbn: false }));
+  });
+
+  it("shows clear all when new boolean filters are active", () => {
+    render(<LibraryFilters {...defaultProps} filters={{ enriched: true }} />);
+    expect(screen.getByText("Clear All")).toBeTruthy();
   });
 
   it("shows active state on selected format button", () => {

--- a/apps/web/src/components/library-filters.tsx
+++ b/apps/web/src/components/library-filters.tsx
@@ -4,7 +4,10 @@ import { X } from "lucide-react";
 export interface FacetCounts {
   format: { formatFamily: string; _count: { _all: number } }[];
   hasCover: { withCover: number; withoutCover: number };
-  series: number;
+  enrichment: { enriched: number; unenriched: number };
+  description: { withDescription: number; withoutDescription: number };
+  series: { inSeries: number; standalone: number };
+  isbn: { withIsbn: number; withoutIsbn: number };
 }
 
 export interface LibraryFilterValues {
@@ -13,6 +16,10 @@ export interface LibraryFilterValues {
   seriesId?: string[];
   publisher?: string[];
   hasCover?: boolean;
+  enriched?: boolean;
+  hasDescription?: boolean;
+  inSeries?: boolean;
+  hasIsbn?: boolean;
 }
 
 interface LibraryFiltersProps {
@@ -25,6 +32,10 @@ function hasActiveFilters(filters: LibraryFilterValues): boolean {
   return (
     (filters.format !== undefined && filters.format.length > 0) ||
     filters.hasCover !== undefined ||
+    filters.enriched !== undefined ||
+    filters.hasDescription !== undefined ||
+    filters.inSeries !== undefined ||
+    filters.hasIsbn !== undefined ||
     (filters.authorId !== undefined && filters.authorId.length > 0) ||
     (filters.seriesId !== undefined && filters.seriesId.length > 0) ||
     (filters.publisher !== undefined && filters.publisher.length > 0)
@@ -45,11 +56,11 @@ export function LibraryFilters({
     }
   }
 
-  function toggleHasCover(value: boolean) {
-    if (filters.hasCover === value) {
-      onFiltersChange({ ...filters, hasCover: undefined });
+  function toggleBoolean(key: keyof LibraryFilterValues, value: boolean) {
+    if (filters[key] === value) {
+      onFiltersChange({ ...filters, [key]: undefined });
     } else {
-      onFiltersChange({ ...filters, hasCover: value });
+      onFiltersChange({ ...filters, [key]: value });
     }
   }
 
@@ -91,7 +102,7 @@ export function LibraryFilters({
             variant="outline"
             size="sm"
             data-active={filters.hasCover === true}
-            onClick={() => { toggleHasCover(true); }}
+            onClick={() => { toggleBoolean("hasCover", true); }}
             className="data-[active=true]:bg-accent"
           >
             With Cover ({String(facetCounts.hasCover.withCover)})
@@ -100,10 +111,106 @@ export function LibraryFilters({
             variant="outline"
             size="sm"
             data-active={filters.hasCover === false}
-            onClick={() => { toggleHasCover(false); }}
+            onClick={() => { toggleBoolean("hasCover", false); }}
             className="data-[active=true]:bg-accent"
           >
             Without Cover ({String(facetCounts.hasCover.withoutCover)})
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Enrichment</h3>
+        <div className="flex flex-wrap gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            data-active={filters.enriched === true}
+            onClick={() => { toggleBoolean("enriched", true); }}
+            className="data-[active=true]:bg-accent"
+          >
+            Enriched ({String(facetCounts.enrichment.enriched)})
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            data-active={filters.enriched === false}
+            onClick={() => { toggleBoolean("enriched", false); }}
+            className="data-[active=true]:bg-accent"
+          >
+            Unenriched ({String(facetCounts.enrichment.unenriched)})
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Description</h3>
+        <div className="flex flex-wrap gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            data-active={filters.hasDescription === true}
+            onClick={() => { toggleBoolean("hasDescription", true); }}
+            className="data-[active=true]:bg-accent"
+          >
+            Has Description ({String(facetCounts.description.withDescription)})
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            data-active={filters.hasDescription === false}
+            onClick={() => { toggleBoolean("hasDescription", false); }}
+            className="data-[active=true]:bg-accent"
+          >
+            No Description ({String(facetCounts.description.withoutDescription)})
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">Series</h3>
+        <div className="flex flex-wrap gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            data-active={filters.inSeries === true}
+            onClick={() => { toggleBoolean("inSeries", true); }}
+            className="data-[active=true]:bg-accent"
+          >
+            In Series ({String(facetCounts.series.inSeries)})
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            data-active={filters.inSeries === false}
+            onClick={() => { toggleBoolean("inSeries", false); }}
+            className="data-[active=true]:bg-accent"
+          >
+            Standalone ({String(facetCounts.series.standalone)})
+          </Button>
+        </div>
+      </div>
+
+      <div className="space-y-2">
+        <h3 className="text-sm font-medium">ISBN</h3>
+        <div className="flex flex-wrap gap-1">
+          <Button
+            variant="outline"
+            size="sm"
+            data-active={filters.hasIsbn === true}
+            onClick={() => { toggleBoolean("hasIsbn", true); }}
+            className="data-[active=true]:bg-accent"
+          >
+            Has ISBN ({String(facetCounts.isbn.withIsbn)})
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            data-active={filters.hasIsbn === false}
+            onClick={() => { toggleBoolean("hasIsbn", false); }}
+            className="data-[active=true]:bg-accent"
+          >
+            No ISBN ({String(facetCounts.isbn.withoutIsbn)})
           </Button>
         </div>
       </div>

--- a/apps/web/src/lib/library-search-schema.ts
+++ b/apps/web/src/lib/library-search-schema.ts
@@ -26,6 +26,10 @@ export const librarySearchSchema = z
     seriesId: coerceToArray(z.string()),
     publisher: coerceToArray(z.string()),
     hasCover: coerceBool,
+    enriched: coerceBool,
+    hasDescription: coerceBool,
+    inSeries: coerceBool,
+    hasIsbn: coerceBool,
   })
   .strip();
 

--- a/apps/web/src/lib/server-fns/library-roots.test.ts
+++ b/apps/web/src/lib/server-fns/library-roots.test.ts
@@ -303,7 +303,7 @@ describe("scanLibraryRootServerFn", () => {
 
     expect(enqueueLibraryJobMock).toHaveBeenCalledWith(
       LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT,
-      { libraryRootId: "root-xyz", importJobId: "job-abc" },
+      { libraryRootId: "root-xyz", importJobId: "job-abc", scanTrigger: "manual" },
     );
   });
 
@@ -318,7 +318,7 @@ describe("scanLibraryRootServerFn", () => {
 
     expect(enqueueLibraryJobMock).toHaveBeenCalledWith(
       LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT,
-      { libraryRootId: "root-xyz", importJobId: "job-abc", scanMode: "FULL" },
+      { libraryRootId: "root-xyz", importJobId: "job-abc", scanMode: "FULL", scanTrigger: "manual" },
     );
   });
 
@@ -404,7 +404,7 @@ describe("getScanProgressServerFn", () => {
     });
   });
 
-  it("returns stale: true when a live scan exceeds the threshold", async () => {
+  it("returns stale: false for waiting-children even when activity exceeds the threshold", async () => {
     const sixMinutesAgo = new Date(Date.now() - 6 * 60 * 1000);
     getLibraryJobSnapshotMock.mockResolvedValue({ state: "waiting-children", progress: null });
     importJobFindManyMock.mockResolvedValue([{
@@ -428,6 +428,34 @@ describe("getScanProgressServerFn", () => {
       processedFiles: 200,
       errorCount: 0,
       scanStage: "PROCESSING",
+      stale: false,
+    });
+  });
+
+  it("returns stale: true for active state when activity exceeds the threshold", async () => {
+    const sixMinutesAgo = new Date(Date.now() - 6 * 60 * 1000);
+    getLibraryJobSnapshotMock.mockResolvedValue({ state: "active", progress: null, lastActivityAt: sixMinutesAgo.getTime() });
+    importJobFindManyMock.mockResolvedValue([{
+      id: "ij-stale-active",
+      bullmqJobId: "bull-stale",
+      status: "RUNNING",
+      totalFiles: 500,
+      processedFiles: 200,
+      errorCount: 0,
+      updatedAt: sixMinutesAgo,
+      scanStage: "DISCOVERY",
+    }]);
+
+    const result = await getScanProgressServerFn({
+      data: { libraryRootId: "root-1" },
+    });
+
+    expect(result).toEqual({
+      status: "RUNNING",
+      totalFiles: 500,
+      processedFiles: 200,
+      errorCount: 0,
+      scanStage: "DISCOVERY",
       stale: true,
     });
   });
@@ -556,9 +584,38 @@ describe("getScanProgressServerFn", () => {
     expect(result).toBeNull();
   });
 
-  it("returns null for scans without a BullMQ id", async () => {
+  it("returns RUNNING for non-stale scan with no live activity instead of marking SUCCEEDED", async () => {
     importJobFindManyMock.mockResolvedValue([{
       id: "ij-no-bull",
+      bullmqJobId: null,
+      status: "RUNNING",
+      totalFiles: 10,
+      processedFiles: 10,
+      errorCount: 0,
+      updatedAt: new Date(),
+      scanStage: null,
+    }]);
+    getImportJobLiveActivityMock.mockResolvedValue(null);
+
+    const result = await getScanProgressServerFn({
+      data: { libraryRootId: "root-1" },
+    });
+
+    expect(getLibraryJobSnapshotMock).not.toHaveBeenCalled();
+    expect(importJobUpdateManyMock).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      status: "RUNNING",
+      totalFiles: 10,
+      processedFiles: 10,
+      errorCount: 0,
+      scanStage: null,
+      stale: false,
+    });
+  });
+
+  it("returns RUNNING for non-stale QUEUED scan with no live activity", async () => {
+    importJobFindManyMock.mockResolvedValue([{
+      id: "ij-queued",
       bullmqJobId: null,
       status: "QUEUED",
       totalFiles: null,
@@ -573,8 +630,14 @@ describe("getScanProgressServerFn", () => {
       data: { libraryRootId: "root-1" },
     });
 
-    expect(getLibraryJobSnapshotMock).not.toHaveBeenCalled();
-    expect(result).toBeNull();
+    expect(result).toEqual({
+      status: "RUNNING",
+      totalFiles: null,
+      processedFiles: null,
+      errorCount: null,
+      scanStage: null,
+      stale: false,
+    });
   });
 
   it("keeps a completed scan visible when descendant queue jobs are still live", async () => {
@@ -668,6 +731,26 @@ describe("getScanProgressServerFn", () => {
       scanStage: "PROCESSING",
       stale: false,
     });
+  });
+
+  it("skips SUCCEEDED scans with no live activity and returns null", async () => {
+    importJobFindManyMock.mockResolvedValue([{
+      id: "ij-done",
+      bullmqJobId: null,
+      status: "SUCCEEDED",
+      totalFiles: 10,
+      processedFiles: 10,
+      errorCount: 0,
+      updatedAt: new Date(),
+      scanStage: null,
+    }]);
+    getImportJobLiveActivityMock.mockResolvedValue(null);
+
+    const result = await getScanProgressServerFn({
+      data: { libraryRootId: "root-1" },
+    });
+
+    expect(result).toBeNull();
   });
 
   it("returns null when no active scan exists", async () => {

--- a/apps/web/src/lib/server-fns/library-roots.ts
+++ b/apps/web/src/lib/server-fns/library-roots.ts
@@ -149,7 +149,11 @@ export const getScanProgressServerFn = createServerFn({
         : null;
       const queueState = snapshot?.state ?? null;
       const lastActivityAt = Math.max(job.updatedAt.getTime(), snapshot?.lastActivityAt ?? 0);
-      const stale = Date.now() - lastActivityAt > STALE_SCAN_THRESHOLD_MS;
+      // A scan-root in waiting-children is validly waiting for child jobs —
+      // not stalled. The blockedByFailedChild check above catches real stuck cases.
+      const stale = queueState === "waiting-children"
+        ? false
+        : Date.now() - lastActivityAt > STALE_SCAN_THRESHOLD_MS;
 
       if (snapshot?.blockedByFailedChild) {
         await db.importJob.updateMany({
@@ -196,6 +200,7 @@ export const getScanProgressServerFn = createServerFn({
         };
       }
 
+      // No live BullMQ job and no live child activity.
       if (
         stale &&
         (job.status === "QUEUED" || job.status === "RUNNING")
@@ -210,6 +215,20 @@ export const getScanProgressServerFn = createServerFn({
             bullmqJobId: null,
           },
         });
+      } else if (
+        !stale &&
+        (job.status === "QUEUED" || job.status === "RUNNING")
+      ) {
+        // Scan root is likely in waiting-children — keep showing RUNNING
+        // until it completes or becomes stale.
+        return {
+          status: "RUNNING" as const,
+          totalFiles: job.totalFiles,
+          processedFiles: job.processedFiles,
+          errorCount: job.errorCount,
+          scanStage: null,
+          stale: false,
+        };
       }
     }
 
@@ -296,6 +315,7 @@ export const scanLibraryRootServerFn = createServerFn({
       {
         libraryRootId: data.libraryRootId,
         importJobId: importJob.id,
+        scanTrigger: "manual" as const,
         ...(data.scanMode ? { scanMode: data.scanMode } : {}),
       },
     );

--- a/apps/web/src/lib/server-fns/library.test.ts
+++ b/apps/web/src/lib/server-fns/library.test.ts
@@ -17,13 +17,11 @@ vi.mock("@tanstack/react-start", () => ({
 const findManyMock = vi.fn();
 const countMock = vi.fn();
 const editionGroupByMock = vi.fn();
-const seriesCountMock = vi.fn();
 
 vi.mock("@bookhouse/db", () => ({
   db: {
     work: { findMany: findManyMock, count: countMock },
     edition: { groupBy: editionGroupByMock },
-    series: { count: seriesCountMock },
   },
 }));
 
@@ -78,15 +76,12 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockReset();
     countMock.mockReset();
     editionGroupByMock.mockReset();
-    seriesCountMock.mockReset();
   });
 
   it("returns paginated works with defaults (page 1, pageSize 50)", async () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     const result = await getFilteredLibraryWorksServerFn({ data: {} });
 
     expect(findManyMock).toHaveBeenCalledWith(
@@ -103,7 +98,10 @@ describe("getFilteredLibraryWorksServerFn", () => {
       facetCounts: {
         format: [],
         hasCover: { withCover: 0, withoutCover: 0 },
-        series: 0,
+        enrichment: { enriched: 0, unenriched: 0 },
+        description: { withDescription: 0, withoutDescription: 0 },
+        series: { inSeries: 0, standalone: 0 },
+        isbn: { withIsbn: 0, withoutIsbn: 0 },
       },
     });
   });
@@ -112,8 +110,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(100);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { page: 3, pageSize: 20 },
     });
@@ -130,8 +126,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { sort: "title-desc" },
     });
@@ -147,8 +141,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { sort: "recent" },
     });
@@ -164,8 +156,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { format: ["EBOOK"] },
     });
@@ -183,8 +173,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { authorId: ["author-1"] },
     });
@@ -211,8 +199,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { seriesId: ["series-1"] },
     });
@@ -230,8 +216,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { publisher: ["Penguin"] },
     });
@@ -249,8 +233,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { hasCover: true },
     });
@@ -268,8 +250,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { hasCover: false },
     });
@@ -287,8 +267,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { q: "hobbit" },
     });
@@ -309,8 +287,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { format: ["EBOOK"], authorId: ["author-1"] },
     });
@@ -338,8 +314,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { format: ["AUDIOBOOK"], publisher: ["Penguin"] },
     });
@@ -363,8 +337,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { authorId: ["author-1"], publisher: ["Penguin"] },
     });
@@ -392,8 +364,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { format: ["EBOOK"], authorId: ["author-1"], publisher: ["Penguin"] },
     });
@@ -422,8 +392,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: {
         format: ["EBOOK"],
@@ -461,8 +429,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(5);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({
       data: { format: ["AUDIOBOOK"] },
     });
@@ -478,8 +444,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
       { formatFamily: "EBOOK", _count: { _all: 10 } },
       { formatFamily: "AUDIOBOOK", _count: { _all: 3 } },
     ]);
-    seriesCountMock.mockResolvedValue(2);
-
     const result = await getFilteredLibraryWorksServerFn({ data: {} });
 
     expect(result.facetCounts.format).toEqual([
@@ -491,9 +455,9 @@ describe("getFilteredLibraryWorksServerFn", () => {
   it("returns facet counts for hasCover", async () => {
     findManyMock.mockResolvedValue([]);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
 
-    // countMock is called three times: totalCount, withCover, withoutCover
+    // Default for all count calls, then override specific ones
+    countMock.mockResolvedValue(0);
     countMock
       .mockResolvedValueOnce(10)  // totalCount
       .mockResolvedValueOnce(7)   // withCover
@@ -510,12 +474,9 @@ describe("getFilteredLibraryWorksServerFn", () => {
   it("returns correct hasCover facet counts when hasCover filter is active", async () => {
     findManyMock.mockResolvedValue([]);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
 
-    // When hasCover=false is active:
-    // totalCount (filtered, coverPath=null) = 343
-    // withCoverCount (coverPath not null) = 347
-    // withoutCoverCount (coverPath null) = 343
+    // Default for remaining count calls, then override specific ones
+    countMock.mockResolvedValue(0);
     countMock
       .mockResolvedValueOnce(343)  // totalCount (filtered by hasCover=false)
       .mockResolvedValueOnce(347)  // withCoverCount
@@ -532,7 +493,7 @@ describe("getFilteredLibraryWorksServerFn", () => {
   it("scopes cover facet counts to active search filter (excludes hasCover)", async () => {
     findManyMock.mockResolvedValue([]);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
+
     countMock.mockResolvedValue(5);
 
     await getFilteredLibraryWorksServerFn({ data: { q: "wind" } });
@@ -578,8 +539,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({ data: { q: "wind" } });
 
     expect(editionGroupByMock).toHaveBeenCalledWith({
@@ -612,7 +571,7 @@ describe("getFilteredLibraryWorksServerFn", () => {
   it("cover facet counts exclude hasCover filter but include format filter", async () => {
     findManyMock.mockResolvedValue([]);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
+
     countMock.mockResolvedValue(5);
 
     await getFilteredLibraryWorksServerFn({
@@ -649,23 +608,38 @@ describe("getFilteredLibraryWorksServerFn", () => {
     });
   });
 
-  it("returns series count in facet counts", async () => {
+  it("returns series facet counts from work.count", async () => {
     findManyMock.mockResolvedValue([]);
-    countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(5);
+
+    // 11 countMock calls: totalCount, withCover, withoutCover,
+    // enriched, unenriched, withDescription, withoutDescription,
+    // inSeries, standalone, withIsbn, withoutIsbn
+    countMock
+      .mockResolvedValueOnce(0)   // totalCount
+      .mockResolvedValueOnce(0)   // withCover
+      .mockResolvedValueOnce(0)   // withoutCover
+      .mockResolvedValueOnce(0)   // enriched
+      .mockResolvedValueOnce(0)   // unenriched
+      .mockResolvedValueOnce(0)   // withDescription
+      .mockResolvedValueOnce(0)   // withoutDescription
+      .mockResolvedValueOnce(5)   // inSeries
+      .mockResolvedValueOnce(3)   // standalone
+      .mockResolvedValueOnce(0)   // withIsbn
+      .mockResolvedValueOnce(0);  // withoutIsbn
 
     const result = await getFilteredLibraryWorksServerFn({ data: {} });
 
-    expect(result.facetCounts.series).toBe(5);
+    expect(result.facetCounts.series).toEqual({
+      inSeries: 5,
+      standalone: 3,
+    });
   });
 
   it("always includes availability filter in where clause", async () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({ data: {} });
 
     const call = (findManyMock.mock.calls[0] as unknown[])[0] as { where: Record<string, unknown> };
@@ -692,8 +666,6 @@ describe("getFilteredLibraryWorksServerFn", () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    seriesCountMock.mockResolvedValue(0);
-
     await getFilteredLibraryWorksServerFn({ data: {} });
 
     expect(findManyMock).toHaveBeenCalledWith(
@@ -706,6 +678,172 @@ describe("getFilteredLibraryWorksServerFn", () => {
                 include: { contributor: true },
               },
             },
+          },
+        },
+      }),
+    );
+  });
+
+  it("filters by enriched true", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { enriched: true },
+    });
+
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          enrichmentStatus: "ENRICHED",
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("filters by enriched false", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { enriched: false },
+    });
+
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          enrichmentStatus: "STUB",
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("filters by hasDescription true", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { hasDescription: true },
+    });
+
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          description: { not: null },
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("filters by hasDescription false", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { hasDescription: false },
+    });
+
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          description: null,
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("filters by inSeries true", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { inSeries: true },
+    });
+
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          seriesId: { not: null },
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("filters by inSeries false", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { inSeries: false },
+    });
+
+    expect(findManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          seriesId: null,
+        }) as unknown,
+      }),
+    );
+  });
+
+  it("filters by hasIsbn true (combined with format + authorId)", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { hasIsbn: true, format: ["EBOOK"], authorId: ["author-1"] },
+    });
+
+    const call = (findManyMock.mock.calls[0] as unknown[])[0] as { where: Record<string, unknown> };
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        editions: {
+          some: {
+            AND: [
+              { formatFamily: { in: ["EBOOK"] } },
+              {
+                contributors: {
+                  some: { contributorId: { in: ["author-1"] }, role: "AUTHOR" },
+                },
+              },
+              { OR: [{ isbn13: { not: null } }, { isbn10: { not: null } }] },
+            ],
+          },
+        },
+      }),
+    );
+  });
+
+  it("filters by hasIsbn false (combined with format + authorId)", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    editionGroupByMock.mockResolvedValue([]);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { hasIsbn: false, format: ["EBOOK"], authorId: ["author-1"] },
+    });
+
+    const call = (findManyMock.mock.calls[0] as unknown[])[0] as { where: Record<string, unknown> };
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        editions: {
+          some: {
+            AND: [
+              { formatFamily: { in: ["EBOOK"] } },
+              {
+                contributors: {
+                  some: { contributorId: { in: ["author-1"] }, role: "AUTHOR" },
+                },
+              },
+              { isbn13: null, isbn10: null },
+            ],
           },
         },
       }),

--- a/apps/web/src/lib/server-fns/library.ts
+++ b/apps/web/src/lib/server-fns/library.ts
@@ -46,6 +46,10 @@ const filterSchema = z.object({
   seriesId: z.array(z.string()).optional(),
   publisher: z.array(z.string()).optional(),
   hasCover: z.boolean().optional(),
+  enriched: z.boolean().optional(),
+  hasDescription: z.boolean().optional(),
+  inSeries: z.boolean().optional(),
+  hasIsbn: z.boolean().optional(),
 });
 
 type WhereClause = Record<string, unknown>;
@@ -97,6 +101,32 @@ function buildWhere(data: z.infer<typeof filterSchema>): WhereClause {
     where.coverPath = null;
   }
 
+  if (data.enriched === true) {
+    where.enrichmentStatus = "ENRICHED";
+  } else if (data.enriched === false) {
+    where.enrichmentStatus = "STUB";
+  }
+
+  if (data.hasDescription === true) {
+    where.description = { not: null };
+  } else if (data.hasDescription === false) {
+    where.description = null;
+  }
+
+  if (data.inSeries === true) {
+    where.seriesId = { not: null };
+  } else if (data.inSeries === false) {
+    where.seriesId = null;
+  }
+
+  if (data.hasIsbn === true) {
+    editionConditions.push({
+      OR: [{ isbn13: { not: null } }, { isbn10: { not: null } }],
+    });
+  } else if (data.hasIsbn === false) {
+    editionConditions.push({ isbn13: null, isbn10: null });
+  }
+
   where.AND = [
     {
       editions: {
@@ -139,26 +169,53 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
     // Facet counts exclude their own filter to show meaningful counts
     const whereForCoverFacets = buildWhere({ ...parsed, hasCover: undefined });
     const whereForFormatFacets = buildWhere({ ...parsed, format: undefined });
+    const whereForEnrichmentFacets = buildWhere({ ...parsed, enriched: undefined });
+    const whereForDescriptionFacets = buildWhere({ ...parsed, hasDescription: undefined });
+    const whereForSeriesFacets = buildWhere({ ...parsed, inSeries: undefined, seriesId: undefined });
+    const whereForIsbnFacets = buildWhere({ ...parsed, hasIsbn: undefined });
 
-    const [works, totalCount, formatCounts, withCoverCount, withoutCoverCount, seriesCount] =
-      await Promise.all([
-        db.work.findMany({
-          where,
-          orderBy,
-          skip: (parsed.page - 1) * parsed.pageSize,
-          take: parsed.pageSize,
-          include: WORK_INCLUDE,
-        }),
-        db.work.count({ where }),
-        db.edition.groupBy({
-          by: ["formatFamily"],
-          _count: { _all: true },
-          where: { work: whereForFormatFacets },
-        }),
-        db.work.count({ where: { ...whereForCoverFacets, coverPath: { not: null } } }),
-        db.work.count({ where: { ...whereForCoverFacets, coverPath: null } }),
-        db.series.count(),
-      ]);
+    const [
+      works, totalCount, formatCounts,
+      withCoverCount, withoutCoverCount,
+      enrichedCount, unenrichedCount,
+      withDescriptionCount, withoutDescriptionCount,
+      inSeriesCount, standaloneCount,
+      withIsbnCount, withoutIsbnCount,
+    ] = await Promise.all([
+      db.work.findMany({
+        where,
+        orderBy,
+        skip: (parsed.page - 1) * parsed.pageSize,
+        take: parsed.pageSize,
+        include: WORK_INCLUDE,
+      }),
+      db.work.count({ where }),
+      db.edition.groupBy({
+        by: ["formatFamily"],
+        _count: { _all: true },
+        where: { work: whereForFormatFacets },
+      }),
+      db.work.count({ where: { ...whereForCoverFacets, coverPath: { not: null } } }),
+      db.work.count({ where: { ...whereForCoverFacets, coverPath: null } }),
+      db.work.count({ where: { ...whereForEnrichmentFacets, enrichmentStatus: "ENRICHED" } }),
+      db.work.count({ where: { ...whereForEnrichmentFacets, enrichmentStatus: "STUB" } }),
+      db.work.count({ where: { ...whereForDescriptionFacets, description: { not: null } } }),
+      db.work.count({ where: { ...whereForDescriptionFacets, description: null } }),
+      db.work.count({ where: { ...whereForSeriesFacets, seriesId: { not: null } } }),
+      db.work.count({ where: { ...whereForSeriesFacets, seriesId: null } }),
+      db.work.count({
+        where: {
+          ...whereForIsbnFacets,
+          editions: { some: { OR: [{ isbn13: { not: null } }, { isbn10: { not: null } }] } },
+        },
+      }),
+      db.work.count({
+        where: {
+          ...whereForIsbnFacets,
+          editions: { every: { isbn13: null, isbn10: null } },
+        },
+      }),
+    ]);
 
     return {
       works,
@@ -169,7 +226,22 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
           withCover: withCoverCount,
           withoutCover: withoutCoverCount,
         },
-        series: seriesCount,
+        enrichment: {
+          enriched: enrichedCount,
+          unenriched: unenrichedCount,
+        },
+        description: {
+          withDescription: withDescriptionCount,
+          withoutDescription: withoutDescriptionCount,
+        },
+        series: {
+          inSeries: inSeriesCount,
+          standalone: standaloneCount,
+        },
+        isbn: {
+          withIsbn: withIsbnCount,
+          withoutIsbn: withoutIsbnCount,
+        },
       },
     };
   });

--- a/apps/web/src/routes/_authenticated/-library.index.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.index.test.tsx
@@ -9,7 +9,10 @@ const defaultFacetCounts = {
     { formatFamily: "EBOOK", _count: { _all: 1 } },
   ],
   hasCover: { withCover: 0, withoutCover: 1 },
-  series: 0,
+  enrichment: { enriched: 0, unenriched: 0 },
+  description: { withDescription: 0, withoutDescription: 0 },
+  series: { inSeries: 0, standalone: 0 },
+  isbn: { withIsbn: 0, withoutIsbn: 0 },
 };
 
 let mockLoaderData: {

--- a/apps/web/src/routes/_authenticated/library.index.tsx
+++ b/apps/web/src/routes/_authenticated/library.index.tsx
@@ -229,6 +229,10 @@ function LibraryPage() {
         seriesId: filters.seriesId,
         publisher: filters.publisher,
         hasCover: filters.hasCover,
+        enriched: filters.enriched,
+        hasDescription: filters.hasDescription,
+        inSeries: filters.inSeries,
+        hasIsbn: filters.hasIsbn,
       });
     },
     [updateSearch],
@@ -297,9 +301,13 @@ function LibraryPage() {
     seriesId: search.seriesId,
     publisher: search.publisher,
     hasCover: search.hasCover,
+    enriched: search.enriched,
+    hasDescription: search.hasDescription,
+    inSeries: search.inSeries,
+    hasIsbn: search.hasIsbn,
   };
 
-  if (totalCount === 0 && !isScanning && !search.q && !search.format && !search.authorId && !search.seriesId && !search.publisher && search.hasCover === undefined) {
+  if (totalCount === 0 && !isScanning && !search.q && !search.format && !search.authorId && !search.seriesId && !search.publisher && search.hasCover === undefined && search.enriched === undefined && search.hasDescription === undefined && search.inSeries === undefined && search.hasIsbn === undefined) {
     return (
       <div>
         <h1 className="text-2xl font-bold">Library</h1>

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -111,13 +111,17 @@ describe("shared queue helpers", () => {
 
   it("re-exports WaitingChildrenError from bullmq", () => {
     expect(WaitingChildrenError).toBeDefined();
-    const err = new WaitingChildrenError();
-    expect(err).toBeInstanceOf(Error);
+    expect(typeof WaitingChildrenError).toBe("function");
   });
 
   it("defines typed queue payload shapes for library jobs", () => {
     const scanPayload: ScanLibraryRootJobPayload = {
       libraryRootId: "root-1",
+    };
+    const scanWithTrigger: ScanLibraryRootJobPayload = {
+      libraryRootId: "root-2",
+      scanMode: "FULL",
+      scanTrigger: "manual",
     };
     const hashPayload: HashFileAssetJobPayload = {
       fileAssetId: "file-1",
@@ -139,6 +143,7 @@ describe("shared queue helpers", () => {
     expect(matchSuggestionsPayload).toEqual({ fileAssetId: "file-1" });
     expect(refreshPayload).toEqual({ workId: "work-1" });
     expect(scanPayload).toEqual({ libraryRootId: "root-1" });
+    expect(scanWithTrigger).toEqual({ libraryRootId: "root-2", scanMode: "FULL", scanTrigger: "manual" });
     expect(hashPayload).toEqual({
       fileAssetId: "file-1",
       forceFullHash: true,

--- a/packages/shared/src/queue-client.test.ts
+++ b/packages/shared/src/queue-client.test.ts
@@ -149,18 +149,13 @@ describe("enqueueLibraryJob", () => {
     expect(jobId).toBe("unknown");
   });
 
-  it("passes parent and removeDependencyOnFailure options to Queue.add", async () => {
-    addMock.mockResolvedValueOnce({ id: "child-1" });
+  it("passes parent and removeDependencyOnFailure when opts.parent is provided", async () => {
+    addMock.mockResolvedValueOnce({ id: "job-parent" });
     const { enqueueLibraryJob, LIBRARY_JOB_NAMES, RETRY_CONFIG } = await import("./index");
 
-    await enqueueLibraryJob(
-      LIBRARY_JOB_NAMES.HASH_FILE_ASSET,
-      { fileAssetId: "file-1" },
-      {
-        parent: { id: "parent-job-1", queue: "bull:library" },
-        removeDependencyOnFailure: true,
-      },
-    );
+    await enqueueLibraryJob(LIBRARY_JOB_NAMES.HASH_FILE_ASSET, {
+      fileAssetId: "file-1",
+    }, { parent: { id: "scan-1", queue: "bull:library" } });
 
     const config = RETRY_CONFIG[LIBRARY_JOB_NAMES.HASH_FILE_ASSET];
     expect(addMock).toHaveBeenCalledWith(
@@ -170,7 +165,7 @@ describe("enqueueLibraryJob", () => {
         attempts: config.attempts,
         backoff: config.backoff,
         priority: expect.any(Number) as unknown,
-        parent: { id: "parent-job-1", queue: "bull:library" },
+        parent: { id: "scan-1", queue: "bull:library" },
         removeDependencyOnFailure: true,
       },
     );
@@ -312,6 +307,90 @@ describe("getLibraryJobSnapshot", () => {
       lastActivityAt: 150,
       state: "waiting-children",
       progress: { processedFiles: 10, scanStage: "PROCESSING" },
+    });
+  });
+
+  it("does not flag waiting-children when failed descendant has retries remaining", async () => {
+    getJobMock.mockImplementation((jobId: string) => {
+      if (jobId === "job-123") {
+        return {
+          finishedOn: 0,
+          getState: vi.fn().mockResolvedValue("waiting-children"),
+          getDependencies: vi.fn().mockResolvedValue({
+            unprocessed: ["bull:library:child-1"],
+            failed: [],
+          }),
+          processedOn: 100,
+          progress: { processedFiles: 10 },
+          timestamp: 50,
+        };
+      }
+
+      if (jobId === "child-1") {
+        return {
+          finishedOn: 0,
+          getState: vi.fn().mockResolvedValue("failed"),
+          getDependencies: vi.fn(),
+          processedOn: 150,
+          progress: 0,
+          timestamp: 120,
+          attemptsMade: 1,
+          opts: { attempts: 3 },
+        };
+      }
+
+      return null;
+    });
+
+    const { getLibraryJobSnapshot } = await import("./index");
+
+    await expect(getLibraryJobSnapshot("job-123")).resolves.toEqual({
+      blockedByFailedChild: false,
+      lastActivityAt: 150,
+      state: "waiting-children",
+      progress: { processedFiles: 10 },
+    });
+  });
+
+  it("flags waiting-children when failed descendant has exhausted all retries", async () => {
+    getJobMock.mockImplementation((jobId: string) => {
+      if (jobId === "job-123") {
+        return {
+          finishedOn: 0,
+          getState: vi.fn().mockResolvedValue("waiting-children"),
+          getDependencies: vi.fn().mockResolvedValue({
+            unprocessed: ["bull:library:child-1"],
+            failed: [],
+          }),
+          processedOn: 100,
+          progress: { processedFiles: 10 },
+          timestamp: 50,
+        };
+      }
+
+      if (jobId === "child-1") {
+        return {
+          finishedOn: 0,
+          getState: vi.fn().mockResolvedValue("failed"),
+          getDependencies: vi.fn(),
+          processedOn: 150,
+          progress: 0,
+          timestamp: 120,
+          attemptsMade: 3,
+          opts: { attempts: 3 },
+        };
+      }
+
+      return null;
+    });
+
+    const { getLibraryJobSnapshot } = await import("./index");
+
+    await expect(getLibraryJobSnapshot("job-123")).resolves.toEqual({
+      blockedByFailedChild: true,
+      lastActivityAt: 150,
+      state: "waiting-children",
+      progress: { processedFiles: 10 },
     });
   });
 

--- a/packages/shared/src/queue-client.ts
+++ b/packages/shared/src/queue-client.ts
@@ -24,9 +24,9 @@ function getQueue(): Queue {
   return queueSingleton.queue;
 }
 
+
 export interface EnqueueJobOpts {
   parent?: { id: string; queue: string };
-  removeDependencyOnFailure?: boolean;
 }
 
 export async function obliterateLibraryQueue(): Promise<void> {
@@ -97,10 +97,16 @@ async function getDescendantStatus(jobId: string): Promise<{
 
     const currentState = await currentJob.getState();
     if (currentState === "failed") {
-      return {
-        blockedByFailedChild: true,
-        lastActivityAt,
-      };
+      const maxAttempts = (currentJob as { opts?: { attempts?: number } }).opts?.attempts ?? 1;
+      const attemptsMade = (currentJob as { attemptsMade?: number }).attemptsMade ?? maxAttempts;
+      if (attemptsMade >= maxAttempts) {
+        return {
+          blockedByFailedChild: true,
+          lastActivityAt,
+        };
+      }
+      // Child has retries remaining — not permanently failed
+      continue;
     }
 
     if (currentState !== "waiting-children") {
@@ -157,7 +163,7 @@ export async function getLibraryJobSnapshot(
   };
 }
 
-const LIVE_IMPORT_JOB_SCAN_STATES = ["active", "prioritized", "waiting", "waiting-children"] as const;
+const LIVE_IMPORT_JOB_SCAN_STATES = ["active", "prioritized", "waiting", "waiting-children", "delayed"] as const;
 const LIVE_IMPORT_JOB_BATCH_SIZE = 500;
 
 export async function getImportJobLiveActivity(
@@ -215,7 +221,10 @@ export async function enqueueLibraryJob<TName extends LibraryJobName>(
       attempts: retryConfig.attempts,
       backoff: retryConfig.backoff,
       priority: JOB_PRIORITY[jobName],
-      ...opts,
+      ...(opts?.parent ? {
+        parent: opts.parent,
+        removeDependencyOnFailure: true,
+      } : {}),
     });
     const jobId = job.id ?? "unknown";
     logger.info({ jobName, jobId }, "Job enqueued");

--- a/packages/shared/src/queues.ts
+++ b/packages/shared/src/queues.ts
@@ -15,12 +15,15 @@ export const LIBRARY_JOB_NAMES = {
 
 export interface BaseJobPayload {
   importJobId?: string;
+  scanJobId?: string;
+  scanQueueName?: string;
   step?: string;
 }
 
 export interface ScanLibraryRootJobPayload extends BaseJobPayload {
   libraryRootId: string;
   scanMode?: "FULL" | "INCREMENTAL";
+  scanTrigger?: "manual" | "scheduled";
 }
 
 export interface HashFileAssetJobPayload extends BaseJobPayload {

--- a/workers/library-worker/src/index.test.ts
+++ b/workers/library-worker/src/index.test.ts
@@ -21,10 +21,6 @@ const matchSuggestionsMock = vi.fn();
 const importJobUpdateMock = vi.fn();
 const importJobUpdateManyMock = vi.fn();
 const appSettingFindUniqueMock = vi.fn();
-const moveToWaitingChildrenMock = vi.fn();
-const getDependenciesCountMock = vi.fn();
-const removeChildDependencyMock = vi.fn();
-const updateDataMock = vi.fn();
 const enqueueLibraryJobMock = vi.fn();
 
 vi.mock("ioredis", () => ({
@@ -39,7 +35,7 @@ vi.mock("ioredis", () => ({
 
 class FakeWaitingChildrenError extends Error {
   constructor() {
-    super("WaitingChildren");
+    super("WaitingChildrenError");
     this.name = "WaitingChildrenError";
   }
 }
@@ -123,17 +119,18 @@ vi.mock("@bookhouse/shared", async () => {
   };
 });
 
+const moveToWaitingChildrenMock = vi.fn().mockResolvedValue(false);
+const updateDataMock = vi.fn().mockResolvedValue(undefined);
+
 function createMockJob(overrides: Record<string, unknown> = {}) {
   return {
     id: "job-1",
     opts: { attempts: 1 },
     queueQualifiedName: "bull:library",
     attemptsMade: 0,
-    moveToWaitingChildren: moveToWaitingChildrenMock,
-    getDependenciesCount: getDependenciesCountMock,
-    removeChildDependency: removeChildDependencyMock,
-    updateData: updateDataMock,
     updateProgress: vi.fn(),
+    moveToWaitingChildren: moveToWaitingChildrenMock,
+    updateData: updateDataMock,
     ...overrides,
   };
 }
@@ -151,17 +148,6 @@ beforeEach(() => {
   importJobUpdateManyMock.mockResolvedValue({ count: 0 });
   enqueueLibraryJobMock.mockReset();
   matchFileAssetToEditionMock.mockReset();
-  moveToWaitingChildrenMock.mockReset();
-  moveToWaitingChildrenMock.mockResolvedValue(false);
-  getDependenciesCountMock.mockReset();
-  getDependenciesCountMock.mockResolvedValue({
-    processed: 0,
-    unprocessed: 0,
-    ignored: 0,
-    failed: 0,
-  });
-  removeChildDependencyMock.mockReset();
-  removeChildDependencyMock.mockResolvedValue(undefined);
   onMock.mockReset();
   parseFileAssetMetadataMock.mockReset();
   processCoverForWorkMock.mockReset();
@@ -169,12 +155,14 @@ beforeEach(() => {
   queueConnectionConfigMock.mockClear();
   redisConstructorMock.mockClear();
   scanLibraryRootMock.mockReset();
-  updateDataMock.mockReset();
-  updateDataMock.mockResolvedValue(undefined);
   workFindUniqueMock.mockReset();
   externalLinkUpsertMock.mockReset();
   workerCloseMock.mockReset();
   workerConstructorMock.mockClear();
+  moveToWaitingChildrenMock.mockReset();
+  moveToWaitingChildrenMock.mockResolvedValue(false);
+  updateDataMock.mockReset();
+  updateDataMock.mockResolvedValue(undefined);
   delete process.env.COVER_CACHE_DIR;
   delete process.env.NODE_ENV;
 });
@@ -285,7 +273,7 @@ describe("library worker", () => {
     await processor(createMockJob({
       data: { libraryRootId: "root-1", scanMode: "FULL" },
       name: "scan-library-root",
-    }) as never);
+    }) as never, "test-token");
 
     expect(scanLibraryRootMock).toHaveBeenCalledWith({
       libraryRootId: "root-1",
@@ -355,7 +343,7 @@ describe("library worker", () => {
     });
   });
 
-  it("updates ImportJob to RUNNING then SUCCEEDED when importJobId is present and no children", async () => {
+  it("updates ImportJob to RUNNING when importJobId is present on scan job", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({
       hashFileAsset: hashFileAssetMock,
@@ -374,7 +362,7 @@ describe("library worker", () => {
       data: { libraryRootId: "root-1", importJobId: "ij-1" },
       name: "scan-library-root",
       attemptsMade: 1,
-    }) as never);
+    }) as never, "test-token");
 
     expect(importJobUpdateMock).toHaveBeenCalledTimes(2);
     expect(importJobUpdateMock).toHaveBeenNthCalledWith(1, {
@@ -385,188 +373,6 @@ describe("library worker", () => {
       where: { id: "ij-1", status: "RUNNING" },
       data: { status: "SUCCEEDED", finishedAt: expect.any(Date) as unknown, scanStage: null, bullmqJobId: null },
     });
-  });
-
-  it("completes immediately when dependency counts omit unprocessed", async () => {
-    const { createLibraryWorkerProcessor } = await import("./index");
-    const processor = createLibraryWorkerProcessor({
-      hashFileAsset: hashFileAssetMock,
-      matchFileAssetToEdition: matchFileAssetToEditionMock,
-      parseFileAssetMetadata: parseFileAssetMetadataMock,
-      processCoverForWork: processCoverForWorkMock,
-      scanLibraryRoot: scanLibraryRootMock,
-      enrichWork: enrichWorkMock,
-      detectDuplicates: detectDuplicatesMock,
-      matchSuggestions: matchSuggestionsMock,
-    });
-
-    scanLibraryRootMock.mockResolvedValueOnce({ missingFileAssetIds: [] });
-    getDependenciesCountMock.mockResolvedValueOnce({});
-
-    await expect(processor(createMockJob({
-      data: { libraryRootId: "root-1", importJobId: "ij-no-unprocessed" },
-      name: "scan-library-root",
-      attemptsMade: 1,
-    }) as never)).resolves.toEqual({ missingFileAssetIds: [] });
-
-    expect(importJobUpdateMock).toHaveBeenNthCalledWith(2, {
-      where: { id: "ij-no-unprocessed", status: "RUNNING" },
-      data: { status: "SUCCEEDED", finishedAt: expect.any(Date) as unknown, scanStage: null, bullmqJobId: null },
-    });
-  });
-
-  it("waits for children when moveToWaitingChildren returns true", async () => {
-    const { createLibraryWorkerProcessor } = await import("./index");
-    const processor = createLibraryWorkerProcessor({
-      hashFileAsset: hashFileAssetMock,
-      matchFileAssetToEdition: matchFileAssetToEditionMock,
-      parseFileAssetMetadata: parseFileAssetMetadataMock,
-      processCoverForWork: processCoverForWorkMock,
-      scanLibraryRoot: scanLibraryRootMock,
-      enrichWork: enrichWorkMock,
-      detectDuplicates: detectDuplicatesMock,
-      matchSuggestions: matchSuggestionsMock,
-    });
-
-    scanLibraryRootMock.mockResolvedValueOnce({ missingFileAssetIds: [] });
-    moveToWaitingChildrenMock.mockResolvedValueOnce(true);
-
-    await expect(
-      processor(
-        createMockJob({
-          data: { libraryRootId: "root-1", importJobId: "ij-wait" },
-          name: "scan-library-root",
-          attemptsMade: 0,
-        }) as never,
-        "lock-token-1",
-      ),
-    ).rejects.toThrow(FakeWaitingChildrenError);
-
-    // RUNNING should be set but NOT SUCCEEDED
-    expect(importJobUpdateMock).toHaveBeenCalledTimes(1);
-    expect(importJobUpdateMock).toHaveBeenCalledWith({
-      where: { id: "ij-wait" },
-      data: { status: "RUNNING", startedAt: expect.any(Date) as unknown, attemptsMade: 0 },
-    });
-
-    // moveToWaitingChildren should be called with the token
-    expect(moveToWaitingChildrenMock).toHaveBeenCalledWith("lock-token-1");
-    // updateData should set step to waiting-children
-    expect(updateDataMock).toHaveBeenCalledWith(
-      expect.objectContaining({ step: "waiting-children" }),
-    );
-  });
-
-  it("waits for children when unresolved dependencies remain even if moveToWaitingChildren returns false", async () => {
-    const { createLibraryWorkerProcessor } = await import("./index");
-    const processor = createLibraryWorkerProcessor({
-      hashFileAsset: hashFileAssetMock,
-      matchFileAssetToEdition: matchFileAssetToEditionMock,
-      parseFileAssetMetadata: parseFileAssetMetadataMock,
-      processCoverForWork: processCoverForWorkMock,
-      scanLibraryRoot: scanLibraryRootMock,
-      enrichWork: enrichWorkMock,
-      detectDuplicates: detectDuplicatesMock,
-      matchSuggestions: matchSuggestionsMock,
-    });
-
-    scanLibraryRootMock.mockResolvedValueOnce({ missingFileAssetIds: [] });
-    moveToWaitingChildrenMock.mockResolvedValueOnce(false);
-    getDependenciesCountMock.mockResolvedValueOnce({
-      processed: 0,
-      unprocessed: 1,
-      ignored: 0,
-      failed: 0,
-    });
-
-    await expect(
-      processor(
-        createMockJob({
-          data: { libraryRootId: "root-1", importJobId: "ij-wait-deps" },
-          name: "scan-library-root",
-          attemptsMade: 0,
-        }) as never,
-        "lock-token-2",
-      ),
-    ).rejects.toThrow(FakeWaitingChildrenError);
-
-    expect(importJobUpdateMock).toHaveBeenCalledTimes(1);
-    expect(importJobUpdateMock).toHaveBeenCalledWith({
-      where: { id: "ij-wait-deps" },
-      data: { status: "RUNNING", startedAt: expect.any(Date) as unknown, attemptsMade: 0 },
-    });
-  });
-
-  it("marks ImportJob SUCCEEDED and clears scanStage in completion phase (step=waiting-children)", async () => {
-    const { createLibraryWorkerProcessor } = await import("./index");
-    const processor = createLibraryWorkerProcessor({
-      hashFileAsset: hashFileAssetMock,
-      matchFileAssetToEdition: matchFileAssetToEditionMock,
-      parseFileAssetMetadata: parseFileAssetMetadataMock,
-      processCoverForWork: processCoverForWorkMock,
-      scanLibraryRoot: scanLibraryRootMock,
-      enrichWork: enrichWorkMock,
-      detectDuplicates: detectDuplicatesMock,
-      matchSuggestions: matchSuggestionsMock,
-    });
-
-    await processor(createMockJob({
-      data: { libraryRootId: "root-1", importJobId: "ij-complete", step: "waiting-children" },
-      name: "scan-library-root",
-      attemptsMade: 0,
-    }) as never);
-
-    // Should mark SUCCEEDED without dispatching the handler
-    expect(scanLibraryRootMock).not.toHaveBeenCalled();
-    expect(importJobUpdateMock).toHaveBeenCalledTimes(1);
-    expect(importJobUpdateMock).toHaveBeenCalledWith({
-      where: { id: "ij-complete", status: "RUNNING" },
-      data: { status: "SUCCEEDED", finishedAt: expect.any(Date) as unknown, scanStage: null, bullmqJobId: null },
-    });
-  });
-
-  it("returns without ImportJob update in completion phase when importJobId is absent", async () => {
-    const { createLibraryWorkerProcessor } = await import("./index");
-    const processor = createLibraryWorkerProcessor({
-      hashFileAsset: hashFileAssetMock,
-      matchFileAssetToEdition: matchFileAssetToEditionMock,
-      parseFileAssetMetadata: parseFileAssetMetadataMock,
-      processCoverForWork: processCoverForWorkMock,
-      scanLibraryRoot: scanLibraryRootMock,
-      enrichWork: enrichWorkMock,
-      detectDuplicates: detectDuplicatesMock,
-      matchSuggestions: matchSuggestionsMock,
-    });
-
-    await processor(createMockJob({
-      data: { fileAssetId: "file-1", step: "waiting-children" },
-      name: "hash-file-asset",
-    }) as never);
-
-    expect(hashFileAssetMock).not.toHaveBeenCalled();
-    expect(importJobUpdateMock).not.toHaveBeenCalled();
-  });
-
-  it("does not mark the parent ImportJob SUCCEEDED when a child job completes its own waiting-children phase", async () => {
-    const { createLibraryWorkerProcessor } = await import("./index");
-    const processor = createLibraryWorkerProcessor({
-      hashFileAsset: hashFileAssetMock,
-      matchFileAssetToEdition: matchFileAssetToEditionMock,
-      parseFileAssetMetadata: parseFileAssetMetadataMock,
-      processCoverForWork: processCoverForWorkMock,
-      scanLibraryRoot: scanLibraryRootMock,
-      enrichWork: enrichWorkMock,
-      detectDuplicates: detectDuplicatesMock,
-      matchSuggestions: matchSuggestionsMock,
-    });
-
-    await processor(createMockJob({
-      data: { fileAssetId: "file-1", importJobId: "ij-child", step: "waiting-children" },
-      name: "match-file-asset-to-edition",
-    }) as never);
-
-    expect(matchFileAssetToEditionMock).not.toHaveBeenCalled();
-    expect(importJobUpdateMock).not.toHaveBeenCalled();
   });
 
   it("does not set RUNNING or update parent progress for child jobs with importJobId", async () => {
@@ -636,7 +442,7 @@ describe("library worker", () => {
         data: { libraryRootId: "root-1", importJobId: "ij-2" },
         name: "scan-library-root",
         attemptsMade: 2,
-      }) as never),
+      }) as never, "test-token"),
     ).rejects.toThrow("Disk full");
 
     expect(importJobUpdateMock).toHaveBeenCalledTimes(2);
@@ -673,7 +479,7 @@ describe("library worker", () => {
         data: { libraryRootId: "root-1", importJobId: "ij-3" },
         name: "scan-library-root",
         attemptsMade: 1,
-      }) as never),
+      }) as never, "test-token"),
     ).rejects.toBe("plain string error");
 
     expect(importJobUpdateMock).toHaveBeenNthCalledWith(2, {
@@ -708,7 +514,7 @@ describe("library worker", () => {
       data: { libraryRootId: "root-1" },
       name: "scan-library-root",
       attemptsMade: 0,
-    }) as never);
+    }) as never, "test-token");
 
     expect(importJobUpdateMock).not.toHaveBeenCalled();
   });
@@ -740,7 +546,7 @@ describe("library worker", () => {
       name: "scan-library-root",
       attemptsMade: 0,
       updateProgress: updateProgressMock,
-    }) as never);
+    }) as never, "test-token");
 
     // importJob.update should have been called: RUNNING, progress(totalFiles), progress(processedFiles), SUCCEEDED
     expect(importJobUpdateMock).toHaveBeenCalledWith({
@@ -750,6 +556,10 @@ describe("library worker", () => {
     expect(importJobUpdateMock).toHaveBeenCalledWith({
       where: { id: "ij-progress" },
       data: { processedFiles: 50, errorCount: 1 },
+    });
+    expect(importJobUpdateMock).toHaveBeenCalledWith({
+      where: { id: "ij-progress", status: "RUNNING" },
+      data: { status: "SUCCEEDED", finishedAt: expect.any(Date) as unknown, scanStage: null, bullmqJobId: null },
     });
     // job.updateProgress should have been called for each progress report
     expect(updateProgressMock).toHaveBeenCalledWith({ totalFiles: 100 });
@@ -772,11 +582,7 @@ describe("library worker", () => {
     importJobUpdateMock
       .mockResolvedValueOnce({})
       .mockRejectedValueOnce(new Error("progress db down"))
-      .mockResolvedValueOnce({
-        status: "SUCCEEDED",
-        finishedAt: new Date(),
-        scanStage: null,
-      });
+      .mockResolvedValueOnce({});
 
     scanLibraryRootMock.mockImplementationOnce(async (input: { reportProgress?: (data: unknown) => Promise<void> }) => {
       await input.reportProgress?.({ processedFiles: 50, errorCount: 1, scanStage: "PROCESSING" });
@@ -788,7 +594,7 @@ describe("library worker", () => {
         data: { libraryRootId: "root-1", importJobId: "ij-progress-fail" },
         name: "scan-library-root",
         attemptsMade: 0,
-      }) as never),
+      }) as never, "test-token"),
     ).resolves.toEqual({ missingFileAssetIds: [] });
   });
 
@@ -811,7 +617,7 @@ describe("library worker", () => {
       data: { libraryRootId: "root-1" },
       name: "scan-library-root",
       attemptsMade: 0,
-    }) as never);
+    }) as never, "test-token");
 
     // scanLibraryRoot should be called WITHOUT reportProgress
     expect(scanLibraryRootMock).toHaveBeenCalledWith({ libraryRootId: "root-1" });
@@ -936,14 +742,14 @@ describe("library worker", () => {
       name: "scan-library-root",
       id: "scan-job-42",
       queueQualifiedName: "bull:library",
-    }) as never);
+    }) as never, "test-token");
 
     expect(createIngestServicesMock).toHaveBeenCalledTimes(1);
     const createArgs = createIngestServicesMock.mock.calls[0] as [{ enqueueLibraryJob: unknown }];
     expect(createArgs[0]).toHaveProperty("enqueueLibraryJob");
   });
 
-  it("wrapped enqueue passes parent without removeDependencyOnFailure to enqueueLibraryJob", async () => {
+  it("wrapped enqueue passes payload with scanJobId/scanQueueName and parent option to enqueueLibraryJob", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const { enqueueLibraryJob: enqueueLibraryJobMock } = await import("@bookhouse/shared");
     const processor = createLibraryWorkerProcessor();
@@ -955,25 +761,23 @@ describe("library worker", () => {
       name: "scan-library-root",
       id: "scan-job-42",
       queueQualifiedName: "bull:library",
-    }) as never);
+    }) as never, "test-token");
 
     // Get the wrapped enqueue from the createIngestServices call
     const createArgs = createIngestServicesMock.mock.calls[0] as [{ enqueueLibraryJob: (name: string, payload: unknown) => Promise<void> }];
     const wrappedEnqueue = createArgs[0].enqueueLibraryJob;
 
-    // Call the wrapped enqueue and verify it adds parent options
+    // Call the wrapped enqueue and verify it passes scanJobId, scanQueueName and parent option
     await wrappedEnqueue("hash-file-asset", { fileAssetId: "file-1" });
 
     expect(enqueueLibraryJobMock).toHaveBeenCalledWith(
       "hash-file-asset",
-      { fileAssetId: "file-1" },
-      {
-        parent: { id: "scan-job-42", queue: "bull:library" },
-      },
+      { fileAssetId: "file-1", scanJobId: "scan-job-42", scanQueueName: "bull:library" },
+      { parent: { id: "scan-job-42", queue: "bull:library" } },
     );
   });
 
-  it("wrapped enqueue falls back to empty string when job.id is undefined", async () => {
+  it("wrapped enqueue uses empty string for scanJobId when job.id is undefined", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const { enqueueLibraryJob: enqueueLibraryJobMock } = await import("@bookhouse/shared");
     const processor = createLibraryWorkerProcessor();
@@ -985,7 +789,7 @@ describe("library worker", () => {
       name: "scan-library-root",
       id: undefined,
       queueQualifiedName: "bull:library",
-    }) as never);
+    }) as never, "test-token");
 
     const createArgs = createIngestServicesMock.mock.calls[0] as [{ enqueueLibraryJob: (name: string, payload: unknown) => Promise<void> }];
     const wrappedEnqueue = createArgs[0].enqueueLibraryJob;
@@ -994,10 +798,8 @@ describe("library worker", () => {
 
     expect(enqueueLibraryJobMock).toHaveBeenCalledWith(
       "hash-file-asset",
-      { fileAssetId: "file-1" },
-      {
-        parent: { id: "", queue: "bull:library" },
-      },
+      { fileAssetId: "file-1", scanJobId: "", scanQueueName: "bull:library" },
+      { parent: { id: "", queue: "bull:library" } },
     );
   });
 
@@ -1013,7 +815,7 @@ describe("library worker", () => {
       name: "scan-library-root",
       id: "scan-job-42",
       queueQualifiedName: "bull:library",
-    }) as never);
+    }) as never, "test-token");
 
     const createArgs = createIngestServicesMock.mock.calls[0] as [{ enqueueLibraryJob: (name: string, payload: unknown) => Promise<void> }];
     const wrappedEnqueue = createArgs[0].enqueueLibraryJob;
@@ -1022,38 +824,8 @@ describe("library worker", () => {
 
     expect(enqueueLibraryJobMock).toHaveBeenCalledWith(
       "hash-file-asset",
-      { fileAssetId: "file-1", importJobId: "ij-42" },
-      {
-        parent: { id: "scan-job-42", queue: "bull:library" },
-      },
-    );
-  });
-
-  it("wrapped enqueue does not inject importJobId when parent lacks it", async () => {
-    const { createLibraryWorkerProcessor } = await import("./index");
-    const { enqueueLibraryJob: enqueueLibraryJobMock } = await import("@bookhouse/shared");
-    const processor = createLibraryWorkerProcessor();
-
-    scanLibraryRootMock.mockResolvedValueOnce({ missingFileAssetIds: [] });
-
-    await processor(createMockJob({
-      data: { libraryRootId: "root-1" },
-      name: "scan-library-root",
-      id: "scan-job-42",
-      queueQualifiedName: "bull:library",
-    }) as never);
-
-    const createArgs = createIngestServicesMock.mock.calls[0] as [{ enqueueLibraryJob: (name: string, payload: unknown) => Promise<void> }];
-    const wrappedEnqueue = createArgs[0].enqueueLibraryJob;
-
-    await wrappedEnqueue("hash-file-asset", { fileAssetId: "file-1" });
-
-    expect(enqueueLibraryJobMock).toHaveBeenCalledWith(
-      "hash-file-asset",
-      { fileAssetId: "file-1" },
-      {
-        parent: { id: "scan-job-42", queue: "bull:library" },
-      },
+      { fileAssetId: "file-1", importJobId: "ij-42", scanJobId: "scan-job-42", scanQueueName: "bull:library" },
+      { parent: { id: "scan-job-42", queue: "bull:library" } },
     );
   });
 
@@ -1075,7 +847,7 @@ describe("library worker", () => {
     await processor(createMockJob({
       data: { libraryRootId: "root-1", importJobId: "ij-new" },
       name: "scan-library-root",
-    }) as never);
+    }) as never, "test-token");
 
     expect(importJobUpdateManyMock).toHaveBeenCalledWith({
       where: {
@@ -1113,7 +885,7 @@ describe("library worker", () => {
     await processor(createMockJob({
       data: { libraryRootId: "root-1", importJobId: "ij-1" },
       name: "scan-library-root",
-    }) as never);
+    }) as never, "test-token");
 
     expect(appSettingFindUniqueMock).toHaveBeenCalledWith({ where: { key: "missingFileBehavior" } });
     expect(cascadeCleanupOrphansMock).toHaveBeenCalledWith(
@@ -1142,7 +914,7 @@ describe("library worker", () => {
     await processor(createMockJob({
       data: { libraryRootId: "root-1", importJobId: "ij-1" },
       name: "scan-library-root",
-    }) as never);
+    }) as never, "test-token");
 
     expect(cascadeCleanupOrphansMock).not.toHaveBeenCalled();
   });
@@ -1165,12 +937,81 @@ describe("library worker", () => {
     await processor(createMockJob({
       data: { libraryRootId: "root-1", importJobId: "ij-1" },
       name: "scan-library-root",
-    }) as never);
+    }) as never, "test-token");
 
     expect(cascadeCleanupOrphansMock).not.toHaveBeenCalled();
   });
 
-  it("calls moveToWaitingChildren and updateData after dispatch", async () => {
+  it("enters completion phase when step is waiting-children and marks SUCCEEDED for scan with importJobId", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      enrichWork: enrichWorkMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+
+    await processor(createMockJob({
+      data: { libraryRootId: "root-1", importJobId: "ij-complete", step: "waiting-children" },
+      name: "scan-library-root",
+    }) as never, "test-token");
+
+    expect(scanLibraryRootMock).not.toHaveBeenCalled();
+    expect(importJobUpdateMock).toHaveBeenCalledWith({
+      where: { id: "ij-complete", status: "RUNNING" },
+      data: { status: "SUCCEEDED", finishedAt: expect.any(Date) as unknown, scanStage: null, bullmqJobId: null },
+    });
+  });
+
+  it("skips activeScanType reset in completion phase for non-scan jobs", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      enrichWork: enrichWorkMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+
+    await processor(createMockJob({
+      data: { fileAssetId: "file-1", step: "waiting-children" },
+      name: "hash-file-asset",
+    }) as never, "test-token");
+
+    expect(hashFileAssetMock).not.toHaveBeenCalled();
+    expect(importJobUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("enters completion phase without updating ImportJob when importJobId is absent", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      enrichWork: enrichWorkMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+
+    await processor(createMockJob({
+      data: { libraryRootId: "root-1", step: "waiting-children" },
+      name: "scan-library-root",
+    }) as never, "test-token");
+
+    expect(scanLibraryRootMock).not.toHaveBeenCalled();
+    expect(importJobUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it("calls moveToWaitingChildren and throws WaitingChildrenError when shouldWait is true", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({
       hashFileAsset: hashFileAssetMock,
@@ -1184,20 +1025,50 @@ describe("library worker", () => {
     });
 
     scanLibraryRootMock.mockResolvedValueOnce({ missingFileAssetIds: [] });
+    moveToWaitingChildrenMock.mockResolvedValueOnce(true);
 
-    await processor(
-      createMockJob({
-        data: { libraryRootId: "root-1" },
+    await expect(
+      processor(createMockJob({
+        data: { libraryRootId: "root-1", importJobId: "ij-wait" },
         name: "scan-library-root",
-      }) as never,
-      "my-token",
-    );
+      }) as never, "test-token"),
+    ).rejects.toThrow("WaitingChildrenError");
 
     expect(updateDataMock).toHaveBeenCalledWith({
       libraryRootId: "root-1",
+      importJobId: "ij-wait",
       step: "waiting-children",
     });
-    expect(moveToWaitingChildrenMock).toHaveBeenCalledWith("my-token");
+    expect(moveToWaitingChildrenMock).toHaveBeenCalledWith("test-token");
+  });
+
+  it("re-throws WaitingChildrenError without marking ImportJob FAILED", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      enrichWork: enrichWorkMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+
+    scanLibraryRootMock.mockResolvedValueOnce({ missingFileAssetIds: [] });
+    moveToWaitingChildrenMock.mockResolvedValueOnce(true);
+
+    await expect(
+      processor(createMockJob({
+        data: { libraryRootId: "root-1", importJobId: "ij-wait-rethrow" },
+        name: "scan-library-root",
+      }) as never, "test-token"),
+    ).rejects.toThrow("WaitingChildrenError");
+
+    // Should NOT have written FAILED — only RUNNING was written
+    expect(importJobUpdateMock).not.toHaveBeenCalledWith(expect.objectContaining({
+      data: expect.objectContaining({ status: "FAILED" }) as unknown,
+    }));
   });
 
   it("marks the parent scan FAILED when a child job exhausts retries", async () => {
@@ -1220,7 +1091,6 @@ describe("library worker", () => {
         data: { fileAssetId: "file-1", importJobId: "ij-child-fail" },
         opts: { attempts: 1 },
         name: "hash-file-asset",
-        parentKey: "bull:library:parent-final",
       }) as never),
     ).rejects.toThrow("hash failed");
 
@@ -1234,7 +1104,6 @@ describe("library worker", () => {
         bullmqJobId: null,
       },
     });
-    expect(removeChildDependencyMock).toHaveBeenCalledTimes(1);
   });
 
   it("records String(error) for final child job failures when opts are missing", async () => {
@@ -1257,7 +1126,6 @@ describe("library worker", () => {
         data: { fileAssetId: "file-1", importJobId: "ij-child-string-fail" },
         name: "hash-file-asset",
         opts: {},
-        parentKey: "bull:library:parent-string",
       }) as never),
     ).rejects.toBe("plain child failure");
 
@@ -1273,7 +1141,7 @@ describe("library worker", () => {
     });
   });
 
-  it("does not remove a parent dependency when a final child failure has no parentKey", async () => {
+  it("marks ImportJob FAILED for final child failure", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({
       hashFileAsset: hashFileAssetMock,
@@ -1306,10 +1174,9 @@ describe("library worker", () => {
         bullmqJobId: null,
       },
     });
-    expect(removeChildDependencyMock).not.toHaveBeenCalled();
   });
 
-  it("does not remove a parent dependency for non-final child failures", async () => {
+  it("does not mark ImportJob FAILED for non-final child failures", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({
       hashFileAsset: hashFileAssetMock,
@@ -1330,14 +1197,12 @@ describe("library worker", () => {
         opts: { attempts: 3 },
         attemptsMade: 0,
         name: "hash-file-asset",
-        parentKey: "bull:library:parent-1",
       }) as never),
     ).rejects.toThrow("transient");
 
     expect(importJobUpdateMock).not.toHaveBeenCalledWith(expect.objectContaining({
       where: expect.objectContaining({ id: "ij-child-retry" }) as unknown,
     }));
-    expect(removeChildDependencyMock).not.toHaveBeenCalled();
   });
 
   it("creates and shuts down a redis-backed worker", async () => {
@@ -1404,32 +1269,30 @@ describe("library worker", () => {
     processExitSpy.mockRestore();
   });
 
-  it("polls DB for concurrency and updates worker", async () => {
+  it("polls DB for concurrency using onDemand key when no scan is active", async () => {
     vi.useFakeTimers();
-    appSettingFindUniqueMock.mockResolvedValue({ key: "workerConcurrency", value: "10" });
+    appSettingFindUniqueMock.mockResolvedValue({ key: "concurrencyOnDemand", value: "7" });
     const { createLibraryWorker, shutdownLibraryWorker } = await import("./index");
     const created = createLibraryWorker();
 
-    // Advance past the poll interval (10s)
     await vi.advanceTimersByTimeAsync(10_000);
 
-    expect(appSettingFindUniqueMock).toHaveBeenCalledWith({ where: { key: "workerConcurrency" } });
-    expect(created.worker.concurrency).toBe(10);
+    expect(appSettingFindUniqueMock).toHaveBeenCalledWith({ where: { key: "concurrencyOnDemand" } });
+    expect(created.worker.concurrency).toBe(7);
 
     await shutdownLibraryWorker(created.worker, created.connection, created.pollInterval);
     vi.useRealTimers();
   });
 
-  it("uses default concurrency when no setting exists in DB", async () => {
+  it("uses default onDemand concurrency when no setting exists in DB", async () => {
     vi.useFakeTimers();
     appSettingFindUniqueMock.mockResolvedValue(null);
-    const { createLibraryWorker, shutdownLibraryWorker } = await import("./index");
+    const { createLibraryWorker, shutdownLibraryWorker, SCAN_CONCURRENCY_DEFAULTS } = await import("./index");
     const created = createLibraryWorker();
 
     await vi.advanceTimersByTimeAsync(10_000);
 
-    // Should stay at default (5)
-    expect(created.worker.concurrency).toBe(5);
+    expect(created.worker.concurrency).toBe(SCAN_CONCURRENCY_DEFAULTS.onDemand);
 
     await shutdownLibraryWorker(created.worker, created.connection, created.pollInterval);
     vi.useRealTimers();
@@ -1447,13 +1310,116 @@ describe("library worker", () => {
   it("keeps current concurrency when DB is unavailable", async () => {
     vi.useFakeTimers();
     appSettingFindUniqueMock.mockRejectedValue(new Error("DB down"));
-    const { createLibraryWorker, shutdownLibraryWorker } = await import("./index");
+    const { createLibraryWorker, shutdownLibraryWorker, SCAN_CONCURRENCY_DEFAULTS } = await import("./index");
     const created = createLibraryWorker();
 
     await vi.advanceTimersByTimeAsync(10_000);
 
     // Should still be default concurrency
-    expect(created.worker.concurrency).toBe(5);
+    expect(created.worker.concurrency).toBe(SCAN_CONCURRENCY_DEFAULTS.onDemand);
+
+    await shutdownLibraryWorker(created.worker, created.connection, created.pollInterval);
+    vi.useRealTimers();
+  });
+
+  it("deriveScanType returns full for FULL scanMode", async () => {
+    const { deriveScanType } = await import("./index");
+    expect(deriveScanType({ libraryRootId: "r1", scanMode: "FULL" })).toBe("full");
+    expect(deriveScanType({ libraryRootId: "r1", scanMode: "FULL", scanTrigger: "manual" })).toBe("full");
+    expect(deriveScanType({ libraryRootId: "r1", scanMode: "FULL", scanTrigger: "scheduled" })).toBe("full");
+  });
+
+  it("deriveScanType returns onDemand for INCREMENTAL manual trigger", async () => {
+    const { deriveScanType } = await import("./index");
+    expect(deriveScanType({ libraryRootId: "r1", scanMode: "INCREMENTAL", scanTrigger: "manual" })).toBe("onDemand");
+    expect(deriveScanType({ libraryRootId: "r1", scanMode: "INCREMENTAL" })).toBe("onDemand");
+    expect(deriveScanType({ libraryRootId: "r1" })).toBe("onDemand");
+  });
+
+  it("deriveScanType returns incremental for INCREMENTAL scheduled trigger", async () => {
+    const { deriveScanType } = await import("./index");
+    expect(deriveScanType({ libraryRootId: "r1", scanMode: "INCREMENTAL", scanTrigger: "scheduled" })).toBe("incremental");
+    expect(deriveScanType({ libraryRootId: "r1", scanTrigger: "scheduled" })).toBe("incremental");
+  });
+
+  it("polls concurrency using active scan type when set directly", async () => {
+    appSettingFindUniqueMock.mockResolvedValue({ key: "concurrencyFull", value: "10" });
+    const { _pollConcurrency, _setActiveScanType, _getActiveScanType } = await import("./index");
+
+    _setActiveScanType("full");
+    expect(_getActiveScanType()).toBe("full");
+
+    const fakeWorker = { concurrency: 5 };
+    await _pollConcurrency(fakeWorker);
+
+    expect(appSettingFindUniqueMock).toHaveBeenCalledWith({ where: { key: "concurrencyFull" } });
+    expect(fakeWorker.concurrency).toBe(10);
+
+    _setActiveScanType(null);
+    expect(_getActiveScanType()).toBe("onDemand");
+  });
+
+  it("polls DB using concurrencyIncremental key when an incremental scan is active", async () => {
+    vi.useFakeTimers();
+    appSettingFindUniqueMock.mockImplementation((args: { where: { key: string } }) => {
+      if (args.where.key === "concurrencyIncremental") return Promise.resolve({ key: "concurrencyIncremental", value: "4" });
+      return Promise.resolve(null);
+    });
+    let resolveScan: ((v: { missingFileAssetIds: string[] }) => void) | undefined;
+    scanLibraryRootMock.mockReturnValue(new Promise((r) => { resolveScan = r; }));
+
+    const { createLibraryWorkerProcessor, createLibraryWorker, shutdownLibraryWorker } = await import("./index");
+    const created = createLibraryWorker();
+
+    const processor = createLibraryWorkerProcessor();
+    const scanPromise = processor(createMockJob({
+      data: { libraryRootId: "root-1", scanTrigger: "scheduled" },
+      name: "scan-library-root",
+    }) as never, "test-token");
+
+    // Advance to trigger the poll and flush microtasks so pollConcurrency completes
+    await vi.advanceTimersByTimeAsync(10_000);
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(appSettingFindUniqueMock).toHaveBeenCalledWith({ where: { key: "concurrencyIncremental" } });
+    expect(created.worker.concurrency).toBe(4);
+
+    if (resolveScan) resolveScan({ missingFileAssetIds: [] });
+    await scanPromise;
+
+    await shutdownLibraryWorker(created.worker, created.connection, created.pollInterval);
+    vi.useRealTimers();
+  });
+
+  it("polls DB using concurrencyFull key when a full scan is active", async () => {
+    vi.useFakeTimers();
+    appSettingFindUniqueMock.mockImplementation((args: { where: { key: string } }) => {
+      if (args.where.key === "concurrencyFull") return Promise.resolve({ key: "concurrencyFull", value: "12" });
+      return Promise.resolve(null);
+    });
+    // Make the scan hang so activeScanType stays set during the poll
+    let resolveScan: ((v: { missingFileAssetIds: string[] }) => void) | undefined;
+    scanLibraryRootMock.mockReturnValue(new Promise((r) => { resolveScan = r; }));
+
+    const { createLibraryWorkerProcessor, createLibraryWorker, shutdownLibraryWorker } = await import("./index");
+    const created = createLibraryWorker();
+
+    // Start a FULL scan (don't await — it's hanging)
+    const processor = createLibraryWorkerProcessor();
+    const scanPromise = processor(createMockJob({
+      data: { libraryRootId: "root-1", scanMode: "FULL" },
+      name: "scan-library-root",
+    }) as never, "test-token");
+
+    // Poll fires while scan is in progress
+    await vi.advanceTimersByTimeAsync(10_000);
+
+    expect(appSettingFindUniqueMock).toHaveBeenCalledWith({ where: { key: "concurrencyFull" } });
+    expect(created.worker.concurrency).toBe(12);
+
+    // Clean up: resolve the scan and await completion
+    if (resolveScan) resolveScan({ missingFileAssetIds: [] });
+    await scanPromise;
 
     await shutdownLibraryWorker(created.worker, created.connection, created.pollInterval);
     vi.useRealTimers();

--- a/workers/library-worker/src/index.ts
+++ b/workers/library-worker/src/index.ts
@@ -27,6 +27,28 @@ const logger = createLogger("library-worker");
 const processCoverForWork = processCoverForWorkDefault(db);
 const rateLimiter = new RateLimiter();
 
+export type ScanType = "full" | "onDemand" | "incremental";
+
+export const SCAN_CONCURRENCY_DEFAULTS: Record<ScanType, number> = {
+  full: 8,
+  onDemand: 5,
+  incremental: 3,
+};
+
+const SCAN_CONCURRENCY_KEYS: Record<ScanType, string> = {
+  full: "concurrencyFull",
+  onDemand: "concurrencyOnDemand",
+  incremental: "concurrencyIncremental",
+};
+
+export function deriveScanType(payload: ScanLibraryRootJobPayload): ScanType {
+  if (payload.scanMode === "FULL") return "full";
+  if (payload.scanTrigger === "scheduled") return "incremental";
+  return "onDemand";
+}
+
+let activeScanType: ScanType | null = null;
+
 function getCoverCacheDir(): string {
   if (process.env.COVER_CACHE_DIR) {
     return process.env.COVER_CACHE_DIR;
@@ -53,16 +75,25 @@ export interface LibraryWorkerHandlers {
 function createJobHandlers(
   job: Job<LibraryJobPayload<LibraryJobName>, unknown, LibraryJobName>,
 ): LibraryWorkerHandlers {
-  const parentImportJobId = (job.data as BaseJobPayload).importJobId;
+  const basePayload = job.data as BaseJobPayload;
+  const parentImportJobId = basePayload.importJobId;
+  // All descendants register the scan-library-root job as their direct parent,
+  // flattening the dependency tree to a single level so BullMQ only needs to
+  // resolve one moveToWaitingChildren call on the root scan job.
+  const scanJobId = basePayload.scanJobId ?? job.id ?? "";
+  const scanQueueName = basePayload.scanQueueName ?? job.queueQualifiedName;
   const wrappedEnqueue = async <TName extends LibraryJobName>(
     jobName: TName,
     payload: LibraryJobPayload<TName>,
   ): Promise<void> => {
-    const enrichedPayload = parentImportJobId
-      ? { ...payload, importJobId: parentImportJobId }
-      : payload;
+    const enrichedPayload: LibraryJobPayload<TName> = {
+      ...payload,
+      ...(parentImportJobId ? { importJobId: parentImportJobId } : {}),
+      scanJobId,
+      scanQueueName,
+    } as LibraryJobPayload<TName>;
     await enqueueLibraryJob(jobName, enrichedPayload, {
-      parent: { id: job.id ?? "", queue: job.queueQualifiedName },
+      parent: { id: scanJobId, queue: scanQueueName },
     });
   };
 
@@ -89,6 +120,7 @@ async function dispatch(
   switch (job.name) {
     case LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT: {
       const payload = job.data as ScanLibraryRootJobPayload;
+      activeScanType = deriveScanType(payload);
       let scanResult: ScanLibraryRootResult;
       if (importJobId) {
         const reportProgress = async (data: ScanProgressData) => {
@@ -188,14 +220,18 @@ export function createLibraryWorkerProcessor(
   const totalAttempts = job.opts.attempts ?? 1;
   const finalAttempt = job.attemptsMade + 1 >= totalAttempts;
 
-  // Completion phase — BullMQ re-activated this job after all children finished
+  // Completion phase — BullMQ re-activated the scan-root after all children finished.
+  // Only scan-root uses the step pattern; other jobs complete in a single pass.
   if ((job.data as BaseJobPayload).step === "waiting-children") {
+    logger.info({ jobId: job.id, jobName: job.name }, "All children finished, entering completion phase");
     if (importJobId && isScanJob) {
       await db.importJob.update({
         where: { id: importJobId, status: "RUNNING" },
         data: { status: "SUCCEEDED", finishedAt: new Date(), scanStage: null, bullmqJobId: null },
       });
+      logger.info({ jobId: job.id, importJobId }, "Scan marked SUCCEEDED");
     }
+    if (isScanJob) activeScanType = null;
     return;
   }
 
@@ -234,23 +270,28 @@ export function createLibraryWorkerProcessor(
     try {
       const result = await dispatch(jobHandlers, job);
 
-      // Attempt to wait for any children this job spawned
-      await job.updateData({ ...job.data, step: "waiting-children" });
-      const shouldWait = await job.moveToWaitingChildren(token ?? "");
-      const dependencyCounts = await job.getDependenciesCount();
-      if (shouldWait) {
-        throw new WaitingChildrenError();
-      }
-      if ((dependencyCounts.unprocessed ?? 0) > 0) {
-        throw new WaitingChildrenError();
-      }
+      // Only the scan root job waits for descendants — all children at every
+      // level register it as their direct parent via scanJobId/scanQueueName.
+      // Uses the BullMQ step pattern: moveToWaitingChildren + throw WaitingChildrenError.
+      // When all children complete, BullMQ re-activates the scan root and the
+      // completion phase (step === "waiting-children") fires above.
+      if (isScanJob) {
+        await job.updateData({ ...job.data, step: "waiting-children" });
+        const shouldWait = await job.moveToWaitingChildren(token ?? "");
+        if (shouldWait) {
+          logger.info({ jobId: job.id, jobName: job.name }, "Waiting for child jobs to complete");
+          throw new WaitingChildrenError();
+        }
 
-      // No children (or all already done) — complete immediately
-      if (importJobId && isScanJob) {
-        await db.importJob.update({
-          where: { id: importJobId, status: "RUNNING" },
-          data: { status: "SUCCEEDED", finishedAt: new Date(), scanStage: null, bullmqJobId: null },
-        });
+        // No children (or all already done) — complete immediately
+        if (importJobId) {
+          await db.importJob.update({
+            where: { id: importJobId, status: "RUNNING" },
+            data: { status: "SUCCEEDED", finishedAt: new Date(), scanStage: null, bullmqJobId: null },
+          });
+          logger.info({ jobId: job.id, importJobId }, "Scan completed immediately (no pending children)");
+        }
+        activeScanType = null;
       }
 
       return result;
@@ -258,7 +299,6 @@ export function createLibraryWorkerProcessor(
       if (error instanceof WaitingChildrenError) {
         throw error;
       }
-
       if (importJobId && isScanJob) {
         await db.importJob.update({
           where: { id: importJobId },
@@ -283,10 +323,8 @@ export function createLibraryWorkerProcessor(
             bullmqJobId: null,
           },
         });
-        if (job.parentKey) {
-          await job.removeChildDependency();
-        }
       }
+      if (isScanJob) activeScanType = null;
       throw error;
     }
   };
@@ -303,7 +341,6 @@ const defaultHandlers: LibraryWorkerHandlers = {
   matchSuggestions,
 };
 
-const DEFAULT_WORKER_CONCURRENCY = 5;
 const CONCURRENCY_POLL_INTERVAL_MS = 10_000;
 
 export function createLibraryWorker(
@@ -315,7 +352,7 @@ export function createLibraryWorker(
     createLibraryWorkerProcessor(handlers),
     {
       connection,
-      concurrency: DEFAULT_WORKER_CONCURRENCY,
+      concurrency: SCAN_CONCURRENCY_DEFAULTS.onDemand,
       removeOnComplete: { count: 1000 },
       removeOnFail: { count: 5000 },
     },
@@ -328,10 +365,20 @@ export function createLibraryWorker(
   return { connection, pollInterval, worker };
 }
 
+function getActiveScanType(): ScanType {
+  if (activeScanType !== null) {
+    return activeScanType;
+  }
+  return "onDemand";
+}
+
 async function pollConcurrency(worker: Pick<Worker, "concurrency">): Promise<void> {
   try {
-    const setting = await db.appSetting.findUnique({ where: { key: "workerConcurrency" } });
-    const desired = setting ? Number(setting.value) : DEFAULT_WORKER_CONCURRENCY;
+    const scanType = getActiveScanType();
+    const key = SCAN_CONCURRENCY_KEYS[scanType];
+    const defaultValue = SCAN_CONCURRENCY_DEFAULTS[scanType];
+    const setting = await db.appSetting.findUnique({ where: { key } });
+    const desired = setting ? Number(setting.value) : defaultValue;
     if (!Number.isNaN(desired) && desired >= 1 && desired <= 20 && worker.concurrency !== desired) {
       worker.concurrency = desired;
       logger.info({ concurrency: desired }, "Worker concurrency updated");
@@ -376,6 +423,13 @@ export function bootstrapLibraryWorker(): void {
 
 // Coverage: defaultHandlers referenced to ensure the import is exercised
 export { defaultHandlers as _defaultHandlers };
+
+// Exported for testing only — allows unit tests to call pollConcurrency directly
+// and set the module-level activeScanType without relying on fake timer async races.
+export { pollConcurrency as _pollConcurrency, getActiveScanType as _getActiveScanType };
+export function _setActiveScanType(scanType: ScanType | null): void {
+  activeScanType = scanType;
+}
 
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
   bootstrapLibraryWorker();


### PR DESCRIPTION
## Summary

- **Fix scan completion**: Remove BullMQ parent-child dependency mechanism which caused "pending dependencies" errors and prevented scans from completing. Replace with polling-based completion detection in `getScanProgressServerFn` — when no live BullMQ jobs remain for an ImportJob, it's marked SUCCEEDED.
- **Fix stale flicker**: Don't report `stale: true` when scan-root is in `waiting-children` state, since the `blockedByFailedChild` check already catches genuinely stuck scans.
- **Add library filter presets**: Four new filter groups in the sidebar — Enrichment, Description, Series, and ISBN — each with faceted counts and URL-persisted toggle state.
- **Per-scan-type concurrency controls** (Closes #104): Granular concurrency settings for full, on-demand, and incremental scans with sensible defaults (8/5/3), persisted in the database.
- **SSE throttling**: Throttle SSE-driven router invalidations to once per 2 seconds to prevent rapid event bursts from hammering the server.

## Test plan

- 1504 tests passing, 100% coverage
- All CI gates pass (lint, typecheck, test, build)
- Verified scan completion end-to-end with ebooks library (3400+ files)