### PR TITLE
Add per-scan-type concurrency controls and SSE throttling

### DIFF
--- a/apps/web/src/hooks/use-sse.test.ts
+++ b/apps/web/src/hooks/use-sse.test.ts
@@ -69,6 +69,41 @@ it("calling an event handler calls router.invalidate()", () => {
   expect(invalidateMock).toHaveBeenCalledTimes(1);
 });
 
+it("throttles rapid invalidations to at most once per 2 seconds", () => {
+  vi.useFakeTimers();
+  renderHook(() => { useSSE({ enabled: true }); });
+
+  // First event fires immediately
+  eventSourceListeners.get("job:completed")?.({});
+  expect(invalidateMock).toHaveBeenCalledTimes(1);
+
+  // Rapid subsequent events within the throttle window are suppressed
+  eventSourceListeners.get("job:progress")?.({});
+  eventSourceListeners.get("job:active")?.({});
+  eventSourceListeners.get("job:completed")?.({});
+  expect(invalidateMock).toHaveBeenCalledTimes(1);
+
+  // After the throttle window, a trailing call fires
+  vi.advanceTimersByTime(2000);
+  expect(invalidateMock).toHaveBeenCalledTimes(2);
+
+  vi.useRealTimers();
+});
+
+it("does not fire trailing call if no events arrived during throttle window", () => {
+  vi.useFakeTimers();
+  renderHook(() => { useSSE({ enabled: true }); });
+
+  eventSourceListeners.get("job:completed")?.({});
+  expect(invalidateMock).toHaveBeenCalledTimes(1);
+
+  // No more events — advancing past throttle window should not trigger another call
+  vi.advanceTimersByTime(2000);
+  expect(invalidateMock).toHaveBeenCalledTimes(1);
+
+  vi.useRealTimers();
+});
+
 it("does not create EventSource when enabled=false", () => {
   renderHook(() => { useSSE({ enabled: false }); });
   expect(addEventListenerMock).not.toHaveBeenCalled();
@@ -78,6 +113,27 @@ it("calls es.close() on unmount", () => {
   const { unmount } = renderHook(() => { useSSE({ enabled: true }); });
   unmount();
   expect(closeMock).toHaveBeenCalled();
+});
+
+it("cancels pending throttled call on unmount", () => {
+  vi.useFakeTimers();
+  const { unmount } = renderHook(() => { useSSE({ enabled: true }); });
+
+  // First event fires immediately
+  eventSourceListeners.get("job:completed")?.({});
+  expect(invalidateMock).toHaveBeenCalledTimes(1);
+
+  // Second event is throttled (pending)
+  eventSourceListeners.get("job:progress")?.({});
+
+  // Unmount before the trailing call fires
+  unmount();
+
+  // Advancing past throttle window should NOT trigger the pending call
+  vi.advanceTimersByTime(2000);
+  expect(invalidateMock).toHaveBeenCalledTimes(1);
+
+  vi.useRealTimers();
 });
 
 it("calling onerror does nothing (no throw)", () => {

--- a/apps/web/src/hooks/use-sse.ts
+++ b/apps/web/src/hooks/use-sse.ts
@@ -1,12 +1,37 @@
-import { useEffect } from "react";
+import { useEffect, useRef, useCallback } from "react";
 import { useRouter } from "@tanstack/react-router";
 
 interface UseSSEOptions {
   enabled?: boolean;
 }
 
+const THROTTLE_MS = 2000;
+
 export function useSSE({ enabled = true }: UseSSEOptions = {}) {
   const router = useRouter();
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingRef = useRef(false);
+  const lastCallRef = useRef(0);
+
+  const throttledInvalidate = useCallback(() => {
+    const now = Date.now();
+    const elapsed = now - lastCallRef.current;
+
+    if (elapsed >= THROTTLE_MS) {
+      lastCallRef.current = now;
+      void router.invalidate();
+    } else {
+      pendingRef.current = true;
+      if (timerRef.current === null) {
+        timerRef.current = setTimeout(() => {
+          timerRef.current = null;
+          pendingRef.current = false;
+          lastCallRef.current = Date.now();
+          void router.invalidate();
+        }, THROTTLE_MS - elapsed);
+      }
+    }
+  }, [router]);
 
   useEffect(() => {
     if (!enabled) return;
@@ -15,12 +40,8 @@ export function useSSE({ enabled = true }: UseSSEOptions = {}) {
 
     const eventTypes = ["job:completed", "job:failed", "job:active", "job:progress"];
 
-    const handler = () => {
-      void router.invalidate();
-    };
-
     for (const type of eventTypes) {
-      es.addEventListener(type, handler);
+      es.addEventListener(type, throttledInvalidate);
     }
 
     es.onerror = () => {
@@ -29,6 +50,11 @@ export function useSSE({ enabled = true }: UseSSEOptions = {}) {
 
     return () => {
       es.close();
+      if (timerRef.current !== null) {
+        clearTimeout(timerRef.current);
+        timerRef.current = null;
+      }
+      pendingRef.current = false;
     };
-  }, [enabled, router]);
+  }, [enabled, throttledInvalidate]);
 }

--- a/apps/web/src/lib/server-fns/app-settings.test.ts
+++ b/apps/web/src/lib/server-fns/app-settings.test.ts
@@ -15,62 +15,108 @@ vi.mock("@tanstack/react-start", () => ({
 }));
 
 const appSettingFindUniqueMock = vi.fn();
+const appSettingFindManyMock = vi.fn();
 const appSettingUpsertMock = vi.fn();
 
 vi.mock("@bookhouse/db", () => ({
   db: {
     appSetting: {
       findUnique: (...args: unknown[]): unknown => appSettingFindUniqueMock(...args),
+      findMany: (...args: unknown[]): unknown => appSettingFindManyMock(...args),
       upsert: (...args: unknown[]): unknown => appSettingUpsertMock(...args),
     },
   },
 }));
 
 import {
-  getWorkerConcurrencyServerFn,
-  setWorkerConcurrencyServerFn,
+  getAllScanConcurrenciesServerFn,
+  setScanConcurrencyServerFn,
   getMissingFileBehaviorServerFn,
   setMissingFileBehaviorServerFn,
   getThemeServerFn,
   setThemeServerFn,
+  SCAN_CONCURRENCY_DEFAULTS,
 } from "./app-settings";
 
 beforeEach(() => {
   appSettingFindUniqueMock.mockReset();
+  appSettingFindManyMock.mockReset();
   appSettingUpsertMock.mockReset();
 });
 
-describe("getWorkerConcurrencyServerFn", () => {
-  it("returns stored concurrency value", async () => {
-    appSettingFindUniqueMock.mockResolvedValue({ key: "workerConcurrency", value: "8" });
+describe("getAllScanConcurrenciesServerFn", () => {
+  it("returns stored values for all scan types", async () => {
+    appSettingFindManyMock.mockResolvedValue([
+      { key: "concurrencyFull", value: "10" },
+      { key: "concurrencyOnDemand", value: "6" },
+      { key: "concurrencyIncremental", value: "2" },
+    ]);
 
-    const result = await getWorkerConcurrencyServerFn({} as never);
+    const result = await getAllScanConcurrenciesServerFn({} as never);
 
-    expect(appSettingFindUniqueMock).toHaveBeenCalledWith({ where: { key: "workerConcurrency" } });
-    expect(result).toBe(8);
+    expect(appSettingFindManyMock).toHaveBeenCalledWith({
+      where: { key: { in: ["concurrencyFull", "concurrencyOnDemand", "concurrencyIncremental"] } },
+    });
+    expect(result).toEqual({ full: 10, onDemand: 6, incremental: 2 });
   });
 
-  it("returns default 5 when no setting exists", async () => {
-    appSettingFindUniqueMock.mockResolvedValue(null);
+  it("returns defaults when no settings exist", async () => {
+    appSettingFindManyMock.mockResolvedValue([]);
 
-    const result = await getWorkerConcurrencyServerFn({} as never);
+    const result = await getAllScanConcurrenciesServerFn({} as never);
 
-    expect(result).toBe(5);
+    expect(result).toEqual(SCAN_CONCURRENCY_DEFAULTS);
+  });
+
+  it("returns partial defaults for missing keys", async () => {
+    appSettingFindManyMock.mockResolvedValue([
+      { key: "concurrencyFull", value: "12" },
+    ]);
+
+    const result = await getAllScanConcurrenciesServerFn({} as never);
+
+    expect(result).toEqual({ full: 12, onDemand: SCAN_CONCURRENCY_DEFAULTS.onDemand, incremental: SCAN_CONCURRENCY_DEFAULTS.incremental });
   });
 });
 
-describe("setWorkerConcurrencyServerFn", () => {
-  it("upserts concurrency setting and returns the value", async () => {
-    appSettingUpsertMock.mockResolvedValue({ key: "workerConcurrency", value: "10" });
+describe("setScanConcurrencyServerFn", () => {
+  it("upserts concurrency for full scan type", async () => {
+    appSettingUpsertMock.mockResolvedValue({ key: "concurrencyFull", value: "10" });
 
-    const result = await setWorkerConcurrencyServerFn({ data: { concurrency: 10 } });
+    const result = await setScanConcurrencyServerFn({ data: { scanType: "full", concurrency: 10 } });
 
     expect(appSettingUpsertMock).toHaveBeenCalledWith({
-      where: { key: "workerConcurrency" },
-      create: { key: "workerConcurrency", value: "10" },
+      where: { key: "concurrencyFull" },
+      create: { key: "concurrencyFull", value: "10" },
       update: { value: "10" },
     });
-    expect(result).toEqual({ concurrency: 10 });
+    expect(result).toEqual({ scanType: "full", concurrency: 10 });
+  });
+
+  it("upserts concurrency for onDemand scan type", async () => {
+    appSettingUpsertMock.mockResolvedValue({ key: "concurrencyOnDemand", value: "7" });
+
+    const result = await setScanConcurrencyServerFn({ data: { scanType: "onDemand", concurrency: 7 } });
+
+    expect(appSettingUpsertMock).toHaveBeenCalledWith({
+      where: { key: "concurrencyOnDemand" },
+      create: { key: "concurrencyOnDemand", value: "7" },
+      update: { value: "7" },
+    });
+    expect(result).toEqual({ scanType: "onDemand", concurrency: 7 });
+  });
+
+  it("upserts concurrency for incremental scan type", async () => {
+    appSettingUpsertMock.mockResolvedValue({ key: "concurrencyIncremental", value: "2" });
+
+    const result = await setScanConcurrencyServerFn({ data: { scanType: "incremental", concurrency: 2 } });
+
+    expect(appSettingUpsertMock).toHaveBeenCalledWith({
+      where: { key: "concurrencyIncremental" },
+      create: { key: "concurrencyIncremental", value: "2" },
+      update: { value: "2" },
+    });
+    expect(result).toEqual({ scanType: "incremental", concurrency: 2 });
   });
 });
 

--- a/apps/web/src/lib/server-fns/app-settings.ts
+++ b/apps/web/src/lib/server-fns/app-settings.ts
@@ -1,31 +1,56 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 
-const DEFAULT_WORKER_CONCURRENCY = 5;
+export type ScanType = "full" | "onDemand" | "incremental";
 
-export const getWorkerConcurrencyServerFn = createServerFn({
+export const SCAN_CONCURRENCY_DEFAULTS: Record<ScanType, number> = {
+  full: 8,
+  onDemand: 5,
+  incremental: 3,
+};
+
+const SCAN_CONCURRENCY_KEYS: Record<ScanType, string> = {
+  full: "concurrencyFull",
+  onDemand: "concurrencyOnDemand",
+  incremental: "concurrencyIncremental",
+};
+
+export const getAllScanConcurrenciesServerFn = createServerFn({
   method: "GET",
 }).handler(async () => {
   const { db } = await import("@bookhouse/db");
 
-  const setting = await db.appSetting.findUnique({ where: { key: "workerConcurrency" } });
-  return setting ? Number(setting.value) : DEFAULT_WORKER_CONCURRENCY;
+  const settings = await db.appSetting.findMany({
+    where: { key: { in: Object.values(SCAN_CONCURRENCY_KEYS) } },
+  });
+
+  const map = new Map(settings.map((s: { key: string; value: string }) => [s.key, s.value]));
+
+  return {
+    full: Number(map.get(SCAN_CONCURRENCY_KEYS.full)) || SCAN_CONCURRENCY_DEFAULTS.full,
+    onDemand: Number(map.get(SCAN_CONCURRENCY_KEYS.onDemand)) || SCAN_CONCURRENCY_DEFAULTS.onDemand,
+    incremental: Number(map.get(SCAN_CONCURRENCY_KEYS.incremental)) || SCAN_CONCURRENCY_DEFAULTS.incremental,
+  };
 });
 
-export const setWorkerConcurrencyServerFn = createServerFn({
+export const setScanConcurrencyServerFn = createServerFn({
   method: "POST",
 })
-  .inputValidator(z.object({ concurrency: z.number().int().min(1).max(20) }))
+  .inputValidator(z.object({
+    scanType: z.enum(["full", "onDemand", "incremental"]),
+    concurrency: z.number().int().min(1).max(20),
+  }))
   .handler(async ({ data }) => {
     const { db } = await import("@bookhouse/db");
+    const key = SCAN_CONCURRENCY_KEYS[data.scanType as ScanType];
 
     await db.appSetting.upsert({
-      where: { key: "workerConcurrency" },
-      create: { key: "workerConcurrency", value: String(data.concurrency) },
+      where: { key },
+      create: { key, value: String(data.concurrency) },
       update: { value: String(data.concurrency) },
     });
 
-    return { concurrency: data.concurrency };
+    return { scanType: data.scanType as ScanType, concurrency: data.concurrency };
   });
 
 export type MissingFileBehavior = "auto-cleanup" | "manual";

--- a/apps/web/src/routes/_authenticated/settings/-index.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-index.test.tsx
@@ -27,8 +27,8 @@ let mockLoaderData: {
     libraryRoot: { name: string } | null;
   }[];
   totalCount: number;
-  concurrency: number;
-} = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrency: 5 };
+  concurrencies: { full: number; onDemand: number; incremental: number };
+} = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 } };
 
 const getLibraryRootsServerFnMock = vi.fn();
 const scanLibraryRootServerFnMock = vi.fn();
@@ -50,14 +50,14 @@ const getMissingFileBehaviorServerFnMock = vi.fn();
 const setMissingFileBehaviorServerFnMock = vi.fn();
 const getImportJobsServerFnMock = vi.fn();
 const stopAllJobsServerFnMock = vi.fn().mockResolvedValue({ stoppedCount: 0 });
-const getWorkerConcurrencyServerFnMock = vi.fn().mockResolvedValue(5);
-const setWorkerConcurrencyServerFnMock = vi.fn().mockResolvedValue({ concurrency: 5 });
+const getAllScanConcurrenciesServerFnMock = vi.fn().mockResolvedValue({ full: 8, onDemand: 5, incremental: 3 });
+const setScanConcurrencyServerFnMock = vi.fn().mockResolvedValue({ scanType: "full", concurrency: 8 });
 
 vi.mock("~/lib/server-fns/app-settings", () => ({
   getMissingFileBehaviorServerFn: getMissingFileBehaviorServerFnMock,
   setMissingFileBehaviorServerFn: setMissingFileBehaviorServerFnMock,
-  getWorkerConcurrencyServerFn: getWorkerConcurrencyServerFnMock,
-  setWorkerConcurrencyServerFn: setWorkerConcurrencyServerFnMock,
+  getAllScanConcurrenciesServerFn: getAllScanConcurrenciesServerFnMock,
+  setScanConcurrencyServerFn: setScanConcurrencyServerFnMock,
 }));
 
 vi.mock("~/lib/server-fns/import-jobs", () => ({
@@ -171,7 +171,7 @@ const makeJob = (overrides: Partial<{
 describe("SettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrency: 5 };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 } };
     mockTheme = "system";
   });
 
@@ -462,14 +462,14 @@ describe("SettingsPage", () => {
     getLibraryRootsServerFnMock.mockResolvedValueOnce(mockRoots);
     getMissingFileBehaviorServerFnMock.mockResolvedValueOnce("manual");
     getImportJobsServerFnMock.mockResolvedValueOnce({ jobs: [], totalCount: 0 });
-    getWorkerConcurrencyServerFnMock.mockResolvedValueOnce(5);
+    getAllScanConcurrenciesServerFnMock.mockResolvedValueOnce({ full: 8, onDemand: 5, incremental: 3 });
     getScanProgressServerFnMock.mockResolvedValueOnce(null);
     getLibraryIssueCountServerFnMock.mockResolvedValueOnce(0);
     const { Route } = await import("./index");
     const result = await (Route.options.loader as (args: Record<string, unknown>) => Promise<unknown>)({});
     expect(getLibraryRootsServerFnMock).toHaveBeenCalled();
     expect(getImportJobsServerFnMock).toHaveBeenCalledWith({ data: { page: 1, pageSize: 100 } });
-    expect(getWorkerConcurrencyServerFnMock).toHaveBeenCalled();
+    expect(getAllScanConcurrenciesServerFnMock).toHaveBeenCalled();
     expect(getScanProgressServerFnMock).toHaveBeenCalledWith({ data: { libraryRootId: "root-1" } });
     expect(getLibraryIssueCountServerFnMock).toHaveBeenCalledWith({ data: { libraryRootId: "root-1" } });
     expect(result).toEqual({
@@ -477,7 +477,7 @@ describe("SettingsPage", () => {
       missingFileBehavior: "manual",
       jobs: [],
       totalCount: 0,
-      concurrency: 5,
+      concurrencies: { full: 8, onDemand: 5, incremental: 3 },
     });
   });
 
@@ -731,7 +731,7 @@ describe("SettingsPage", () => {
 describe("AppearanceCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrency: 5 };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 } };
     mockTheme = "system";
   });
 
@@ -798,7 +798,7 @@ describe("AppearanceCard", () => {
 describe("JobsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrency: 5 };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 } };
     mockTheme = "system";
   });
 
@@ -868,36 +868,47 @@ describe("JobsTab", () => {
     expect(stopAllJobsServerFnMock).not.toHaveBeenCalled();
   });
 
-  it("renders concurrency input with loader value", async () => {
-    mockLoaderData = { ...mockLoaderData, concurrency: 8 };
+  it("renders three concurrency inputs with loader values", async () => {
+    mockLoaderData = { ...mockLoaderData, concurrencies: { full: 10, onDemand: 7, incremental: 2 } };
     const { Route } = await import("./index");
     const SettingsPage = (Route.options.component as React.ComponentType);
     render(<SettingsPage />);
-    expect(screen.getByDisplayValue("8")).toBeTruthy();
+    expect(screen.getByDisplayValue("10")).toBeTruthy();
+    expect(screen.getByDisplayValue("7")).toBeTruthy();
+    expect(screen.getByDisplayValue("2")).toBeTruthy();
   });
 
-  it("shows Save button when concurrency is changed", async () => {
+  it("renders concurrency labels for each scan type", async () => {
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    expect(screen.getByText("Full Scan:")).toBeTruthy();
+    expect(screen.getByText("On-demand:")).toBeTruthy();
+    expect(screen.getByText("Incremental:")).toBeTruthy();
+  });
+
+  it("shows Save button when any concurrency is changed", async () => {
     const { Route } = await import("./index");
     const SettingsPage = (Route.options.component as React.ComponentType);
     render(<SettingsPage />);
 
-    const input = screen.getByDisplayValue("5");
-    fireEvent.change(input, { target: { value: "10" } });
+    const input = screen.getByDisplayValue("8");
+    fireEvent.change(input, { target: { value: "12" } });
     expect(screen.getByText("Save")).toBeTruthy();
   });
 
-  it("calls setWorkerConcurrencyServerFn when Save is clicked", async () => {
+  it("calls setScanConcurrencyServerFn for each changed value when Save is clicked", async () => {
     const { Route } = await import("./index");
     const SettingsPage = (Route.options.component as React.ComponentType);
     render(<SettingsPage />);
 
-    const input = screen.getByDisplayValue("5");
-    fireEvent.change(input, { target: { value: "10" } });
+    const fullInput = screen.getByDisplayValue("8");
+    fireEvent.change(fullInput, { target: { value: "12" } });
     const saveBtn = screen.getByText("Save");
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
-      expect(setWorkerConcurrencyServerFnMock).toHaveBeenCalledWith({ data: { concurrency: 10 } });
+      expect(setScanConcurrencyServerFnMock).toHaveBeenCalledWith({ data: { scanType: "full", concurrency: 12 } });
     });
   });
 

--- a/apps/web/src/routes/_authenticated/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/settings/index.tsx
@@ -51,9 +51,10 @@ import {
 import {
   getMissingFileBehaviorServerFn,
   setMissingFileBehaviorServerFn,
-  getWorkerConcurrencyServerFn,
-  setWorkerConcurrencyServerFn,
+  getAllScanConcurrenciesServerFn,
+  setScanConcurrencyServerFn,
   type MissingFileBehavior,
+  type ScanType,
 } from "~/lib/server-fns/app-settings";
 import type { ThemePreference } from "~/lib/server-fns/app-settings";
 import {
@@ -70,11 +71,11 @@ export interface LibraryRootWithExtras extends LibraryRootRow {
 
 export const Route = createFileRoute("/_authenticated/settings/")({
   loader: async () => {
-    const [roots, missingFileBehavior, jobsResult, concurrency] = await Promise.all([
+    const [roots, missingFileBehavior, jobsResult, concurrencies] = await Promise.all([
       getLibraryRootsServerFn(),
       getMissingFileBehaviorServerFn(),
       getImportJobsServerFn({ data: { page: 1, pageSize: 100 } }),
-      getWorkerConcurrencyServerFn(),
+      getAllScanConcurrenciesServerFn(),
     ]);
     const rootsWithExtras: LibraryRootWithExtras[] = await Promise.all(
       roots.map(async (root) => {
@@ -90,7 +91,7 @@ export const Route = createFileRoute("/_authenticated/settings/")({
       missingFileBehavior,
       jobs: jobsResult.jobs,
       totalCount: jobsResult.totalCount,
-      concurrency,
+      concurrencies,
     };
   },
   pendingComponent: SettingsSkeleton,
@@ -110,7 +111,7 @@ function SettingsSkeleton() {
 }
 
 function SettingsPage() {
-  const { roots, missingFileBehavior, jobs, totalCount, concurrency } = Route.useLoaderData();
+  const { roots, missingFileBehavior, jobs, totalCount, concurrencies } = Route.useLoaderData();
 
   const hasActiveScan = roots.some((r) => r.scanProgress !== null);
   const hasActiveJobs = jobs.some(
@@ -138,7 +139,7 @@ function SettingsPage() {
         </TabsContent>
 
         <TabsContent value="jobs" forceMount className="space-y-6 data-[state=inactive]:hidden">
-          <JobsTab jobs={jobs} totalCount={totalCount} initialConcurrency={concurrency} />
+          <JobsTab jobs={jobs} totalCount={totalCount} initialConcurrencies={concurrencies} />
         </TabsContent>
       </Tabs>
     </div>
@@ -327,20 +328,30 @@ const jobColumns: ColumnDef<ImportJobRow>[] = [
   },
 ];
 
+type ScanConcurrencies = Record<ScanType, number>;
+
+const SCAN_TYPE_LABELS: Record<ScanType, string> = {
+  full: "Full Scan:",
+  onDemand: "On-demand:",
+  incremental: "Incremental:",
+};
+
 function JobsTab({
   jobs,
   totalCount,
-  initialConcurrency,
+  initialConcurrencies,
 }: {
   jobs: ImportJobRow[];
   totalCount: number;
-  initialConcurrency: number;
+  initialConcurrencies: ScanConcurrencies;
 }) {
   const router = useRouter();
   const [stopping, setStopping] = useState(false);
-  const [concurrency, setConcurrency] = useState(initialConcurrency);
+  const [concurrencies, setConcurrencies] = useState<ScanConcurrencies>(initialConcurrencies);
   const [savingConcurrency, setSavingConcurrency] = useState(false);
-  const concurrencyChanged = concurrency !== initialConcurrency;
+  const concurrencyChanged = (Object.keys(concurrencies) as ScanType[]).some(
+    (k) => concurrencies[k] !== initialConcurrencies[k],
+  );
 
   async function handleStopAll() {
     if (!window.confirm("Stop all running and queued jobs? This cannot be undone.")) return;
@@ -352,9 +363,16 @@ function JobsTab({
 
   async function handleSaveConcurrency() {
     setSavingConcurrency(true);
+    const changed = (Object.keys(concurrencies) as ScanType[]).filter(
+      (k) => concurrencies[k] !== initialConcurrencies[k],
+    );
     await runMutation(
-      () => setWorkerConcurrencyServerFn({ data: { concurrency } }),
-      { success: `Worker concurrency set to ${String(concurrency)}` },
+      async () => {
+        for (const scanType of changed) {
+          await setScanConcurrencyServerFn({ data: { scanType, concurrency: concurrencies[scanType] } });
+        }
+      },
+      { success: "Worker concurrency updated" },
     );
     setSavingConcurrency(false);
     void router.invalidate();
@@ -368,15 +386,19 @@ function JobsTab({
         </p>
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-2">
-            <label className="text-sm text-muted-foreground whitespace-nowrap">Concurrency:</label>
-            <Input
-              type="number"
-              min={1}
-              max={20}
-              value={concurrency}
-              onChange={(e) => { setConcurrency(Number(e.target.value)); }}
-              className="w-20"
-            />
+            {(Object.keys(SCAN_TYPE_LABELS) as ScanType[]).map((scanType) => (
+              <div key={scanType} className="flex items-center gap-1">
+                <label className="text-sm text-muted-foreground whitespace-nowrap">{SCAN_TYPE_LABELS[scanType]}</label>
+                <Input
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={concurrencies[scanType]}
+                  onChange={(e) => { setConcurrencies((prev) => ({ ...prev, [scanType]: Number(e.target.value) })); }}
+                  className="w-20"
+                />
+              </div>
+            ))}
             {concurrencyChanged && (
               <Button
                 size="sm"


### PR DESCRIPTION
## Summary

- **Per-scan-type concurrency controls**: Replace single `workerConcurrency` setting with granular controls for full (default 8), on-demand (default 5), and incremental (default 3) scans. Settings persisted in the database and respected by the worker pool at runtime.
- **SSE throttling**: Throttle SSE-driven router invalidations to once per 2 seconds to prevent rapid event bursts from hammering the server with re-fetches during active scans.

Closes #104

## Test plan

- All tests passing, 100% coverage
- All CI gates pass (lint, typecheck, test, build)