### PR TITLE
Fix cross-format duplicates, zombie workers, and error masking

### DIFF
--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -8556,6 +8556,81 @@ describe("detectDuplicates", () => {
     expect(state.duplicateCandidates.size).toBe(1);
   });
 
+  it("SIMILAR_TITLE_AUTHOR: creates candidate when matched edition has same media kind", async () => {
+    const state = createEmptyState();
+    addDetectFileAsset(state, "file-1", "hash-a", "/tmp/root/book1.epub");
+    addDetectFileAsset(state, "file-2", null, "/tmp/root/book2.epub");
+    addDetectWork(state, "work-1", "looking for alaska", "Looking for Alaska");
+    addDetectWork(state, "work-2", "looking for alaska", "Looking for Alaska");
+    addDetectEdition(state, "edition-1", "work-1");
+    addDetectEdition(state, "edition-2", "work-2");
+    addDetectEditionFile(state, "ef-1", "edition-1", "file-1");
+    addDetectEditionFile(state, "ef-2", "edition-2", "file-2");
+    addDetectContributor(state, "c-1", "John Green");
+    addDetectContributor(state, "c-2", "John Green");
+    addDetectEditionContributor(state, "ec-1", "edition-1", "c-1");
+    addDetectEditionContributor(state, "ec-2", "edition-2", "c-2");
+    const services = createIngestServices({ db: createTestDb(state) });
+
+    const result = await services.detectDuplicates({ fileAssetId: "file-1" });
+
+    expect(result.candidatesCreated).toBe(1);
+    const candidates = [...state.duplicateCandidates.values()];
+    expect(candidates[0]).toMatchObject({
+      leftEditionId: "edition-1",
+      rightEditionId: "edition-2",
+      reason: "SIMILAR_TITLE_AUTHOR",
+    });
+  });
+
+  it("SIMILAR_TITLE_AUTHOR: creates candidate when matched edition has no files", async () => {
+    const state = createEmptyState();
+    addDetectFileAsset(state, "file-1", "hash-a", "/tmp/root/book.epub");
+    addDetectWork(state, "work-1", "looking for alaska", "Looking for Alaska");
+    addDetectWork(state, "work-2", "looking for alaska", "Looking for Alaska");
+    addDetectEdition(state, "edition-1", "work-1");
+    addDetectEdition(state, "edition-2", "work-2");
+    addDetectEditionFile(state, "ef-1", "edition-1", "file-1");
+    // edition-2 has no linked files
+    addDetectContributor(state, "c-1", "John Green");
+    addDetectContributor(state, "c-2", "John Green");
+    addDetectEditionContributor(state, "ec-1", "edition-1", "c-1");
+    addDetectEditionContributor(state, "ec-2", "edition-2", "c-2");
+    const services = createIngestServices({ db: createTestDb(state) });
+
+    const result = await services.detectDuplicates({ fileAssetId: "file-1" });
+
+    expect(result.candidatesCreated).toBe(1);
+    const candidates = [...state.duplicateCandidates.values()];
+    expect(candidates[0]).toMatchObject({
+      leftEditionId: "edition-1",
+      rightEditionId: "edition-2",
+      reason: "SIMILAR_TITLE_AUTHOR",
+    });
+  });
+
+  it("SIMILAR_TITLE_AUTHOR: does not create candidate when matched edition has different media kind", async () => {
+    const state = createEmptyState();
+    addDetectFileAsset(state, "file-1", "hash-a", "/tmp/root/book.epub");
+    addDetectFileAsset(state, "file-2", null, "/tmp/root/book.pdf", { mediaKind: MediaKind.PDF });
+    addDetectWork(state, "work-1", "looking for alaska", "Looking for Alaska");
+    addDetectWork(state, "work-2", "looking for alaska", "Looking for Alaska");
+    addDetectEdition(state, "edition-1", "work-1");
+    addDetectEdition(state, "edition-2", "work-2");
+    addDetectEditionFile(state, "ef-1", "edition-1", "file-1");
+    addDetectEditionFile(state, "ef-2", "edition-2", "file-2");
+    addDetectContributor(state, "c-1", "John Green");
+    addDetectContributor(state, "c-2", "John Green");
+    addDetectEditionContributor(state, "ec-1", "edition-1", "c-1");
+    addDetectEditionContributor(state, "ec-2", "edition-2", "c-2");
+    const services = createIngestServices({ db: createTestDb(state) });
+
+    const result = await services.detectDuplicates({ fileAssetId: "file-1" });
+
+    expect(result.candidatesCreated).toBe(0);
+    expect(state.duplicateCandidates.size).toBe(0);
+  });
+
   it("SIMILAR_TITLE_AUTHOR: skips other work with no titleCanonical", async () => {
     const state = createEmptyState();
     addDetectFileAsset(state, "file-1", "hash-a", "/tmp/root/book.epub");

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -1125,6 +1125,20 @@ async function detectDuplicatesImpl(
       const otherEdition = otherWork.editions[0];
       if (!otherEdition) continue;
 
+      // Skip different file types (e.g. EPUB vs PDF of same book)
+      const otherEditionFiles = await ingestDb.editionFile.findMany({ where: { editionId: otherEdition.id } });
+      if (otherEditionFiles.length > 0) {
+        const otherFileAssets = await Promise.all(
+          otherEditionFiles.map((ef) => ingestDb.fileAsset.findUnique({ where: { id: ef.fileAssetId } })),
+        );
+        const otherMediaKinds = new Set(
+          otherFileAssets.filter((fa): fa is FileAssetRecord => fa !== null).map((fa) => fa.mediaKind),
+        );
+        if (otherMediaKinds.size > 0 && !otherMediaKinds.has(fileAsset.mediaKind)) {
+          continue;
+        }
+      }
+
       const titleSim = normalizedSimilarity(work.titleCanonical, otherWork.titleCanonical);
       if (titleSim < SIMILARITY_THRESHOLD) continue;
 

--- a/scripts/dev-restart.sh
+++ b/scripts/dev-restart.sh
@@ -104,8 +104,7 @@ echo "Stopping existing local dev processes"
 kill_pattern_if_running "pnpm -r --parallel dev"
 kill_pattern_if_running "vite dev"
 kill_pattern_if_running "tsx watch src/index.ts"
-kill_pattern_if_running "Bookhouse/workers/library-worker.*tsx.*src/index.ts"
-kill_pattern_if_running "Bookhouse/workers/library-worker.*npm exec tsx src/index.ts"
+kill_pattern_if_running "@bookhouse/library-worker.*exec tsx"
 kill_dev_listener_on_port 3000
 
 if [[ "$USE_DOCKER" == "1" ]]; then

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -38,8 +38,7 @@ if [[ -f ".env" ]]; then
 fi
 
 # Kill stale workers from previous runs
-pkill -f 'Bookhouse/workers/library-worker.*tsx.*src/index.ts' 2>/dev/null || true
-pkill -f 'Bookhouse/workers/library-worker.*npm exec tsx src/index.ts' 2>/dev/null || true
+pkill -f '@bookhouse/library-worker.*exec tsx' 2>/dev/null || true
 
 # Start dev in background, then trap EXIT to kill the entire process group
 trap 'kill 0 2>/dev/null' EXIT

--- a/workers/library-worker/src/index.test.ts
+++ b/workers/library-worker/src/index.test.ts
@@ -1096,7 +1096,7 @@ describe("library worker", () => {
       }) as never),
     ).rejects.toThrow("hash failed");
 
-    expect(importJobUpdateMock).toHaveBeenCalledWith({
+    expect(importJobUpdateManyMock).toHaveBeenCalledWith({
       where: { id: "ij-child-fail", status: { in: ["QUEUED", "RUNNING"] } },
       data: {
         status: "FAILED",
@@ -1131,7 +1131,7 @@ describe("library worker", () => {
       }) as never),
     ).rejects.toBe("plain child failure");
 
-    expect(importJobUpdateMock).toHaveBeenCalledWith({
+    expect(importJobUpdateManyMock).toHaveBeenCalledWith({
       where: { id: "ij-child-string-fail", status: { in: ["QUEUED", "RUNNING"] } },
       data: {
         status: "FAILED",
@@ -1166,7 +1166,7 @@ describe("library worker", () => {
       }) as never),
     ).rejects.toThrow("hash failed");
 
-    expect(importJobUpdateMock).toHaveBeenCalledWith({
+    expect(importJobUpdateManyMock).toHaveBeenCalledWith({
       where: { id: "ij-child-no-parent", status: { in: ["QUEUED", "RUNNING"] } },
       data: {
         status: "FAILED",
@@ -1307,6 +1307,27 @@ describe("library worker", () => {
 
     expect(workerCloseMock).toHaveBeenCalled();
     expect(quitMock).toHaveBeenCalled();
+  });
+
+  it("force-exits when shutdown exceeds timeout", async () => {
+    vi.useFakeTimers();
+    const processExitSpy = vi.spyOn(process, "exit").mockImplementation((() => undefined) as never);
+    const hangingClose = vi.fn(() => new Promise<void>(() => { /* never resolves */ }));
+    const { shutdownLibraryWorker, SHUTDOWN_TIMEOUT_MS } = await import("./index");
+
+    const shutdownPromise = shutdownLibraryWorker(
+      { close: hangingClose },
+      { quit: quitMock } as never,
+    );
+
+    await vi.advanceTimersByTimeAsync(SHUTDOWN_TIMEOUT_MS);
+
+    expect(processExitSpy).toHaveBeenCalledWith(1);
+
+    processExitSpy.mockRestore();
+    vi.useRealTimers();
+    // Prevent unhandled promise — shutdownPromise will never resolve since close hangs
+    void shutdownPromise.catch(() => {});
   });
 
   it("keeps current concurrency when DB is unavailable", async () => {

--- a/workers/library-worker/src/index.ts
+++ b/workers/library-worker/src/index.ts
@@ -325,7 +325,7 @@ export function createLibraryWorkerProcessor(
         });
       }
       if (importJobId && !isScanJob && finalAttempt) {
-        await db.importJob.update({
+        await db.importJob.updateMany({
           where: { id: importJobId, status: { in: ["QUEUED", "RUNNING"] } },
           data: {
             status: "FAILED",
@@ -400,16 +400,25 @@ async function pollConcurrency(worker: Pick<Worker, "concurrency">): Promise<voi
   }
 }
 
+export const SHUTDOWN_TIMEOUT_MS = 10_000;
+
 export async function shutdownLibraryWorker(
   worker: Pick<Worker, "close">,
   connection: Pick<IORedis, "quit">,
   pollInterval?: ReturnType<typeof setInterval>,
 ): Promise<void> {
+  const forceExit = setTimeout(() => {
+    logger.error("Shutdown timed out, forcing exit");
+    process.exit(1);
+  }, SHUTDOWN_TIMEOUT_MS);
+  forceExit.unref();
+
   if (pollInterval !== undefined) {
     clearInterval(pollInterval);
   }
   await worker.close();
   await connection.quit();
+  clearTimeout(forceExit);
 }
 
 export function bootstrapLibraryWorker(): void {


### PR DESCRIPTION
## Summary

- **SIMILAR_TITLE_AUTHOR media kind check** — EPUB and PDF editions of the same book are no longer flagged as duplicates. Adds the same media kind filtering that SAME_ISBN already uses. Closes #120
- **Fix zombie worker cleanup** — `pkill` patterns in `dev.sh` and `dev-restart.sh` looked for the filesystem path (`Bookhouse/workers/library-worker`) but pnpm-spawned processes use the package name (`@bookhouse/library-worker`). Stale workers were never killed on restart, causing 5,000 failed jobs from workers with stale Prisma clients.
- **Fix error masking** — Child job failure handler used `db.importJob.update()` which throws when the ImportJob status has already changed (e.g. superseded by a new scan). Changed to `updateMany` so the original job error is preserved in BullMQ's `failedReason`.
- **Shutdown timeout** — `shutdownLibraryWorker` now force-exits after 10 seconds if `worker.close()` hangs, preventing zombie processes.