### PR TITLE
Fix cover images failing to load despite being marked as present

### DIFF
--- a/apps/web/server/routes/api/covers/[workId]/[size].test.ts
+++ b/apps/web/server/routes/api/covers/[workId]/[size].test.ts
@@ -1,12 +1,37 @@
 import { describe, it, expect, vi } from "vitest";
+import { Readable } from "node:stream";
+
+const mockSendStream = vi.fn();
 
 vi.mock("h3", () => ({
   defineEventHandler: (fn: (event: object) => object | Promise<object>) => fn,
+  setResponseHeader: vi.fn(),
+  sendStream: (...args: unknown[]) => mockSendStream(...args),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: () => true,
+  createReadStream: () => Readable.from(Buffer.from("fake-image")),
 }));
 
 describe("cover route", () => {
   it("exports a handler function", async () => {
     const mod = await import("./[size]");
     expect(typeof mod.default).toBe("function");
+  });
+
+  it("converts Node stream to Web ReadableStream for h3 sendStream", async () => {
+    const mod = await import("./[size]");
+    const handler = mod.default as (event: object) => Promise<unknown>;
+
+    const event = {
+      context: { params: { workId: "work-1", size: "thumb" } },
+    };
+
+    await handler(event);
+
+    expect(mockSendStream).toHaveBeenCalledTimes(1);
+    const [, webStream] = mockSendStream.mock.calls[0] as [unknown, unknown];
+    expect(webStream).toBeInstanceOf(ReadableStream);
   });
 });

--- a/apps/web/server/routes/api/covers/[workId]/[size].ts
+++ b/apps/web/server/routes/api/covers/[workId]/[size].ts
@@ -1,5 +1,6 @@
 import { existsSync, createReadStream } from "node:fs";
-import { defineEventHandler } from "h3";
+import { Readable } from "node:stream";
+import { defineEventHandler, setResponseHeader, sendStream } from "h3";
 import { createCoverHandler } from "../handler";
 
 const COVER_CACHE_DIR = process.env.COVER_CACHE_DIR ?? "/data/covers";
@@ -9,5 +10,8 @@ export default defineEventHandler(
     existsSync,
     createReadStream,
     coverCacheDir: COVER_CACHE_DIR,
+    setResponseHeader,
+    sendStream: (event, stream) =>
+      sendStream(event, Readable.toWeb(stream as Readable) as ReadableStream),
   }),
 );

--- a/apps/web/server/routes/api/covers/handler.test.ts
+++ b/apps/web/server/routes/api/covers/handler.test.ts
@@ -6,6 +6,8 @@ function createMockDeps(overrides: Partial<CoverHandlerDeps> = {}): CoverHandler
     existsSync: vi.fn().mockReturnValue(true),
     createReadStream: vi.fn().mockReturnValue("mock-stream"),
     coverCacheDir: "/data/covers",
+    setResponseHeader: vi.fn(),
+    sendStream: vi.fn(),
     ...overrides,
   };
 }
@@ -25,25 +27,43 @@ describe("cover handler", () => {
     deps = createMockDeps();
   });
 
-  it("returns a stream for valid thumb request", async () => {
+  it("sends stream via sendStream for valid thumb request", async () => {
     const handler = createCoverHandler(deps);
     const event = createMockEvent("work-1", "thumb");
 
-    const result = await handler(event as never);
+    await handler(event as never);
 
     expect(deps.existsSync).toHaveBeenCalledWith("/data/covers/work-1/thumb.webp");
     expect(deps.createReadStream).toHaveBeenCalledWith("/data/covers/work-1/thumb.webp");
-    expect(result).toBe("mock-stream");
+    expect(deps.sendStream).toHaveBeenCalledWith(event, "mock-stream");
   });
 
-  it("returns a stream for valid medium request", async () => {
+  it("sends stream via sendStream for valid medium request", async () => {
     const handler = createCoverHandler(deps);
     const event = createMockEvent("work-1", "medium");
 
-    const result = await handler(event as never);
+    await handler(event as never);
 
     expect(deps.existsSync).toHaveBeenCalledWith("/data/covers/work-1/medium.webp");
-    expect(result).toBe("mock-stream");
+    expect(deps.sendStream).toHaveBeenCalledWith(event, "mock-stream");
+  });
+
+  it("sets Content-Type image/webp via setResponseHeader when cover exists", async () => {
+    const handler = createCoverHandler(deps);
+    const event = createMockEvent("work-1", "thumb");
+
+    await handler(event as never);
+
+    expect(deps.setResponseHeader).toHaveBeenCalledWith(event, "Content-Type", "image/webp");
+  });
+
+  it("sets Cache-Control header via setResponseHeader when cover exists", async () => {
+    const handler = createCoverHandler(deps);
+    const event = createMockEvent("work-1", "thumb");
+
+    await handler(event as never);
+
+    expect(deps.setResponseHeader).toHaveBeenCalledWith(event, "Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
   });
 
   it("throws 400 for invalid size", async () => {
@@ -56,22 +76,19 @@ describe("cover handler", () => {
   });
 
   it("returns an SVG placeholder when cover file does not exist", async () => {
-    const setHeader = vi.fn();
     deps = createMockDeps({ existsSync: vi.fn().mockReturnValue(false) });
     const handler = createCoverHandler(deps);
-    const event = {
-      context: { params: { workId: "work-1", size: "thumb" } },
-      node: { res: { setHeader } },
-    };
+    const event = createMockEvent("work-1", "thumb");
 
     const result = await handler(event as never);
 
     expect(typeof result).toBe("string");
     expect(result as string).toContain("<svg");
     expect(result as string).toContain("</svg>");
-    expect(setHeader).toHaveBeenCalledWith("Content-Type", "image/svg+xml");
-    expect(setHeader).toHaveBeenCalledWith("Cache-Control", "public, max-age=3600");
+    expect(deps.setResponseHeader).toHaveBeenCalledWith(event, "Content-Type", "image/svg+xml");
+    expect(deps.setResponseHeader).toHaveBeenCalledWith(event, "Cache-Control", "no-cache");
     expect(deps.createReadStream).not.toHaveBeenCalled();
+    expect(deps.sendStream).not.toHaveBeenCalled();
   });
 
   it("sanitizes workId to prevent path traversal", async () => {

--- a/apps/web/server/routes/api/covers/handler.ts
+++ b/apps/web/server/routes/api/covers/handler.ts
@@ -5,6 +5,8 @@ export interface CoverHandlerDeps {
   existsSync: (path: string) => boolean;
   createReadStream: (path: string) => NodeJS.ReadableStream;
   coverCacheDir: string;
+  setResponseHeader: (event: H3Event, name: string, value: string) => void;
+  sendStream: (event: H3Event, stream: NodeJS.ReadableStream) => unknown;
 }
 
 const VALID_SIZES = new Set(["thumb", "medium"]);
@@ -30,14 +32,14 @@ export function createCoverHandler(deps: CoverHandlerDeps) {
     const filePath = path.join(deps.coverCacheDir, workId, `${size}.webp`);
 
     if (!deps.existsSync(filePath)) {
-      event.node?.res?.setHeader?.("Content-Type", "image/svg+xml");
-      event.node?.res?.setHeader?.("Cache-Control", "public, max-age=3600");
+      deps.setResponseHeader(event, "Content-Type", "image/svg+xml");
+      deps.setResponseHeader(event, "Cache-Control", "no-cache");
       return PLACEHOLDER_SVG;
     }
 
-    event.node?.res?.setHeader?.("Content-Type", "image/webp");
-    event.node?.res?.setHeader?.("Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
+    deps.setResponseHeader(event, "Content-Type", "image/webp");
+    deps.setResponseHeader(event, "Cache-Control", "public, max-age=86400, stale-while-revalidate=604800");
 
-    return deps.createReadStream(filePath);
+    return deps.sendStream(event, deps.createReadStream(filePath));
   };
 }


### PR DESCRIPTION
## Summary

- Replaced silently-failing `event.node?.res?.setHeader?.()` calls with H3's `setResponseHeader()` utility, which works reliably across all H3 adapters
- Replaced direct Node ReadableStream return with H3's `sendStream()` (with Node→Web stream conversion), ensuring proper Content-Type headers reach the browser
- Changed placeholder SVG cache from `max-age=3600` to `no-cache` so browsers recheck after cover upload instead of showing stale placeholders

## Test plan

- Verified all 1986 tests pass with 100% coverage
- All CI gates pass: lint, typecheck, test, build
- Confirmed cover serving handler tests verify `setResponseHeader` and `sendStream` are called correctly for both cover-exists and placeholder paths
- Confirmed route wiring test verifies Node-to-Web stream conversion

Closes #118