### PR TITLE
Add author photos from enrichment sources

### DIFF
--- a/apps/web/server/routes/api/authors/[contributorId]/[size].test.ts
+++ b/apps/web/server/routes/api/authors/[contributorId]/[size].test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect, vi } from "vitest";
+import { Readable } from "node:stream";
+
+const mockSendStream = vi.fn();
+
+vi.mock("h3", () => ({
+  defineEventHandler: (fn: (event: object) => object | Promise<object>) => fn,
+  setResponseHeader: vi.fn(),
+  sendStream: (...args: unknown[]) => mockSendStream(...args),
+}));
+
+vi.mock("node:fs", () => ({
+  existsSync: () => true,
+  createReadStream: () => Readable.from(Buffer.from("fake-image")),
+}));
+
+describe("author photo route", () => {
+  it("exports a handler function", async () => {
+    const mod = await import("./[size]");
+    expect(typeof mod.default).toBe("function");
+  });
+
+  it("converts Node stream to Web ReadableStream for h3 sendStream", async () => {
+    const mod = await import("./[size]");
+    const handler = mod.default as (event: object) => Promise<unknown>;
+
+    const event = {
+      context: { params: { contributorId: "c1", size: "thumb" } },
+    };
+
+    await handler(event);
+
+    expect(mockSendStream).toHaveBeenCalledTimes(1);
+    const [, webStream] = mockSendStream.mock.calls[0] as [unknown, unknown];
+    expect(webStream).toBeInstanceOf(ReadableStream);
+  });
+});

--- a/apps/web/server/routes/api/authors/[contributorId]/[size].ts
+++ b/apps/web/server/routes/api/authors/[contributorId]/[size].ts
@@ -1,0 +1,19 @@
+import { existsSync, createReadStream } from "node:fs";
+import path from "node:path";
+import { Readable } from "node:stream";
+import { defineEventHandler, setResponseHeader, sendStream } from "h3";
+import { createCoverHandler } from "../../../api/covers/handler";
+
+const COVER_CACHE_DIR = process.env.COVER_CACHE_DIR ?? "/data/covers";
+
+export default defineEventHandler(
+  createCoverHandler({
+    existsSync,
+    createReadStream,
+    coverCacheDir: path.join(COVER_CACHE_DIR, "authors"),
+    setResponseHeader,
+    sendStream: (event, stream) =>
+      sendStream(event, Readable.toWeb(stream as Readable) as ReadableStream),
+    idParamName: "contributorId",
+  }),
+);

--- a/apps/web/server/routes/api/covers/handler.test.ts
+++ b/apps/web/server/routes/api/covers/handler.test.ts
@@ -108,4 +108,34 @@ describe("cover handler", () => {
       statusCode: 400,
     });
   });
+
+  it("uses custom idParamName when provided", async () => {
+    deps = createMockDeps({ idParamName: "contributorId" });
+    const handler = createCoverHandler(deps);
+    const event = {
+      context: {
+        params: { contributorId: "c1", size: "thumb" },
+      },
+    };
+
+    await handler(event as never);
+
+    expect(deps.existsSync).toHaveBeenCalledWith("/data/covers/c1/thumb.webp");
+    expect(deps.sendStream).toHaveBeenCalled();
+  });
+
+  it("throws 400 with custom idParamName for invalid id", async () => {
+    deps = createMockDeps({ idParamName: "contributorId" });
+    const handler = createCoverHandler(deps);
+    const event = {
+      context: {
+        params: { contributorId: "../etc/passwd", size: "thumb" },
+      },
+    };
+
+    await expect(handler(event as never)).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: "Invalid contributorId",
+    });
+  });
 });

--- a/apps/web/server/routes/api/covers/handler.ts
+++ b/apps/web/server/routes/api/covers/handler.ts
@@ -7,6 +7,7 @@ export interface CoverHandlerDeps {
   coverCacheDir: string;
   setResponseHeader: (event: H3Event, name: string, value: string) => void;
   sendStream: (event: H3Event, stream: NodeJS.ReadableStream) => unknown;
+  idParamName?: string;
 }
 
 const VALID_SIZES = new Set(["thumb", "medium"]);
@@ -17,19 +18,22 @@ const PLACEHOLDER_SVG = `<svg xmlns="http://www.w3.org/2000/svg" width="200" hei
 </svg>`;
 
 export function createCoverHandler(deps: CoverHandlerDeps) {
-  return async (event: H3Event) => {
-    const params = event.context.params as { workId: string; size: string };
-    const { workId, size } = params;
+  const idParam = deps.idParamName ?? "workId";
 
-    if (!VALID_WORK_ID.test(workId)) {
-      throw Object.assign(new Error("Invalid workId"), { statusCode: 400, statusMessage: "Invalid workId" });
+  return async (event: H3Event) => {
+    const params = event.context.params as Record<string, string>;
+    const id = params[idParam] as string;
+    const size = params.size as string;
+
+    if (!VALID_WORK_ID.test(id)) {
+      throw Object.assign(new Error(`Invalid ${idParam}`), { statusCode: 400, statusMessage: `Invalid ${idParam}` });
     }
 
     if (!VALID_SIZES.has(size)) {
       throw Object.assign(new Error("Invalid size"), { statusCode: 400, statusMessage: "Invalid size" });
     }
 
-    const filePath = path.join(deps.coverCacheDir, workId, `${size}.webp`);
+    const filePath = path.join(deps.coverCacheDir, id, `${size}.webp`);
 
     if (!deps.existsSync(filePath)) {
       deps.setResponseHeader(event, "Content-Type", "image/svg+xml");

--- a/apps/web/server/routes/api/upload-author-photo/[contributorId].test.ts
+++ b/apps/web/server/routes/api/upload-author-photo/[contributorId].test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createAuthorPhotoUploadHandler, type AuthorPhotoUploadDeps } from "./[contributorId]";
+
+const VALID_JPEG = Buffer.from([0xFF, 0xD8, 0xFF, 0xE0, 0x00, 0x10]);
+
+function createMockDeps(overrides: Partial<AuthorPhotoUploadDeps> = {}): AuthorPhotoUploadDeps {
+  return {
+    coverCacheDir: "/data/covers",
+    readFormData: vi.fn().mockResolvedValue([
+      { name: "file", data: VALID_JPEG, type: "image/jpeg" },
+    ]),
+    resizeAndSave: vi.fn().mockResolvedValue(undefined),
+    db: {
+      findContributor: vi.fn().mockResolvedValue({ id: "c1" }),
+      updateContributor: vi.fn().mockResolvedValue(undefined),
+    },
+    ...overrides,
+  };
+}
+
+function createMockEvent(contributorId: string) {
+  return {
+    context: { params: { contributorId } },
+  };
+}
+
+describe("author photo upload handler", () => {
+  let deps: AuthorPhotoUploadDeps;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+  });
+
+  it("processes upload and updates contributor", async () => {
+    const handler = createAuthorPhotoUploadHandler(deps);
+    const result = await handler(createMockEvent("c1") as never);
+
+    expect(deps.resizeAndSave).toHaveBeenCalledWith(
+      expect.any(Buffer) as Buffer,
+      "/data/covers/authors/c1",
+    );
+    expect(deps.db.updateContributor).toHaveBeenCalledWith("c1", { imagePath: "c1" });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("throws 400 for invalid contributorId", async () => {
+    const handler = createAuthorPhotoUploadHandler(deps);
+    await expect(handler(createMockEvent("../etc/passwd") as never)).rejects.toMatchObject({
+      statusCode: 400,
+    });
+  });
+
+  it("throws 400 when no file is uploaded", async () => {
+    deps = createMockDeps({ readFormData: vi.fn().mockResolvedValue([]) });
+    const handler = createAuthorPhotoUploadHandler(deps);
+    await expect(handler(createMockEvent("c1") as never)).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: "No file uploaded",
+    });
+  });
+
+  it("throws 400 when file is too large", async () => {
+    deps = createMockDeps({
+      readFormData: vi.fn().mockResolvedValue([
+        { name: "file", data: Buffer.alloc(11 * 1024 * 1024), type: "image/jpeg" },
+      ]),
+    });
+    const handler = createAuthorPhotoUploadHandler(deps);
+    await expect(handler(createMockEvent("c1") as never)).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: "File too large (max 10 MB)",
+    });
+  });
+
+  it("throws 400 for invalid MIME type", async () => {
+    deps = createMockDeps({
+      readFormData: vi.fn().mockResolvedValue([
+        { name: "file", data: VALID_JPEG, type: "application/pdf" },
+      ]),
+    });
+    const handler = createAuthorPhotoUploadHandler(deps);
+    await expect(handler(createMockEvent("c1") as never)).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: "Invalid image type",
+    });
+  });
+
+  it("throws 400 for invalid magic bytes", async () => {
+    deps = createMockDeps({
+      readFormData: vi.fn().mockResolvedValue([
+        { name: "file", data: Buffer.from("not an image"), type: "image/jpeg" },
+      ]),
+    });
+    const handler = createAuthorPhotoUploadHandler(deps);
+    await expect(handler(createMockEvent("c1") as never)).rejects.toMatchObject({
+      statusCode: 400,
+      statusMessage: "File is not a valid image",
+    });
+  });
+
+  it("throws 404 when contributor not found", async () => {
+    deps = createMockDeps({
+      db: {
+        findContributor: vi.fn().mockResolvedValue(null),
+        updateContributor: vi.fn(),
+      },
+    });
+    const handler = createAuthorPhotoUploadHandler(deps);
+    await expect(handler(createMockEvent("c1") as never)).rejects.toMatchObject({
+      statusCode: 404,
+    });
+  });
+
+  it("allows missing MIME type if magic bytes are valid", async () => {
+    deps = createMockDeps({
+      readFormData: vi.fn().mockResolvedValue([
+        { name: "file", data: VALID_JPEG },
+      ]),
+    });
+    const handler = createAuthorPhotoUploadHandler(deps);
+    const result = await handler(createMockEvent("c1") as never);
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/apps/web/server/routes/api/upload-author-photo/[contributorId].ts
+++ b/apps/web/server/routes/api/upload-author-photo/[contributorId].ts
@@ -1,0 +1,85 @@
+import path from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import { defineEventHandler, readMultipartFormData, createError } from "h3";
+import type { H3Event } from "h3";
+import { VALID_WORK_ID, MAX_FILE_SIZE, isValidImageData, isAllowedMimeType } from "@bookhouse/ingest";
+
+const COVER_CACHE_DIR = process.env.COVER_CACHE_DIR ?? "/data/covers";
+
+export interface AuthorPhotoUploadDeps {
+  coverCacheDir: string;
+  readFormData: (event: H3Event) => Promise<{ name?: string; data: Uint8Array; type?: string }[] | undefined>;
+  resizeAndSave: (imageBuffer: Buffer, outputDir: string) => Promise<void>;
+  db: {
+    findContributor: (id: string) => Promise<{ id: string } | null>;
+    updateContributor: (id: string, data: { imagePath: string }) => Promise<void>;
+  };
+}
+
+export function createAuthorPhotoUploadHandler(deps: AuthorPhotoUploadDeps) {
+  return async (event: H3Event) => {
+    const params = event.context.params as { contributorId: string };
+    const { contributorId } = params;
+
+    if (!VALID_WORK_ID.test(contributorId)) {
+      throw createError({ statusCode: 400, statusMessage: "Invalid contributorId" });
+    }
+
+    const formData = await deps.readFormData(event);
+    const fileField = formData?.find((f) => f.name === "file");
+
+    if (!fileField?.data || fileField.data.length === 0) {
+      throw createError({ statusCode: 400, statusMessage: "No file uploaded" });
+    }
+
+    if (fileField.data.length > MAX_FILE_SIZE) {
+      throw createError({ statusCode: 400, statusMessage: "File too large (max 10 MB)" });
+    }
+
+    if (!isAllowedMimeType(fileField.type)) {
+      throw createError({ statusCode: 400, statusMessage: "Invalid image type" });
+    }
+
+    if (!isValidImageData(fileField.data)) {
+      throw createError({ statusCode: 400, statusMessage: "File is not a valid image" });
+    }
+
+    const imageBuffer = Buffer.from(fileField.data);
+    const outputDir = path.join(deps.coverCacheDir, "authors", contributorId);
+    await deps.resizeAndSave(imageBuffer, outputDir);
+
+    const contributor = await deps.db.findContributor(contributorId);
+    if (!contributor) {
+      throw createError({ statusCode: 404, statusMessage: "Contributor not found" });
+    }
+
+    await deps.db.updateContributor(contributorId, { imagePath: contributorId });
+
+    return { success: true };
+  };
+}
+
+/* c8 ignore start — runtime wiring, tested via unit tests on createAuthorPhotoUploadHandler */
+export default defineEventHandler(async (event) => {
+  const { db } = await import("@bookhouse/db");
+  const { resizeCoverImage } = await import("@bookhouse/ingest");
+  const sharpModule = await import("sharp");
+
+  const handler = createAuthorPhotoUploadHandler({
+    coverCacheDir: COVER_CACHE_DIR,
+    readFormData: readMultipartFormData,
+    resizeAndSave: async (imageBuffer, outputDir) => {
+      await resizeCoverImage(
+        { imageBuffer, outputDir },
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+        { sharp: sharpModule.default as never, mkdir, writeFile },
+      );
+    },
+    db: {
+      findContributor: (id) => db.contributor.findUnique({ where: { id }, select: { id: true } }),
+      updateContributor: async (id, data) => { await db.contributor.update({ where: { id }, data }); },
+    },
+  });
+  return handler(event);
+});
+/* c8 ignore stop */

--- a/apps/web/server/utils/queue-events.test.ts
+++ b/apps/web/server/utils/queue-events.test.ts
@@ -15,6 +15,7 @@ function createMockQueueEvents() {
 
 vi.mock("@bookhouse/shared", () => ({
   createQueueEvents: vi.fn(() => createMockQueueEvents()),
+  QUEUES: { LIBRARY: "library", ENRICHMENT: "enrichment" },
 }));
 
 describe("QueueEventsManager", () => {
@@ -95,6 +96,32 @@ describe("QueueEventsManager", () => {
     await manager.close();
 
     expect(qe.close).toHaveBeenCalled();
+  });
+
+  it("listens to multiple queue events when passed an array", () => {
+    const qe1 = createMockQueueEvents();
+    const qe2 = createMockQueueEvents();
+    const manager = new QueueEventsManager([qe1, qe2]);
+    const callback = vi.fn();
+    manager.subscribe(callback);
+
+    qe1.emit("completed", { jobId: "lib-1" });
+    qe2.emit("completed", { jobId: "enrich-1" });
+
+    expect(callback).toHaveBeenCalledTimes(2);
+    expect(callback).toHaveBeenCalledWith({ type: "job:completed", data: { jobId: "lib-1" } });
+    expect(callback).toHaveBeenCalledWith({ type: "job:completed", data: { jobId: "enrich-1" } });
+  });
+
+  it("close delegates to all queue events in array", async () => {
+    const qe1 = createMockQueueEvents();
+    const qe2 = createMockQueueEvents();
+    const manager = new QueueEventsManager([qe1, qe2]);
+
+    await manager.close();
+
+    expect(qe1.close).toHaveBeenCalled();
+    expect(qe2.close).toHaveBeenCalled();
   });
 });
 

--- a/apps/web/server/utils/queue-events.ts
+++ b/apps/web/server/utils/queue-events.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from "node:events";
-import { createQueueEvents } from "@bookhouse/shared";
+import { createQueueEvents, QUEUES } from "@bookhouse/shared";
 import type { QueueProgressData } from "@bookhouse/shared";
 
 export type SSEJobEventData =
@@ -18,25 +18,27 @@ interface QueueEventsLike {
 }
 
 export class QueueEventsManager {
-  private queueEvents: QueueEventsLike;
+  private queueEventsList: QueueEventsLike[];
   private emitter = new EventEmitter();
 
-  constructor(queueEvents: QueueEventsLike) {
-    this.queueEvents = queueEvents;
-    this.setupListeners();
+  constructor(queueEvents: QueueEventsLike | QueueEventsLike[]) {
+    this.queueEventsList = Array.isArray(queueEvents) ? queueEvents : [queueEvents];
+    for (const qe of this.queueEventsList) {
+      this.setupListeners(qe);
+    }
   }
 
-  private setupListeners() {
-    this.queueEvents.on("completed", ({ jobId }: { jobId: string }) => {
+  private setupListeners(queueEvents: QueueEventsLike) {
+    queueEvents.on("completed", ({ jobId }: { jobId: string }) => {
       this.broadcast({ type: "job:completed", data: { jobId } });
     });
-    this.queueEvents.on("failed", ({ jobId, failedReason }: { jobId: string; failedReason: string }) => {
+    queueEvents.on("failed", ({ jobId, failedReason }: { jobId: string; failedReason: string }) => {
       this.broadcast({ type: "job:failed", data: { jobId, error: failedReason } });
     });
-    this.queueEvents.on("active", ({ jobId }: { jobId: string }) => {
+    queueEvents.on("active", ({ jobId }: { jobId: string }) => {
       this.broadcast({ type: "job:active", data: { jobId } });
     });
-    this.queueEvents.on("progress", ({ jobId, data }: { jobId: string; data: QueueProgressData }) => {
+    queueEvents.on("progress", ({ jobId, data }: { jobId: string; data: QueueProgressData }) => {
       this.broadcast({ type: "job:progress", data: { jobId, progress: data } });
     });
   }
@@ -53,7 +55,7 @@ export class QueueEventsManager {
   }
 
   async close() {
-    await this.queueEvents.close();
+    await Promise.all(this.queueEventsList.map((qe) => qe.close()));
   }
 }
 
@@ -61,7 +63,10 @@ let instance: QueueEventsManager | null = null;
 
 export function getQueueEventsManager(): QueueEventsManager {
   if (!instance) {
-    instance = new QueueEventsManager(createQueueEvents());
+    instance = new QueueEventsManager([
+      createQueueEvents(QUEUES.LIBRARY),
+      createQueueEvents(QUEUES.ENRICHMENT),
+    ]);
   }
   return instance;
 }

--- a/apps/web/src/components/author-avatar.test.tsx
+++ b/apps/web/src/components/author-avatar.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment happy-dom
+import { render, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { AuthorAvatar } from "./author-avatar";
+
+vi.mock("lucide-react", () => ({
+  Users: (props: Record<string, string>) => <svg data-testid="users-icon" {...props} />,
+}));
+
+describe("AuthorAvatar", () => {
+  it("renders img when imagePath is set", () => {
+    const { container } = render(<AuthorAvatar id="c1" imagePath="c1" />);
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute("src")).toBe("/api/authors/c1/thumb");
+    expect(img?.getAttribute("loading")).toBe("lazy");
+  });
+
+  it("uses medium size when specified", () => {
+    const { container } = render(<AuthorAvatar id="c1" imagePath="c1" size="medium" />);
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("/api/authors/c1/medium");
+  });
+
+  it("renders fallback icon when imagePath is null", () => {
+    const { container, getByTestId } = render(<AuthorAvatar id="c1" imagePath={null} />);
+    expect(container.querySelector("img")).toBeNull();
+    expect(getByTestId("users-icon")).toBeTruthy();
+  });
+
+  it("renders fallback icon when img fails to load", () => {
+    const { container, getByTestId } = render(<AuthorAvatar id="c1" imagePath="c1" />);
+    const img = container.querySelector("img") as HTMLImageElement;
+    expect(img).toBeTruthy();
+    fireEvent.error(img);
+    expect(container.querySelector("img")).toBeNull();
+    expect(getByTestId("users-icon")).toBeTruthy();
+  });
+
+  it("applies custom className", () => {
+    const { container } = render(<AuthorAvatar id="c1" imagePath={null} className="size-16" />);
+    const div = container.firstElementChild;
+    expect(div?.className).toContain("size-16");
+  });
+
+  it("includes cache version in img src when provided", () => {
+    const { container } = render(<AuthorAvatar id="c1" imagePath="c1" cacheVersion={3} />);
+    const img = container.querySelector("img");
+    expect(img?.getAttribute("src")).toBe("/api/authors/c1/thumb?v=3");
+  });
+
+  it("applies custom className to img", () => {
+    const { container } = render(<AuthorAvatar id="c1" imagePath="c1" className="size-16" />);
+    const img = container.querySelector("img");
+    expect(img?.className).toContain("size-16");
+  });
+});

--- a/apps/web/src/components/author-avatar.tsx
+++ b/apps/web/src/components/author-avatar.tsx
@@ -1,0 +1,32 @@
+import { useState } from "react";
+import { Users } from "lucide-react";
+
+interface AuthorAvatarProps {
+  id: string;
+  imagePath: string | null;
+  size?: "thumb" | "medium";
+  className?: string;
+  cacheVersion?: number;
+}
+
+export function AuthorAvatar({ id, imagePath, size = "thumb", className = "size-10", cacheVersion }: AuthorAvatarProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+
+  if (!imagePath || imgFailed) {
+    return (
+      <div className={`flex shrink-0 items-center justify-center rounded-full bg-muted ${className}`}>
+        <Users className="size-5 text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={`/api/authors/${id}/${size}${cacheVersion ? `?v=${String(cacheVersion)}` : ""}`}
+      alt=""
+      loading="lazy"
+      className={`shrink-0 rounded-full object-cover ${className}`}
+      onError={() => { setImgFailed(true); }}
+    />
+  );
+}

--- a/apps/web/src/components/editable-tag-field.test.tsx
+++ b/apps/web/src/components/editable-tag-field.test.tsx
@@ -1,0 +1,309 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import { EditableTagField } from "./editable-tag-field";
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn() },
+}));
+
+describe("EditableTagField", () => {
+  it("renders comma-separated values in read mode", () => {
+    render(<EditableTagField values={["Alice", "Bob"]} onSave={vi.fn()} />);
+    expect(screen.getByText("Alice, Bob")).toBeTruthy();
+  });
+
+  it("renders placeholder when values are empty", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} placeholder="No authors" />);
+    expect(screen.getByText("No authors")).toBeTruthy();
+  });
+
+  it("switches to edit mode on click", () => {
+    render(<EditableTagField values={["Alice"]} onSave={vi.fn()} />);
+    fireEvent.click(screen.getByText("Alice"));
+    // Should show a tag chip and an input
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByRole("textbox")).toBeTruthy();
+  });
+
+  it("adds a tag on Enter", () => {
+    render(<EditableTagField values={["Alice"]} onSave={vi.fn()} />);
+    fireEvent.click(screen.getByText("Alice"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Bob" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    // Bob should now appear as a tag
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
+  it("adds a tag on Tab", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Carol" } });
+    fireEvent.keyDown(input, { key: "Tab" });
+    expect(screen.getByText("Carol")).toBeTruthy();
+  });
+
+  it("does not add empty tags", () => {
+    render(<EditableTagField values={["Alice"]} onSave={vi.fn()} />);
+    fireEvent.click(screen.getByText("Alice"));
+    const input = screen.getByRole("textbox");
+    fireEvent.keyDown(input, { key: "Enter" });
+    // Should still only have Alice
+    const chips = screen.getAllByRole("button", { name: /remove/i });
+    expect(chips).toHaveLength(1);
+  });
+
+  it("removes a tag when X is clicked", () => {
+    render(<EditableTagField values={["Alice", "Bob"]} onSave={vi.fn()} />);
+    fireEvent.click(screen.getByText("Alice, Bob"));
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    fireEvent.click(removeButtons[0] as HTMLButtonElement);
+    // Alice should be gone
+    expect(screen.queryByText("Alice")).toBeNull();
+    expect(screen.getByText("Bob")).toBeTruthy();
+  });
+
+  it("removes last tag on Backspace when input is empty", () => {
+    render(<EditableTagField values={["Alice", "Bob"]} onSave={vi.fn()} />);
+    fireEvent.click(screen.getByText("Alice, Bob"));
+    const input = screen.getByRole("textbox");
+    fireEvent.keyDown(input, { key: "Backspace" });
+    // Bob should be removed
+    expect(screen.getByText("Alice")).toBeTruthy();
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    expect(removeButtons).toHaveLength(1);
+  });
+
+  it("does not remove tag on Backspace when input has text", () => {
+    render(<EditableTagField values={["Alice"]} onSave={vi.fn()} />);
+    fireEvent.click(screen.getByText("Alice"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Bo" } });
+    fireEvent.keyDown(input, { key: "Backspace" });
+    // Alice should still be there
+    expect(screen.getByText("Alice")).toBeTruthy();
+  });
+
+  it("saves on blur", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<EditableTagField values={["Alice"]} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Alice"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Bob" } });
+    fireEvent.blur(input);
+    await vi.waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(["Alice", "Bob"]);
+    });
+  });
+
+  it("includes pending input text as a tag on blur", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<EditableTagField values={[]} onSave={onSave} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "New Author" } });
+    fireEvent.blur(input);
+    await vi.waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(["New Author"]);
+    });
+  });
+
+  it("cancels on Escape and reverts to original values", () => {
+    const onSave = vi.fn();
+    render(<EditableTagField values={["Alice"]} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Alice"));
+    // Add a tag
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Bob" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    // Now cancel
+    fireEvent.keyDown(input, { key: "Escape" });
+    // Should revert to read mode showing original
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("does not save when required and all tags removed", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<EditableTagField values={["Alice"]} onSave={onSave} required />);
+    fireEvent.click(screen.getByText("Alice"));
+    // Remove the only tag
+    const removeButton = screen.getByRole("button", { name: /remove/i });
+    fireEvent.click(removeButton);
+    // Blur to try saving
+    const input = screen.getByRole("textbox");
+    fireEvent.blur(input);
+    // Should revert, not save
+    await vi.waitFor(() => {
+      expect(screen.getByText("Alice")).toBeTruthy();
+    });
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("does not save when values unchanged", () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    render(<EditableTagField values={["Alice"]} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Alice"));
+    const input = screen.getByRole("textbox");
+    fireEvent.blur(input);
+    expect(onSave).not.toHaveBeenCalled();
+  });
+
+  it("shows toast on save error", async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error("Network error"));
+    render(<EditableTagField values={["Alice"]} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Alice"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Bob" } });
+    fireEvent.blur(input);
+    await vi.waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
+  });
+
+  it("handles non-Error save failure", async () => {
+    const onSave = vi.fn().mockRejectedValue("string error");
+    render(<EditableTagField values={["Alice"]} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Alice"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Bob" } });
+    fireEvent.blur(input);
+    await vi.waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
+  });
+
+  it("switches to edit mode on Enter key in read mode", () => {
+    render(<EditableTagField values={["Alice"]} onSave={vi.fn()} />);
+    const display = screen.getByText("Alice");
+    fireEvent.keyDown(display, { key: "Enter" });
+    expect(screen.getByRole("textbox")).toBeTruthy();
+  });
+
+  it("switches to edit mode on Space key in read mode", () => {
+    render(<EditableTagField values={["Alice"]} onSave={vi.fn()} />);
+    const display = screen.getByText("Alice");
+    fireEvent.keyDown(display, { key: " " });
+    expect(screen.getByRole("textbox")).toBeTruthy();
+  });
+
+  it("does not save when focus moves within the container (e.g., clicking X button)", async () => {
+    const onSave = vi.fn().mockResolvedValue(undefined);
+    const { container } = render(<EditableTagField values={["Alice", "Bob"]} onSave={onSave} />);
+    fireEvent.click(screen.getByText("Alice, Bob"));
+    const removeButtons = screen.getAllByRole("button", { name: /remove/i });
+    // Simulate blur with relatedTarget inside the container
+    const input = screen.getByRole("textbox");
+    const editContainer = container.firstElementChild as HTMLElement;
+    fireEvent.blur(input, { relatedTarget: removeButtons[0] });
+    // Focus stayed inside — should NOT save
+    expect(onSave).not.toHaveBeenCalled();
+    // Now click the X to remove Alice
+    fireEvent.click(removeButtons[0] as HTMLButtonElement);
+    expect(screen.queryByText("Alice")).toBeNull();
+    // Blur outside the container to trigger save
+    fireEvent.blur(editContainer, { relatedTarget: null });
+    await vi.waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(["Bob"]);
+    });
+  });
+
+  it("shows autocomplete suggestions when typing 2+ characters", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} suggestions={["Alice Walker", "Alice Munro", "Bob"]} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Al" } });
+    expect(screen.getByText("Alice Walker")).toBeTruthy();
+    expect(screen.getByText("Alice Munro")).toBeTruthy();
+    expect(screen.queryByText("Bob")).toBeNull();
+  });
+
+  it("does not show suggestions with fewer than 2 characters", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} suggestions={["Alice"]} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "A" } });
+    expect(screen.queryByText("Alice")).toBeNull();
+  });
+
+  it("excludes already-added tags from suggestions", () => {
+    render(<EditableTagField values={["Alice Walker"]} onSave={vi.fn()} suggestions={["Alice Walker", "Alice Munro"]} />);
+    fireEvent.click(screen.getByText("Alice Walker"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Ali" } });
+    expect(screen.queryByText("Alice Walker")).not.toBeNull(); // exists as a tag chip
+    // Only Alice Munro should appear in the dropdown
+    const suggestions = screen.getAllByText("Alice Munro");
+    expect(suggestions).toHaveLength(1);
+  });
+
+  it("selects a suggestion with Enter after arrow down", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} suggestions={["Alice Walker", "Alice Munro"]} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Ali" } });
+    fireEvent.keyDown(input, { key: "ArrowDown" });
+    fireEvent.keyDown(input, { key: "Enter" });
+    // Alice Walker should be added as a tag
+    expect(screen.getByText("Alice Walker")).toBeTruthy();
+  });
+
+  it("navigates suggestions down then up", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} suggestions={["Alice Walker", "Alice Munro"]} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Ali" } });
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // index 0
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // index 1
+    fireEvent.keyDown(input, { key: "ArrowUp" }); // back to index 0
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(screen.getByText("Alice Walker")).toBeTruthy();
+  });
+
+  it("navigates suggestions with ArrowUp", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} suggestions={["Alice Walker", "Alice Munro"]} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Ali" } });
+    fireEvent.keyDown(input, { key: "ArrowUp" }); // wraps to last
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(screen.getByText("Alice Munro")).toBeTruthy();
+  });
+
+  it("selects a suggestion on click", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} suggestions={["Alice Walker"]} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Ali" } });
+    fireEvent.mouseDown(screen.getByText("Alice Walker"));
+    // Should be added as a tag
+    const tags = screen.getAllByRole("button", { name: /remove/i });
+    expect(tags).toHaveLength(1);
+  });
+
+  it("resets selected index when input changes", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} suggestions={["Alice Walker", "Bob Smith"]} placeholder="Add" />);
+    fireEvent.click(screen.getByText("Add"));
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "Ali" } });
+    fireEvent.keyDown(input, { key: "ArrowDown" }); // select first
+    fireEvent.change(input, { target: { value: "Bo" } }); // type something different
+    fireEvent.keyDown(input, { key: "Enter" }); // should add "Bo" as typed, not select suggestion
+    // "Bo" should be added (not "Bob Smith" since index was reset)
+    expect(screen.getByText("Bo")).toBeTruthy();
+  });
+
+  it("does not switch to edit mode on other keys in read mode", () => {
+    render(<EditableTagField values={["Alice"]} onSave={vi.fn()} />);
+    const display = screen.getByText("Alice");
+    fireEvent.keyDown(display, { key: "Tab" });
+    expect(screen.queryByRole("textbox")).toBeNull();
+  });
+
+  it("renders dash when no values and no placeholder", () => {
+    render(<EditableTagField values={[]} onSave={vi.fn()} />);
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/editable-tag-field.tsx
+++ b/apps/web/src/components/editable-tag-field.tsx
@@ -1,0 +1,204 @@
+import { useRef, useState } from "react";
+import { X } from "lucide-react";
+import { toast } from "sonner";
+import { cn } from "~/lib/utils";
+
+interface EditableTagFieldProps {
+  values: string[];
+  onSave: (values: string[]) => Promise<void>;
+  suggestions?: string[];
+  placeholder?: string;
+  required?: boolean;
+  className?: string;
+}
+
+export function EditableTagField({
+  values,
+  onSave,
+  suggestions = [],
+  placeholder,
+  required = false,
+  className,
+}: EditableTagFieldProps) {
+  const [editing, setEditing] = useState(false);
+  const [tags, setTags] = useState<string[]>(values);
+  const [input, setInput] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [selectedIndex, setSelectedIndex] = useState(-1);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+
+  const filtered = input.length >= 2
+    ? suggestions.filter((s) =>
+        s.toLowerCase().includes(input.toLowerCase()) && !tags.includes(s),
+      ).slice(0, 8)
+    : [];
+
+  function startEditing() {
+    setTags(values);
+    setInput("");
+    setSelectedIndex(-1);
+    setEditing(true);
+  }
+
+  function selectSuggestion(name: string) {
+    setTags((prev) => [...prev, name]);
+    setInput("");
+    setSelectedIndex(-1);
+    inputRef.current?.focus();
+  }
+
+  function addTag() {
+    const trimmed = input.trim();
+    setTags((prev) => [...prev, trimmed]);
+    setInput("");
+    setSelectedIndex(-1);
+  }
+
+  function removeTag(index: number) {
+    setTags((prev) => prev.filter((_, i) => i !== index));
+  }
+
+  async function save() {
+    const finalTags = input.trim() ? [...tags, input.trim()] : tags;
+
+    if (required && finalTags.length === 0) {
+      setTags(values);
+      setInput("");
+      setEditing(false);
+      return;
+    }
+
+    if (JSON.stringify(finalTags) === JSON.stringify(values)) {
+      setEditing(false);
+      return;
+    }
+
+    setSaving(true);
+    try {
+      await onSave(finalTags);
+      setEditing(false);
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === "Escape") {
+      setTags(values);
+      setInput("");
+      setSelectedIndex(-1);
+      setEditing(false);
+      return;
+    }
+    if (e.key === "ArrowDown" && filtered.length > 0) {
+      e.preventDefault();
+      setSelectedIndex((prev) => (prev + 1) % filtered.length);
+      return;
+    }
+    if (e.key === "ArrowUp" && filtered.length > 0) {
+      e.preventDefault();
+      setSelectedIndex((prev) => (prev <= 0 ? filtered.length - 1 : prev - 1));
+      return;
+    }
+    if (e.key === "Enter" || e.key === "Tab") {
+      if (selectedIndex >= 0 && filtered[selectedIndex]) {
+        e.preventDefault();
+        selectSuggestion(filtered[selectedIndex]);
+        return;
+      }
+      if (input.trim()) {
+        e.preventDefault();
+        addTag();
+      }
+      return;
+    }
+    if (e.key === "Backspace" && input === "" && tags.length > 0) {
+      setTags((prev) => prev.slice(0, -1));
+    }
+  }
+
+  if (!editing) {
+    const display = values.length > 0 ? values.join(", ") : undefined;
+    return (
+      <div
+        className={cn(
+          "cursor-pointer rounded px-1 -mx-1 border border-transparent hover:border-border hover:bg-accent/50 transition-colors",
+          !display && "text-muted-foreground italic",
+          className,
+        )}
+        onClick={startEditing}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") startEditing(); }}
+      >
+        {display ?? placeholder ?? "—"}
+      </div>
+    );
+  }
+
+  function handleContainerBlur(e: React.FocusEvent) {
+    if (containerRef.current?.contains(e.relatedTarget as Node)) return;
+    void save();
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className={cn(
+        "relative flex flex-wrap items-center gap-1 rounded border border-input px-1 -mx-1 py-0.5 transition-colors",
+        "focus-within:border-ring focus-within:ring-[2px] focus-within:ring-ring/50",
+        className,
+      )}
+      onBlur={handleContainerBlur}
+    >
+      {tags.map((tag, i) => (
+        <span
+          key={`${tag}-${String(i)}`}
+          className="inline-flex items-center gap-0.5 rounded-full bg-secondary px-2 py-0.5 text-sm"
+        >
+          {tag}
+          <button
+            type="button"
+            aria-label={`remove ${tag}`}
+            className="ml-0.5 rounded-full p-0.5 hover:bg-muted-foreground/20"
+            onClick={() => { removeTag(i); inputRef.current?.focus(); }}
+            disabled={saving}
+          >
+            <X className="size-3" />
+          </button>
+        </span>
+      ))}
+      <input
+        ref={inputRef}
+        type="text"
+        value={input}
+        onChange={(e) => { setInput(e.target.value); setSelectedIndex(-1); }}
+        onKeyDown={handleKeyDown}
+        disabled={saving}
+        autoFocus
+        className="min-w-[80px] flex-1 bg-transparent py-0.5 outline-none text-sm"
+        placeholder={tags.length === 0 ? (placeholder ?? "Type and press Enter") : ""}
+      />
+      {filtered.length > 0 && (
+        <div className="absolute left-0 top-full z-50 mt-1 w-full rounded-md border bg-popover shadow-md">
+          {filtered.map((name, i) => (
+            <button
+              key={name}
+              type="button"
+              className={cn(
+                "block w-full px-3 py-1.5 text-left text-sm hover:bg-accent",
+                i === selectedIndex && "bg-accent",
+              )}
+              onMouseDown={(e) => { e.preventDefault(); selectSuggestion(name); }}
+            >
+              {name}
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/lib/server-fns/authors.test.ts
+++ b/apps/web/src/lib/server-fns/authors.test.ts
@@ -17,21 +17,45 @@ vi.mock("@tanstack/react-start", () => ({
 const contributorFindManyMock = vi.fn();
 const contributorFindUniqueOrThrowMock = vi.fn();
 const workFindManyMock = vi.fn();
+const importJobCreateMock = vi.fn().mockResolvedValue({ id: "ij-1" });
 vi.mock("@bookhouse/db", () => ({
   db: {
     contributor: {
       findMany: contributorFindManyMock,
+      findUnique: vi.fn().mockResolvedValue({ id: "c1" }),
       findUniqueOrThrow: contributorFindUniqueOrThrowMock,
+      update: vi.fn().mockResolvedValue({}),
     },
     work: {
       findMany: workFindManyMock,
     },
+    importJob: {
+      create: importJobCreateMock,
+    },
   },
+}));
+
+const enqueueEnrichmentJobMock = vi.fn().mockResolvedValue("job-id");
+const getActiveEnrichmentJobCountMock = vi.fn().mockResolvedValue(0);
+vi.mock("@bookhouse/shared", () => ({
+  enqueueEnrichmentJob: enqueueEnrichmentJobMock,
+  getActiveEnrichmentJobCount: getActiveEnrichmentJobCountMock,
+  ENRICHMENT_JOB_NAMES: { ENRICH_CONTRIBUTOR: "enrich-contributor" },
+}));
+
+const applyAuthorPhotoFromUrlMock = vi.fn().mockResolvedValue({ success: true });
+const resizeAndSaveCoverMock = vi.fn();
+vi.mock("@bookhouse/ingest", () => ({
+  applyAuthorPhotoFromUrl: applyAuthorPhotoFromUrlMock,
+  resizeAndSaveCover: resizeAndSaveCoverMock,
 }));
 
 import {
   getAuthorsListServerFn,
   getAuthorDetailServerFn,
+  enrichAuthorPhotosServerFn,
+  getEnrichAuthorPhotosProgressServerFn,
+  fetchAuthorPhotoFromUrlServerFn,
 } from "./authors";
 
 describe("getAuthorsListServerFn", () => {
@@ -44,6 +68,7 @@ describe("getAuthorsListServerFn", () => {
       {
         id: "c1",
         nameDisplay: "Author One",
+        imagePath: null,
         editions: [
           { edition: { workId: "w1" } },
           { edition: { workId: "w1" } },
@@ -65,7 +90,7 @@ describe("getAuthorsListServerFn", () => {
       orderBy: { nameDisplay: "asc" },
     });
     expect(result).toEqual([
-      { id: "c1", nameDisplay: "Author One", workCount: 2 },
+      { id: "c1", nameDisplay: "Author One", workCount: 2, imagePath: null },
     ]);
   });
 
@@ -87,6 +112,7 @@ describe("getAuthorDetailServerFn", () => {
       id: "c1",
       nameDisplay: "Author One",
       nameCanonical: "author one",
+      imagePath: "c1",
       editions: [
         { edition: { workId: "w1" } },
         { edition: { workId: "w2" } },
@@ -109,6 +135,7 @@ describe("getAuthorDetailServerFn", () => {
         id: true,
         nameDisplay: true,
         nameCanonical: true,
+        imagePath: true,
         editions: {
           where: { role: "AUTHOR" },
           select: { edition: { select: { workId: true } } },
@@ -130,6 +157,7 @@ describe("getAuthorDetailServerFn", () => {
       id: "c1",
       nameDisplay: "Author One",
       nameCanonical: "author one",
+      imagePath: "c1",
       works: fakeWorks,
     });
   });
@@ -147,6 +175,7 @@ describe("getAuthorDetailServerFn", () => {
       id: "c1",
       nameDisplay: "Lonely Author",
       nameCanonical: "lonely author",
+      imagePath: null,
       editions: [],
     });
     workFindManyMock.mockResolvedValue([]);
@@ -167,5 +196,133 @@ describe("getAuthorDetailServerFn", () => {
       },
     });
     expect(result.works).toEqual([]);
+  });
+});
+
+describe("enrichAuthorPhotosServerFn", () => {
+  beforeEach(() => {
+    contributorFindManyMock.mockReset();
+    enqueueEnrichmentJobMock.mockReset();
+    enqueueEnrichmentJobMock.mockResolvedValue("job-id");
+    importJobCreateMock.mockReset();
+    importJobCreateMock.mockResolvedValue({ id: "ij-1" });
+  });
+
+  it("creates ImportJob and enqueues ENRICH_CONTRIBUTOR jobs with importJobId", async () => {
+    contributorFindManyMock.mockResolvedValue([
+      { id: "c1" },
+      { id: "c2" },
+    ]);
+
+    const result = await enrichAuthorPhotosServerFn();
+
+    expect(importJobCreateMock).toHaveBeenCalledWith({
+      data: {
+        kind: "ENRICH_AUTHOR_PHOTOS",
+        status: "QUEUED",
+        totalFiles: 2,
+        processedFiles: 0,
+        errorCount: 0,
+      },
+    });
+    expect(enqueueEnrichmentJobMock).toHaveBeenCalledTimes(2);
+    expect(enqueueEnrichmentJobMock).toHaveBeenCalledWith("enrich-contributor", { contributorId: "c1", importJobId: "ij-1" });
+    expect(enqueueEnrichmentJobMock).toHaveBeenCalledWith("enrich-contributor", { contributorId: "c2", importJobId: "ij-1" });
+    expect(result).toEqual({ enqueuedCount: 2, importJobId: "ij-1" });
+  });
+
+  it("returns 0 when all contributors have photos", async () => {
+    contributorFindManyMock.mockResolvedValue([]);
+
+    const result = await enrichAuthorPhotosServerFn();
+
+    expect(importJobCreateMock).not.toHaveBeenCalled();
+    expect(enqueueEnrichmentJobMock).not.toHaveBeenCalled();
+    expect(result).toEqual({ enqueuedCount: 0 });
+  });
+});
+
+describe("getEnrichAuthorPhotosProgressServerFn", () => {
+  beforeEach(() => {
+    getActiveEnrichmentJobCountMock.mockReset();
+    getActiveEnrichmentJobCountMock.mockResolvedValue(0);
+  });
+
+  it("returns active count from queue", async () => {
+    getActiveEnrichmentJobCountMock.mockResolvedValue(5);
+
+    const result = await getEnrichAuthorPhotosProgressServerFn();
+
+    expect(getActiveEnrichmentJobCountMock).toHaveBeenCalledWith("enrich-contributor");
+    expect(result).toEqual({ activeCount: 5 });
+  });
+
+  it("returns 0 when no jobs are active", async () => {
+    getActiveEnrichmentJobCountMock.mockResolvedValue(0);
+
+    const result = await getEnrichAuthorPhotosProgressServerFn();
+
+    expect(result).toEqual({ activeCount: 0 });
+  });
+});
+
+describe("fetchAuthorPhotoFromUrlServerFn", () => {
+  beforeEach(() => {
+    applyAuthorPhotoFromUrlMock.mockReset();
+    applyAuthorPhotoFromUrlMock.mockResolvedValue({ success: true });
+  });
+
+  it("calls applyAuthorPhotoFromUrl with correct args", async () => {
+    const result = await fetchAuthorPhotoFromUrlServerFn({
+      data: { contributorId: "c1", imageUrl: "https://example.com/photo.jpg" },
+    });
+
+    expect(applyAuthorPhotoFromUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({ contributorId: "c1", imageUrl: "https://example.com/photo.jpg" }),
+      expect.objectContaining({ fetchUrl: expect.any(Function) as (() => void), resizeAndSave: expect.any(Function) as (() => void) }),
+      expect.objectContaining({ findContributor: expect.any(Function) as (() => void), updateContributor: expect.any(Function) as (() => void) }),
+    );
+    expect(result).toEqual({ success: true });
+  });
+
+  it("exercises inner deps for coverage", async () => {
+    await fetchAuthorPhotoFromUrlServerFn({
+      data: { contributorId: "c1", imageUrl: "https://example.com/photo.jpg" },
+    });
+
+    type InnerDeps = { fetchUrl: (url: string) => Promise<{ buffer: Buffer; contentType: string | null }>; resizeAndSave: (buf: Buffer, dir: string) => Promise<void> };
+    type InnerDbDeps = { findContributor: (id: string) => Promise<object | null>; updateContributor: (id: string, data: object) => Promise<void> };
+    const [[, innerDeps, innerDbDeps]] = applyAuthorPhotoFromUrlMock.mock.calls as [[object, InnerDeps, InnerDbDeps]];
+
+    // Exercise fetchUrl
+    const savedFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(new Uint8Array([0xff]).buffer),
+      headers: { get: () => "image/jpeg" },
+    }) as typeof fetch;
+    const fetchResult = await innerDeps.fetchUrl("https://example.com/img.jpg");
+    expect(fetchResult.contentType).toBe("image/jpeg");
+    globalThis.fetch = savedFetch;
+
+    // Exercise resizeAndSave
+    await innerDeps.resizeAndSave(Buffer.from([1]), "/tmp");
+    expect(resizeAndSaveCoverMock).toHaveBeenCalled();
+
+    // Exercise findContributor
+    contributorFindManyMock.mockResolvedValueOnce({ id: "c1" });
+    await innerDbDeps.findContributor("c1");
+
+    // Exercise updateContributor
+    await innerDbDeps.updateContributor("c1", { imagePath: "c1" });
+  });
+
+  it("propagates errors from applyAuthorPhotoFromUrl", async () => {
+    applyAuthorPhotoFromUrlMock.mockRejectedValue(new Error("Image too small"));
+
+    await expect(
+      fetchAuthorPhotoFromUrlServerFn({
+        data: { contributorId: "c1", imageUrl: "https://example.com/tiny.jpg" },
+      }),
+    ).rejects.toThrow("Image too small");
   });
 });

--- a/apps/web/src/lib/server-fns/authors.ts
+++ b/apps/web/src/lib/server-fns/authors.ts
@@ -21,6 +21,7 @@ export const getAuthorsListServerFn = createServerFn({
     id: c.id,
     nameDisplay: c.nameDisplay,
     workCount: new Set(c.editions.map((ec) => ec.edition.workId)).size,
+    imagePath: c.imagePath,
   }));
 });
 
@@ -45,6 +46,7 @@ export const getAuthorDetailServerFn = createServerFn({
         id: true,
         nameDisplay: true,
         nameCanonical: true,
+        imagePath: true,
         editions: {
           where: { role: "AUTHOR" },
           select: { edition: { select: { workId: true } } },
@@ -70,6 +72,7 @@ export const getAuthorDetailServerFn = createServerFn({
       id: contributor.id,
       nameDisplay: contributor.nameDisplay,
       nameCanonical: contributor.nameCanonical,
+      imagePath: contributor.imagePath,
       works,
     };
   });
@@ -77,3 +80,81 @@ export const getAuthorDetailServerFn = createServerFn({
 export type AuthorDetail = Awaited<
   ReturnType<typeof getAuthorDetailServerFn>
 >;
+
+export const getEnrichAuthorPhotosProgressServerFn = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  const { getActiveEnrichmentJobCount } = await import("@bookhouse/shared");
+  const activeCount = await getActiveEnrichmentJobCount("enrich-contributor");
+  return { activeCount };
+});
+
+export const enrichAuthorPhotosServerFn = createServerFn({
+  method: "POST",
+}).handler(async () => {
+  const { db } = await import("@bookhouse/db");
+  const { enqueueEnrichmentJob } = await import("@bookhouse/shared");
+
+  const contributors = await db.contributor.findMany({
+    where: { imagePath: null },
+    select: { id: true },
+  });
+
+  if (contributors.length === 0) {
+    return { enqueuedCount: 0 };
+  }
+
+  const importJob = await db.importJob.create({
+    data: {
+      kind: "ENRICH_AUTHOR_PHOTOS",
+      status: "QUEUED",
+      totalFiles: contributors.length,
+      processedFiles: 0,
+      errorCount: 0,
+    },
+  });
+
+  for (const contributor of contributors) {
+    await enqueueEnrichmentJob("enrich-contributor", {
+      contributorId: contributor.id,
+      importJobId: importJob.id,
+    });
+  }
+
+  return { enqueuedCount: contributors.length, importJobId: importJob.id };
+});
+
+const fetchAuthorPhotoSchema = z.object({
+  contributorId: z.string().min(1),
+  imageUrl: z.string().url(),
+});
+
+export const fetchAuthorPhotoFromUrlServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(fetchAuthorPhotoSchema)
+  .handler(async ({ data }) => {
+    const { applyAuthorPhotoFromUrl, resizeAndSaveCover } = await import("@bookhouse/ingest");
+    const { db } = await import("@bookhouse/db");
+
+    const coverCacheDir = process.env.COVER_CACHE_DIR ?? "/data/covers";
+
+    await applyAuthorPhotoFromUrl(
+      { contributorId: data.contributorId, imageUrl: data.imageUrl, coverCacheDir },
+      {
+        fetchUrl: async (url) => {
+          const response = await fetch(url);
+          const buffer = Buffer.from(await response.arrayBuffer());
+          const contentType = response.headers.get("content-type");
+          return { buffer, contentType };
+        },
+        resizeAndSave: (buf, dir) => resizeAndSaveCover(buf, dir),
+      },
+      {
+        findContributor: (id) => db.contributor.findUnique({ where: { id }, select: { id: true } }),
+        updateContributor: async (id, upd) => { await db.contributor.update({ where: { id }, data: upd }); },
+      },
+    );
+
+    return { success: true };
+  });

--- a/apps/web/src/lib/server-fns/editing.test.ts
+++ b/apps/web/src/lib/server-fns/editing.test.ts
@@ -21,6 +21,7 @@ const editionUpdateMock = vi.fn();
 const editionFindManyMock = vi.fn();
 const contributorFindFirstMock = vi.fn();
 const contributorCreateMock = vi.fn();
+const contributorFindManyMock = vi.fn();
 const editionContributorDeleteManyMock = vi.fn();
 const editionContributorCreateManyMock = vi.fn();
 const transactionMock = vi.fn();
@@ -38,6 +39,7 @@ vi.mock("@bookhouse/db", () => ({
     },
     contributor: {
       findFirst: contributorFindFirstMock,
+      findMany: contributorFindManyMock,
       create: contributorCreateMock,
     },
     editionContributor: {
@@ -60,6 +62,7 @@ import {
   updateWorkServerFn,
   updateEditionServerFn,
   updateWorkAuthorsServerFn,
+  getContributorNamesServerFn,
 } from "./editing";
 
 beforeEach(() => {
@@ -437,5 +440,23 @@ describe("updateWorkAuthorsServerFn", () => {
         },
       }),
     ).rejects.toThrow("At least one author is required");
+  });
+});
+
+describe("getContributorNamesServerFn", () => {
+  it("returns sorted contributor names", async () => {
+    contributorFindManyMock.mockResolvedValue([
+      { nameDisplay: "Brandon Sanderson" },
+      { nameDisplay: "Patrick Rothfuss" },
+    ]);
+
+    const result = await getContributorNamesServerFn();
+
+    expect(contributorFindManyMock).toHaveBeenCalledWith({
+      where: { editions: { some: {} } },
+      select: { nameDisplay: true },
+      orderBy: { nameDisplay: "asc" },
+    });
+    expect(result).toEqual(["Brandon Sanderson", "Patrick Rothfuss"]);
   });
 });

--- a/apps/web/src/lib/server-fns/editing.ts
+++ b/apps/web/src/lib/server-fns/editing.ts
@@ -183,3 +183,15 @@ export const updateWorkAuthorsServerFn = createServerFn({
 
     return { success: true };
   });
+
+export const getContributorNamesServerFn = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  const { db } = await import("@bookhouse/db");
+  const contributors = await db.contributor.findMany({
+    where: { editions: { some: {} } },
+    select: { nameDisplay: true },
+    orderBy: { nameDisplay: "asc" },
+  });
+  return contributors.map((c) => c.nameDisplay);
+});

--- a/apps/web/src/lib/server-fns/enrichment.test.ts
+++ b/apps/web/src/lib/server-fns/enrichment.test.ts
@@ -91,6 +91,7 @@ vi.mock("@bookhouse/ingest", () => {
     resizeCoverImage: vi.fn(),
     extractDominantColors: vi.fn(),
     canonicalizeContributorName: (name: string): string | null => name === "UNKNOWN" ? null : name.toLowerCase(),
+    createOLFetcher: () => fetch,
   };
 });
 

--- a/apps/web/src/lib/server-fns/enrichment.ts
+++ b/apps/web/src/lib/server-fns/enrichment.ts
@@ -104,8 +104,10 @@ export const searchEnrichmentServerFn = createServerFn({
       getDecryptedApiKey("hardcover"),
     ]);
 
+    const { createOLFetcher } = await import("@bookhouse/ingest");
+    const olFetch = createOLFetcher("bookhouse@teamsnail.org");
     const rateLimiter = new RateLimiter();
-    const deps = buildSearchDeps(gbKey, hcKey, rateLimiter, fetch, {
+    const deps = buildSearchDeps(gbKey, hcKey, rateLimiter, olFetch, {
       searchOpenLibrary,
       getOpenLibraryWork,
       getOpenLibraryEdition,

--- a/apps/web/src/routes/_authenticated/-authors.$authorId.test.tsx
+++ b/apps/web/src/routes/_authenticated/-authors.$authorId.test.tsx
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 import type * as TanstackRouter from "@tanstack/react-router";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 let mockLoaderData: {
@@ -8,6 +8,7 @@ let mockLoaderData: {
     id: string;
     nameDisplay: string;
     nameCanonical: string;
+    imagePath: string | null;
     works: {
       id: string;
       titleDisplay: string;
@@ -22,13 +23,18 @@ let mockLoaderData: {
     }[];
   };
 } = {
-  author: { id: "a1", nameDisplay: "Patrick Rothfuss", nameCanonical: "patrick rothfuss", works: [] },
+  author: { id: "a1", nameDisplay: "Patrick Rothfuss", nameCanonical: "patrick rothfuss", imagePath: null, works: [] },
 };
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
 
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual<typeof TanstackRouter>("@tanstack/react-router");
   return {
     ...actual,
+    useRouter: () => ({ invalidate: vi.fn() }),
     Link: ({ children, to, params, ...props }: { children?: React.ReactNode; to: string; params?: Record<string, string>; [key: string]: string | undefined | React.ReactNode | Record<string, string> | (() => void) }) => {
       let href = to;
       if (params) {
@@ -56,8 +62,14 @@ vi.mock("~/components/work-card", () => ({
 }));
 
 const getAuthorDetailServerFnMock = vi.fn();
+const fetchAuthorPhotoFromUrlServerFnMock = vi.fn().mockResolvedValue({ success: true });
 vi.mock("~/lib/server-fns/authors", () => ({
   getAuthorDetailServerFn: getAuthorDetailServerFnMock,
+  fetchAuthorPhotoFromUrlServerFn: fetchAuthorPhotoFromUrlServerFnMock,
+}));
+
+vi.mock("~/lib/mutation", () => ({
+  runMutation: async (fn: () => Promise<object>) => fn(),
 }));
 
 const makeWork = (title: string, formats: string[] = ["EBOOK"]) => ({
@@ -76,7 +88,7 @@ const makeWork = (title: string, formats: string[] = ["EBOOK"]) => ({
 describe("AuthorDetailPage", () => {
   beforeEach(() => {
     mockLoaderData = {
-      author: { id: "a1", nameDisplay: "Patrick Rothfuss", nameCanonical: "patrick rothfuss", works: [] },
+      author: { id: "a1", nameDisplay: "Patrick Rothfuss", nameCanonical: "patrick rothfuss", imagePath: null, works: [] },
     };
     vi.clearAllMocks();
   });
@@ -144,6 +156,196 @@ describe("AuthorDetailPage", () => {
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
     expect(screen.getByText("No works by this author")).toBeTruthy();
+  });
+
+  it("renders author photo when imagePath is set", async () => {
+    mockLoaderData.author.imagePath = "a1";
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    const { container } = render(<Page />);
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute("src")).toBe("/api/authors/a1/medium");
+  });
+
+  it("renders fallback icon when imagePath is null", async () => {
+    mockLoaderData.author.imagePath = null;
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    const { container } = render(<Page />);
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("uploads photo when file is selected", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    globalThis.fetch = mockFetch;
+
+    const { toast } = await import("sonner");
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const input = screen.getByTestId("photo-file-input");
+    const file = new File(["fake-image"], "photo.jpg", { type: "image/jpeg" });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await vi.waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Author photo updated");
+    });
+  });
+
+  it("shows error toast on upload failure", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, text: () => Promise.resolve("Bad image") });
+    globalThis.fetch = mockFetch;
+
+    const { toast } = await import("sonner");
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const input = screen.getByTestId("photo-file-input");
+    const file = new File(["bad"], "bad.jpg", { type: "image/jpeg" });
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalled();
+    });
+  });
+
+  it("shows generic error message on non-Error throw", async () => {
+    const mockFetch = vi.fn().mockRejectedValue("network failure");
+    globalThis.fetch = mockFetch;
+
+    const { toast } = await import("sonner");
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const input = screen.getByTestId("photo-file-input");
+    fireEvent.change(input, { target: { files: [new File(["x"], "x.jpg", { type: "image/jpeg" })] } });
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Failed to upload photo");
+    });
+  });
+
+  it("shows default error message when response text is empty", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, text: () => Promise.resolve("") });
+    globalThis.fetch = mockFetch;
+
+    const { toast } = await import("sonner");
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const input = screen.getByTestId("photo-file-input");
+    fireEvent.change(input, { target: { files: [new File(["x"], "x.jpg", { type: "image/jpeg" })] } });
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith("Upload failed");
+    });
+  });
+
+  it("does nothing when no file is selected", async () => {
+    const mockFetch = vi.fn();
+    globalThis.fetch = mockFetch;
+
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const input = screen.getByTestId("photo-file-input");
+    fireEvent.change(input, { target: { files: [] } });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("opens file picker on avatar click", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const avatarButton = screen.getByTestId("avatar-upload-button");
+    fireEvent.click(avatarButton);
+    // Verifies click handler runs without error
+  });
+
+  it("opens file picker on avatar Enter key", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const avatarButton = screen.getByTestId("avatar-upload-button");
+    fireEvent.keyDown(avatarButton, { key: "Enter" });
+  });
+
+  it("opens file picker on avatar Space key", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const avatarButton = screen.getByTestId("avatar-upload-button");
+    fireEvent.keyDown(avatarButton, { key: " " });
+  });
+
+  it("ignores other keys on avatar", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const avatarButton = screen.getByTestId("avatar-upload-button");
+    fireEvent.keyDown(avatarButton, { key: "Tab" });
+  });
+
+  it("shows URL input when 'Link to photo' is clicked", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("link-photo-button"));
+    expect(screen.getByTestId("photo-url-input")).toBeTruthy();
+  });
+
+  it("fetches photo from URL when Fetch is clicked", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("link-photo-button"));
+    const input = screen.getByTestId("photo-url-input");
+    fireEvent.change(input, { target: { value: "https://example.com/photo.jpg" } });
+    fireEvent.click(screen.getByText("Fetch"));
+    await vi.waitFor(() => {
+      expect(fetchAuthorPhotoFromUrlServerFnMock).toHaveBeenCalledWith({
+        data: { contributorId: "a1", imageUrl: "https://example.com/photo.jpg" },
+      });
+    });
+    // After success, URL input should be hidden
+    await vi.waitFor(() => {
+      expect(screen.queryByTestId("url-input-row")).toBeNull();
+    });
+  });
+
+  it("does not fetch when URL is empty", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("link-photo-button"));
+    const fetchButton = screen.getByText("Fetch").closest("button");
+    expect(fetchButton?.disabled).toBe(true);
+  });
+
+  it("renders photo upload file input", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByTestId("photo-file-input")).toBeTruthy();
+  });
+
+  it("renders camera overlay on avatar hover area", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    const { container } = render(<Page />);
+    const overlay = container.querySelector(".group-hover\\:opacity-100");
+    expect(overlay).toBeTruthy();
   });
 
   it("renders pending skeleton", async () => {

--- a/apps/web/src/routes/_authenticated/-authors.index.test.tsx
+++ b/apps/web/src/routes/_authenticated/-authors.index.test.tsx
@@ -4,13 +4,15 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 let mockLoaderData: {
-  authors: { id: string; nameDisplay: string; workCount: number }[];
-} = { authors: [] };
+  authors: { id: string; nameDisplay: string; workCount: number; imagePath: string | null }[];
+  enrichingCount: number;
+} = { authors: [], enrichingCount: 0 };
 
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual<typeof TanstackRouter>("@tanstack/react-router");
   return {
     ...actual,
+    useRouter: () => ({ invalidate: vi.fn() }),
     Link: ({ children, to, params, ...props }: { children?: React.ReactNode; to: string; params?: Record<string, string>; [key: string]: string | undefined | React.ReactNode | Record<string, string> | (() => void) }) => {
       let href = to;
       if (params) {
@@ -34,28 +36,43 @@ vi.mock("~/components/skeletons/grid-page-skeleton", () => ({
 }));
 
 const getAuthorsListServerFnMock = vi.fn();
+const enrichAuthorPhotosServerFnMock = vi.fn().mockResolvedValue({ enqueuedCount: 0 });
+const getEnrichAuthorPhotosProgressServerFnMock = vi.fn().mockResolvedValue({ activeCount: 0 });
 vi.mock("~/lib/server-fns/authors", () => ({
   getAuthorsListServerFn: getAuthorsListServerFnMock,
+  enrichAuthorPhotosServerFn: enrichAuthorPhotosServerFnMock,
+  getEnrichAuthorPhotosProgressServerFn: getEnrichAuthorPhotosProgressServerFnMock,
 }));
 
-const makeAuthor = (name: string, workCount: number) => ({
+vi.mock("~/lib/mutation", () => ({
+  runMutation: async (fn: () => Promise<object>) => fn(),
+}));
+
+vi.mock("~/hooks/use-sse", () => ({
+  useSSE: vi.fn(),
+}));
+
+const makeAuthor = (name: string, workCount: number, imagePath: string | null = null) => ({
   id: `author-${name.toLowerCase().replace(/\s/g, "-")}`,
   nameDisplay: name,
   workCount,
+  imagePath,
 });
 
 describe("AuthorsListPage", () => {
   beforeEach(() => {
-    mockLoaderData = { authors: [] };
+    mockLoaderData = { authors: [], enrichingCount: 0 };
     vi.clearAllMocks();
   });
 
-  it("loader calls getAuthorsListServerFn", async () => {
+  it("loader calls getAuthorsListServerFn and getEnrichAuthorPhotosProgressServerFn", async () => {
     getAuthorsListServerFnMock.mockResolvedValueOnce([]);
+    getEnrichAuthorPhotosProgressServerFnMock.mockResolvedValueOnce({ activeCount: 3 });
     const { Route } = await import("./authors.index");
     const result = await (Route.options.loader as () => Promise<object>)();
     expect(getAuthorsListServerFnMock).toHaveBeenCalled();
-    expect(result).toEqual({ authors: [] });
+    expect(getEnrichAuthorPhotosProgressServerFnMock).toHaveBeenCalled();
+    expect(result).toEqual({ authors: [], enrichingCount: 3 });
   });
 
   it("renders 'Authors' heading", async () => {
@@ -68,6 +85,7 @@ describe("AuthorsListPage", () => {
   it("renders author names", async () => {
     mockLoaderData = {
       authors: [makeAuthor("Patrick Rothfuss", 3), makeAuthor("Brandon Sanderson", 15)],
+      enrichingCount: 0,
     };
     const { Route } = await import("./authors.index");
     const Page = Route.options.component as React.ComponentType;
@@ -79,6 +97,7 @@ describe("AuthorsListPage", () => {
   it("renders work count for each author", async () => {
     mockLoaderData = {
       authors: [makeAuthor("Patrick Rothfuss", 3)],
+      enrichingCount: 0,
     };
     const { Route } = await import("./authors.index");
     const Page = Route.options.component as React.ComponentType;
@@ -89,6 +108,7 @@ describe("AuthorsListPage", () => {
   it("renders singular 'work' for author with one work", async () => {
     mockLoaderData = {
       authors: [makeAuthor("One Book Author", 1)],
+      enrichingCount: 0,
     };
     const { Route } = await import("./authors.index");
     const Page = Route.options.component as React.ComponentType;
@@ -99,6 +119,7 @@ describe("AuthorsListPage", () => {
   it("links each author to /authors/$authorId", async () => {
     mockLoaderData = {
       authors: [makeAuthor("Patrick Rothfuss", 3)],
+      enrichingCount: 0,
     };
     const { Route } = await import("./authors.index");
     const Page = Route.options.component as React.ComponentType;
@@ -108,16 +129,81 @@ describe("AuthorsListPage", () => {
   });
 
   it("shows empty state when no authors", async () => {
-    mockLoaderData = { authors: [] };
+    mockLoaderData = { authors: [], enrichingCount: 0 };
     const { Route } = await import("./authors.index");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
     expect(screen.getByText("No authors found")).toBeTruthy();
   });
 
+  it("renders author photo when imagePath is set", async () => {
+    mockLoaderData = {
+      authors: [makeAuthor("Patrick Rothfuss", 3, "author-patrick-rothfuss")],
+      enrichingCount: 0,
+    };
+    const { Route } = await import("./authors.index");
+    const Page = Route.options.component as React.ComponentType;
+    const { container } = render(<Page />);
+    const img = container.querySelector("img");
+    expect(img).toBeTruthy();
+    expect(img?.getAttribute("src")).toBe("/api/authors/author-patrick-rothfuss/thumb");
+  });
+
+  it("renders fallback icon when imagePath is null", async () => {
+    mockLoaderData = {
+      authors: [makeAuthor("Patrick Rothfuss", 3, null)],
+      enrichingCount: 0,
+    };
+    const { Route } = await import("./authors.index");
+    const Page = Route.options.component as React.ComponentType;
+    const { container } = render(<Page />);
+    expect(container.querySelector("img")).toBeNull();
+  });
+
+  it("shows 'Fetching Photos...' when enrichingCount > 0", async () => {
+    mockLoaderData = {
+      authors: [makeAuthor("Patrick Rothfuss", 3)],
+      enrichingCount: 5,
+    };
+    const { Route } = await import("./authors.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByText("Fetching Photos...")).toBeTruthy();
+    const button = screen.getByText("Fetching Photos...").closest("button") as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+  });
+
+  it("renders Fetch Photos button", async () => {
+    mockLoaderData = {
+      authors: [makeAuthor("Patrick Rothfuss", 3)],
+      enrichingCount: 0,
+    };
+    const { Route } = await import("./authors.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByText("Fetch Photos")).toBeTruthy();
+  });
+
+  it("calls enrichAuthorPhotosServerFn when Fetch Photos is clicked", async () => {
+    enrichAuthorPhotosServerFnMock.mockResolvedValue({ enqueuedCount: 5 });
+    mockLoaderData = {
+      authors: [makeAuthor("Patrick Rothfuss", 3)],
+      enrichingCount: 0,
+    };
+    const { Route } = await import("./authors.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    const button = screen.getByText("Fetch Photos").closest("button") as HTMLButtonElement;
+    fireEvent.click(button);
+    await vi.waitFor(() => {
+      expect(enrichAuthorPhotosServerFnMock).toHaveBeenCalled();
+    });
+  });
+
   it("search filters authors by name", async () => {
     mockLoaderData = {
       authors: [makeAuthor("Patrick Rothfuss", 3), makeAuthor("Brandon Sanderson", 15)],
+      enrichingCount: 0,
     };
     const { Route } = await import("./authors.index");
     const Page = Route.options.component as React.ComponentType;

--- a/apps/web/src/routes/_authenticated/-library.$workId.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.$workId.test.tsx
@@ -47,7 +47,7 @@ interface MockProgress {
   percent: number | null;
 }
 
-let mockLoaderData: { work: MockWork; progress: MockProgress[]; trackingMode: string } = {
+let mockLoaderData: { work: MockWork; progress: MockProgress[]; trackingMode: string; contributorNames: string[] } = {
   work: {
     id: "work-1",
     titleDisplay: "The Name of the Wind",
@@ -91,6 +91,7 @@ let mockLoaderData: { work: MockWork; progress: MockProgress[]; trackingMode: st
   },
   progress: [],
   trackingMode: "BY_EDITION",
+  contributorNames: ["Patrick Rothfuss", "Brandon Sanderson"],
 };
 
 const mockNavigate = vi.fn();
@@ -176,6 +177,7 @@ vi.mock("~/lib/server-fns/editing", () => ({
   updateWorkServerFn: vi.fn(),
   updateEditionServerFn: vi.fn(),
   updateWorkAuthorsServerFn: vi.fn(),
+  getContributorNamesServerFn: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock("~/lib/server-fns/tags", () => ({
@@ -301,6 +303,7 @@ describe("WorkDetailPage", () => {
       },
       progress: [],
       trackingMode: "BY_EDITION",
+      contributorNames: ["Patrick Rothfuss", "Brandon Sanderson"],
     };
     capturedDialogProps.length = 0;
     forceRenderClosed = false;
@@ -328,6 +331,7 @@ describe("WorkDetailPage", () => {
       work: mockLoaderData.work,
       progress: [],
       trackingMode: "BY_EDITION",
+      contributorNames: [],
     });
   });
 
@@ -1053,24 +1057,31 @@ describe("WorkDetailPage", () => {
     }
 
     await waitFor(() => {
-      // Work fields: title, authors, description, tags = 4 editable fields
-      expect(updateWorkServerFnMock.mock.calls.length + updateWorkAuthorsServerFnMock.mock.calls.length).toBeGreaterThanOrEqual(3);
+      // Work fields: title, description, tags = 3 editable fields (authors is now a tag field)
+      expect(updateWorkServerFnMock.mock.calls.length).toBeGreaterThanOrEqual(2);
     });
   });
 
-  it("calls updateWorkAuthorsServerFn when clicking authors field", async () => {
+  it("calls updateWorkAuthorsServerFn when editing authors tag field", async () => {
     updateWorkAuthorsServerFnMock.mockResolvedValue({ success: true });
     const { Route } = await import("./library.$workId");
     const Page = Route.options.component as React.ComponentType;
     const { fireEvent, waitFor } = await import("@testing-library/react");
     render(<Page />);
 
-    // Click the authors editable field - gets first "Patrick Rothfuss" (the work-level one)
+    // Click the authors field to enter edit mode
     const authorFields = screen.getAllByText("Patrick Rothfuss");
     if (authorFields[0]) fireEvent.click(authorFields[0]);
 
+    // Add a new author and blur to save
+    const input = screen.getByRole("textbox");
+    fireEvent.change(input, { target: { value: "New Author" } });
+    fireEvent.blur(input);
+
     await waitFor(() => {
-      expect(updateWorkAuthorsServerFnMock).toHaveBeenCalled();
+      expect(updateWorkAuthorsServerFnMock).toHaveBeenCalledWith({
+        data: { workId: "work-1", authors: ["Patrick Rothfuss", "New Author"] },
+      });
     });
   });
 

--- a/apps/web/src/routes/_authenticated/authors.$authorId.tsx
+++ b/apps/web/src/routes/_authenticated/authors.$authorId.tsx
@@ -1,8 +1,14 @@
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { ChevronRight } from "lucide-react";
+import { useRef, useState } from "react";
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { Camera, ChevronRight, ImagePlus, Link2 } from "lucide-react";
+import { toast } from "sonner";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
 import { WorkCard } from "~/components/work-card";
+import { AuthorAvatar } from "~/components/author-avatar";
 import { GridPageSkeleton } from "~/components/skeletons/grid-page-skeleton";
-import { getAuthorDetailServerFn } from "~/lib/server-fns/authors";
+import { getAuthorDetailServerFn, fetchAuthorPhotoFromUrlServerFn } from "~/lib/server-fns/authors";
+import { runMutation } from "~/lib/mutation";
 
 export const Route = createFileRoute("/_authenticated/authors/$authorId")({
   loader: async ({ params }) => {
@@ -29,6 +35,54 @@ function getFormats(work: { editions: { formatFamily: string }[] }): string[] {
 
 function AuthorDetailPage() {
   const { author } = Route.useLoaderData();
+  const router = useRouter();
+  const photoInputRef = useRef<HTMLInputElement>(null);
+  const [uploading, setUploading] = useState(false);
+  const [photoVersion, setPhotoVersion] = useState(0);
+  const [showUrlInput, setShowUrlInput] = useState(false);
+  const [photoUrl, setPhotoUrl] = useState("");
+
+  async function handlePhotoUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploading(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetch(`/api/upload-author-photo/${author.id}`, {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || "Upload failed");
+      }
+      toast.success("Author photo updated");
+      setPhotoVersion((v) => v + 1);
+      void router.invalidate();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to upload photo");
+    } finally {
+      setUploading(false);
+      e.target.value = "";
+    }
+  }
+
+  async function handlePhotoUrl() {
+    setUploading(true);
+    try {
+      await runMutation(
+        () => fetchAuthorPhotoFromUrlServerFn({ data: { contributorId: author.id, imageUrl: photoUrl.trim() } }),
+        { success: "Author photo updated" },
+      );
+      setPhotoVersion((v) => v + 1);
+      setShowUrlInput(false);
+      setPhotoUrl("");
+      void router.invalidate();
+    } finally {
+      setUploading(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -40,7 +94,64 @@ function AuthorDetailPage() {
         <span className="text-foreground">{author.nameDisplay}</span>
       </nav>
 
-      <h1 className="text-2xl font-bold">{author.nameDisplay}</h1>
+      <div className="flex items-center gap-4">
+        <div
+          className="group relative cursor-pointer"
+          data-testid="avatar-upload-button"
+          onClick={() => { photoInputRef.current?.click(); }}
+          role="button"
+          tabIndex={0}
+          onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") photoInputRef.current?.click(); }}
+        >
+          <AuthorAvatar
+            id={author.id}
+            imagePath={author.imagePath}
+            size="medium"
+            className="size-16"
+            cacheVersion={photoVersion}
+          />
+          <div className="absolute inset-0 flex items-center justify-center rounded-full bg-black/50 opacity-0 transition-opacity group-hover:opacity-100">
+            <Camera className="size-5 text-white" />
+          </div>
+        </div>
+        <input
+          ref={photoInputRef}
+          type="file"
+          accept="image/*"
+          className="hidden"
+          data-testid="photo-file-input"
+          onChange={(e) => { void handlePhotoUpload(e); }}
+          disabled={uploading}
+        />
+        <div>
+          <h1 className="text-2xl font-bold">{author.nameDisplay}</h1>
+          <button
+            type="button"
+            className="mt-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"
+            onClick={() => { setShowUrlInput((v) => !v); }}
+            data-testid="link-photo-button"
+          >
+            <Link2 className="size-3" />
+            Link to photo
+          </button>
+        </div>
+      </div>
+
+      {showUrlInput && (
+        <div className="flex items-center gap-2" data-testid="url-input-row">
+          <Input
+            placeholder="https://example.com/author-photo.jpg"
+            value={photoUrl}
+            onChange={(e) => { setPhotoUrl(e.target.value); }}
+            className="max-w-md"
+            data-testid="photo-url-input"
+          />
+          <Button size="sm" disabled={uploading || !photoUrl.trim()} onClick={() => { void handlePhotoUrl(); }}>
+            <ImagePlus className="size-4" />
+            Fetch
+          </Button>
+        </div>
+      )}
 
       {author.works.length === 0 ? (
         <p className="text-muted-foreground">No works by this author</p>

--- a/apps/web/src/routes/_authenticated/authors.index.tsx
+++ b/apps/web/src/routes/_authenticated/authors.index.tsx
@@ -1,25 +1,39 @@
 import { useState, useMemo } from "react";
-import { createFileRoute, Link } from "@tanstack/react-router";
-import { Users } from "lucide-react";
+import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
+import { ImagePlus, Loader2, Users } from "lucide-react";
+import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { AuthorAvatar } from "~/components/author-avatar";
 import { GridPageSkeleton } from "~/components/skeletons/grid-page-skeleton";
+import { useSSE } from "~/hooks/use-sse";
+import { runMutation } from "~/lib/mutation";
 import {
   getAuthorsListServerFn,
+  enrichAuthorPhotosServerFn,
+  getEnrichAuthorPhotosProgressServerFn,
   type AuthorListItem,
 } from "~/lib/server-fns/authors";
 
 export const Route = createFileRoute("/_authenticated/authors/")({
   loader: async () => {
-    const authors = await getAuthorsListServerFn();
-    return { authors };
+    const [authors, progress] = await Promise.all([
+      getAuthorsListServerFn(),
+      getEnrichAuthorPhotosProgressServerFn(),
+    ]);
+    return { authors, enrichingCount: progress.activeCount };
   },
   pendingComponent: GridPageSkeleton,
   component: AuthorsListPage,
 });
 
 function AuthorsListPage() {
-  const { authors } = Route.useLoaderData();
+  const { authors, enrichingCount } = Route.useLoaderData();
+  const router = useRouter();
   const [search, setSearch] = useState("");
+  const [fetching, setFetching] = useState(false);
+
+  const enriching = enrichingCount > 0;
+  useSSE({ enabled: enriching });
 
   const filtered = useMemo(() => {
     if (!search) return authors;
@@ -28,6 +42,18 @@ function AuthorsListPage() {
       a.nameDisplay.toLowerCase().includes(q),
     );
   }, [authors, search]);
+
+  async function handleFetchPhotos() {
+    setFetching(true);
+    try {
+      await runMutation(() => enrichAuthorPhotosServerFn(), {
+        success: "Author photo enrichment started",
+      });
+      void router.invalidate();
+    } finally {
+      setFetching(false);
+    }
+  }
 
   return (
     <div className="space-y-6">
@@ -38,12 +64,32 @@ function AuthorsListPage() {
         </p>
       </div>
 
-      <Input
-        placeholder="Search authors..."
-        value={search}
-        onChange={(e) => { setSearch(e.target.value); }}
-        className="max-w-sm"
-      />
+      <div className="flex items-center gap-3">
+        <Input
+          placeholder="Search authors..."
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); }}
+          className="max-w-sm"
+        />
+        <Button variant="outline" size="sm" disabled={fetching || enriching} onClick={() => { void handleFetchPhotos(); }}>
+          {fetching ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              Starting...
+            </>
+          ) : enriching ? (
+            <>
+              <Loader2 className="size-4 animate-spin" />
+              Fetching Photos...
+            </>
+          ) : (
+            <>
+              <ImagePlus className="size-4" />
+              Fetch Photos
+            </>
+          )}
+        </Button>
+      </div>
 
       {filtered.length === 0 ? (
         <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
@@ -59,9 +105,7 @@ function AuthorsListPage() {
               params={{ authorId: author.id }}
               className="flex items-center gap-3 rounded-lg border bg-card p-4 transition-colors hover:bg-accent"
             >
-              <div className="flex size-10 shrink-0 items-center justify-center rounded-full bg-muted">
-                <Users className="size-5 text-muted-foreground" />
-              </div>
+              <AuthorAvatar id={author.id} imagePath={author.imagePath} />
               <div className="min-w-0">
                 <p className="truncate text-sm font-medium">{author.nameDisplay}</p>
                 <p className="text-xs text-muted-foreground">

--- a/apps/web/src/routes/_authenticated/library.$workId.tsx
+++ b/apps/web/src/routes/_authenticated/library.$workId.tsx
@@ -32,17 +32,19 @@ import {
 import { getReadingProgressServerFn } from "~/lib/server-fns/reading-progress";
 import { deleteWorkServerFn, deleteEditionServerFn } from "~/lib/server-fns/deletion";
 import { EditableField } from "~/components/editable-field";
-import { updateWorkServerFn, updateWorkAuthorsServerFn } from "~/lib/server-fns/editing";
+import { EditableTagField } from "~/components/editable-tag-field";
+import { updateWorkServerFn, updateWorkAuthorsServerFn, getContributorNamesServerFn } from "~/lib/server-fns/editing";
 import { updateWorkTagsServerFn } from "~/lib/server-fns/tags";
 import { useAppColor } from "~/hooks/use-app-color";
 
 export const Route = createFileRoute("/_authenticated/library/$workId")({
   loader: async ({ params }) => {
-    const [work, { progress, trackingMode }] = await Promise.all([
+    const [work, { progress, trackingMode }, contributorNames] = await Promise.all([
       getWorkDetailServerFn({ data: { workId: params.workId } }),
       getReadingProgressServerFn({ data: { workId: params.workId } }),
+      getContributorNamesServerFn(),
     ]);
-    return { work, progress, trackingMode };
+    return { work, progress, trackingMode, contributorNames };
   },
   pendingComponent: WorkDetailSkeleton,
   component: WorkDetailPage,
@@ -80,7 +82,7 @@ function getAuthors(work: WorkDetail): { id: string; name: string }[] {
 
 
 function WorkDetailPage() {
-  const { work, progress, trackingMode } = Route.useLoaderData();
+  const { work, progress, trackingMode, contributorNames } = Route.useLoaderData();
   const router = useRouter();
   const [imgFailed, setImgFailed] = useState(false);
   const [deleteWorkOpen, setDeleteWorkOpen] = useState(false);
@@ -258,11 +260,11 @@ function WorkDetailPage() {
               </Button>
             </div>
             <div className="mt-1 text-lg text-muted-foreground">
-              <EditableField
-                value={authors.map((a) => a.name).join(", ")}
+              <EditableTagField
+                values={authors.map((a) => a.name)}
+                suggestions={contributorNames}
                 required
-                onSave={async (val) => {
-                  const authorList = val.split(",").map((a) => a.trim()).filter((a) => a.length > 0);
+                onSave={async (authorList) => {
                   await updateWorkAuthorsServerFn({ data: { workId: work.id, authors: authorList } });
                   void router.invalidate();
                 }}

--- a/packages/db/prisma/migrations/20260328120000_add_contributor_image_path/migration.sql
+++ b/packages/db/prisma/migrations/20260328120000_add_contributor_image_path/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Contributor" ADD COLUMN "imagePath" TEXT;

--- a/packages/db/prisma/migrations/20260328140000_add_enrich_author_photos_kind/migration.sql
+++ b/packages/db/prisma/migrations/20260328140000_add_enrich_author_photos_kind/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "ImportJobKind" ADD VALUE 'ENRICH_AUTHOR_PHOTOS';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -103,6 +103,7 @@ enum ImportJobKind {
   REFRESH_METADATA
   DETECT_DUPLICATES
   MATCH_SUGGESTIONS
+  ENRICH_AUTHOR_PHOTOS
 }
 
 enum ImportJobStatus {
@@ -278,6 +279,7 @@ model Contributor {
   id            String   @id @default(cuid())
   nameDisplay   String
   nameCanonical String
+  imagePath     String?
   createdAt     DateTime @default(now())
 
   editions EditionContributor[]

--- a/packages/ingest/src/author-photo.test.ts
+++ b/packages/ingest/src/author-photo.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { applyAuthorPhotoFromUrl, type AuthorPhotoDeps, type AuthorPhotoDbDeps } from "./author-photo";
+
+// JPEG header followed by padding to exceed MIN_PHOTO_SIZE (100 bytes)
+const VALID_JPEG = Buffer.concat([Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10]), Buffer.alloc(200)]);
+
+function createMockDeps(overrides: Partial<AuthorPhotoDeps> = {}): AuthorPhotoDeps {
+  return {
+    fetchUrl: vi.fn().mockResolvedValue({ buffer: VALID_JPEG, contentType: "image/jpeg" }),
+    resizeAndSave: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+function createMockDb(overrides: Partial<AuthorPhotoDbDeps> = {}): AuthorPhotoDbDeps {
+  return {
+    findContributor: vi.fn().mockResolvedValue({ id: "c1" }),
+    updateContributor: vi.fn().mockResolvedValue(undefined),
+    ...overrides,
+  };
+}
+
+describe("applyAuthorPhotoFromUrl", () => {
+  let deps: AuthorPhotoDeps;
+  let db: AuthorPhotoDbDeps;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+    db = createMockDb();
+  });
+
+  it("downloads, resizes, and updates the contributor", async () => {
+    const result = await applyAuthorPhotoFromUrl(
+      { contributorId: "c1", imageUrl: "https://covers.openlibrary.org/a/olid/OL1A-M.jpg", coverCacheDir: "/data/covers" },
+      deps,
+      db,
+    );
+
+    expect(deps.fetchUrl).toHaveBeenCalledWith("https://covers.openlibrary.org/a/olid/OL1A-M.jpg");
+    expect(deps.resizeAndSave).toHaveBeenCalledWith(expect.any(Buffer) as Buffer, "/data/covers/authors/c1");
+    expect(db.updateContributor).toHaveBeenCalledWith("c1", { imagePath: "c1" });
+    expect(result).toEqual({ success: true });
+  });
+
+  it("throws for invalid contributorId", async () => {
+    await expect(
+      applyAuthorPhotoFromUrl(
+        { contributorId: "../etc/passwd", imageUrl: "https://example.com/photo.jpg", coverCacheDir: "/data/covers" },
+        deps,
+        db,
+      ),
+    ).rejects.toThrow("Invalid contributorId");
+  });
+
+  it("throws when fetched content exceeds 10 MB", async () => {
+    deps = createMockDeps({
+      fetchUrl: vi.fn().mockResolvedValue({ buffer: Buffer.alloc(11 * 1024 * 1024), contentType: "image/jpeg" }),
+    });
+
+    await expect(
+      applyAuthorPhotoFromUrl(
+        { contributorId: "c1", imageUrl: "https://example.com/huge.jpg", coverCacheDir: "/data/covers" },
+        deps,
+        db,
+      ),
+    ).rejects.toThrow("too large");
+  });
+
+  it("throws when content-type is not an allowed image type", async () => {
+    const largeBuffer = Buffer.concat([VALID_JPEG]);
+    deps = createMockDeps({
+      fetchUrl: vi.fn().mockResolvedValue({ buffer: largeBuffer, contentType: "application/pdf" }),
+    });
+
+    await expect(
+      applyAuthorPhotoFromUrl(
+        { contributorId: "c1", imageUrl: "https://example.com/file.pdf", coverCacheDir: "/data/covers" },
+        deps,
+        db,
+      ),
+    ).rejects.toThrow("Invalid image type");
+  });
+
+  it("throws when fetched content has bad magic bytes", async () => {
+    deps = createMockDeps({
+      fetchUrl: vi.fn().mockResolvedValue({ buffer: Buffer.alloc(200, 0x42), contentType: "image/jpeg" }),
+    });
+
+    await expect(
+      applyAuthorPhotoFromUrl(
+        { contributorId: "c1", imageUrl: "https://example.com/fake.jpg", coverCacheDir: "/data/covers" },
+        deps,
+        db,
+      ),
+    ).rejects.toThrow("not a valid image");
+  });
+
+  it("throws when image is too small (OL placeholder)", async () => {
+    deps = createMockDeps({
+      fetchUrl: vi.fn().mockResolvedValue({ buffer: Buffer.alloc(50), contentType: "image/jpeg" }),
+    });
+
+    await expect(
+      applyAuthorPhotoFromUrl(
+        { contributorId: "c1", imageUrl: "https://example.com/tiny.jpg", coverCacheDir: "/data/covers" },
+        deps,
+        db,
+      ),
+    ).rejects.toThrow("too small");
+  });
+
+  it("throws when contributor is not found", async () => {
+    db = createMockDb({ findContributor: vi.fn().mockResolvedValue(null) });
+
+    await expect(
+      applyAuthorPhotoFromUrl(
+        { contributorId: "c1", imageUrl: "https://example.com/photo.jpg", coverCacheDir: "/data/covers" },
+        deps,
+        db,
+      ),
+    ).rejects.toThrow("Contributor not found");
+  });
+
+  it("allows missing content-type if magic bytes are valid", async () => {
+    deps = createMockDeps({
+      fetchUrl: vi.fn().mockResolvedValue({ buffer: VALID_JPEG, contentType: null }),
+    });
+
+    const result = await applyAuthorPhotoFromUrl(
+      { contributorId: "c1", imageUrl: "https://example.com/photo", coverCacheDir: "/data/covers" },
+      deps,
+      db,
+    );
+
+    expect(result).toEqual({ success: true });
+  });
+});

--- a/packages/ingest/src/author-photo.ts
+++ b/packages/ingest/src/author-photo.ts
@@ -1,0 +1,66 @@
+import path from "node:path";
+import { VALID_WORK_ID, MAX_FILE_SIZE, isValidImageData, isAllowedMimeType } from "./cover-validation";
+
+const MIN_PHOTO_SIZE = 100;
+
+export interface AuthorPhotoDeps {
+  fetchUrl: (url: string) => Promise<{ buffer: Buffer; contentType: string | null }>;
+  resizeAndSave: (imageBuffer: Buffer, outputDir: string) => Promise<void>;
+}
+
+export interface AuthorPhotoDbDeps {
+  findContributor: (id: string) => Promise<{ id: string } | null>;
+  updateContributor: (id: string, data: { imagePath: string }) => Promise<void>;
+}
+
+export interface AuthorPhotoInput {
+  contributorId: string;
+  imageUrl: string;
+  coverCacheDir: string;
+}
+
+export interface AuthorPhotoResult {
+  success: boolean;
+}
+
+export async function applyAuthorPhotoFromUrl(
+  input: AuthorPhotoInput,
+  deps: AuthorPhotoDeps,
+  db: AuthorPhotoDbDeps,
+): Promise<AuthorPhotoResult> {
+  const { contributorId, imageUrl, coverCacheDir } = input;
+
+  if (!VALID_WORK_ID.test(contributorId)) {
+    throw new Error("Invalid contributorId");
+  }
+
+  const { buffer, contentType } = await deps.fetchUrl(imageUrl);
+
+  if (buffer.length < MIN_PHOTO_SIZE) {
+    throw new Error("Image too small (likely a placeholder)");
+  }
+
+  if (buffer.length > MAX_FILE_SIZE) {
+    throw new Error("Image too large (max 10 MB)");
+  }
+
+  if (!isAllowedMimeType(contentType)) {
+    throw new Error("Invalid image type");
+  }
+
+  if (!isValidImageData(buffer)) {
+    throw new Error("File is not a valid image");
+  }
+
+  const outputDir = path.join(coverCacheDir, "authors", contributorId);
+  await deps.resizeAndSave(buffer, outputDir);
+
+  const contributor = await db.findContributor(contributorId);
+  if (!contributor) {
+    throw new Error("Contributor not found");
+  }
+
+  await db.updateContributor(contributorId, { imagePath: contributorId });
+
+  return { success: true };
+}

--- a/packages/ingest/src/covers.test.ts
+++ b/packages/ingest/src/covers.test.ts
@@ -7,6 +7,7 @@ import { MediaKind } from "@bookhouse/domain";
 import {
   detectAdjacentCover,
   resizeCoverImage,
+  resizeAndSaveCover,
   processCoverForWork,
   processCoverForWorkDefault,
   type CoverDependencies,
@@ -120,6 +121,18 @@ describe("resizeCoverImage", () => {
       thumbPath: path.join("/data/covers/work-123", "thumb.webp"),
       mediumPath: path.join("/data/covers/work-123", "medium.webp"),
     });
+  });
+});
+
+describe("resizeAndSaveCover", () => {
+  it("calls resizeCoverImage with real deps", async () => {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), "resize-test-"));
+    const sharp = await import("sharp");
+    const pngBuffer = await sharp.default({ create: { width: 10, height: 10, channels: 3, background: { r: 255, g: 0, b: 0 } } }).png().toBuffer();
+    await resizeAndSaveCover(pngBuffer, tmpDir);
+    const { existsSync } = await import("node:fs");
+    expect(existsSync(path.join(tmpDir, "thumb.webp"))).toBe(true);
+    expect(existsSync(path.join(tmpDir, "medium.webp"))).toBe(true);
   });
 });
 

--- a/packages/ingest/src/covers.ts
+++ b/packages/ingest/src/covers.ts
@@ -124,6 +124,13 @@ export async function resizeCoverImage(
   return { thumbPath, mediumPath };
 }
 
+export async function resizeAndSaveCover(
+  imageBuffer: Buffer,
+  outputDir: string,
+): Promise<void> {
+  await resizeCoverImage({ imageBuffer, outputDir }, { mkdir, sharp: sharp as ResizeCoverDeps["sharp"], writeFile });
+}
+
 export async function processCoverForWork(
   input: ProcessCoverInput,
   deps: CoverDependencies,

--- a/packages/ingest/src/enrichment/enrich-contributor.test.ts
+++ b/packages/ingest/src/enrichment/enrich-contributor.test.ts
@@ -1,0 +1,272 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { enrichContributor, type EnrichContributorDeps } from "./enrich-contributor";
+
+function createMockDeps(overrides: Partial<EnrichContributorDeps> = {}): EnrichContributorDeps {
+  return {
+    findContributor: vi.fn().mockResolvedValue({ id: "c1", nameDisplay: "J.R.R. Tolkien", imagePath: null }),
+    acquireOLToken: vi.fn().mockResolvedValue(undefined),
+    searchOLAuthors: vi.fn().mockResolvedValue([{ olid: "OL34184A", name: "J.R.R. Tolkien", workCount: 200 }]),
+    applyPhoto: vi.fn().mockResolvedValue({ success: true }),
+    ...overrides,
+  };
+}
+
+describe("enrichContributor", () => {
+  let deps: EnrichContributorDeps;
+
+  beforeEach(() => {
+    deps = createMockDeps();
+  });
+
+  it("acquires OL token, searches, and applies photo", async () => {
+    const result = await enrichContributor("c1", deps);
+
+    expect(deps.acquireOLToken).toHaveBeenCalledTimes(2); // once for search, once for photo fetch
+    expect(deps.searchOLAuthors).toHaveBeenCalledWith("J.R.R. Tolkien");
+    expect(deps.applyPhoto).toHaveBeenCalledWith(
+      "c1",
+      "https://covers.openlibrary.org/a/olid/OL34184A-M.jpg",
+    );
+    expect(result).toEqual({ status: "enriched", authorOlid: "OL34184A" });
+  });
+
+  it("returns not-found when contributor does not exist", async () => {
+    deps = createMockDeps({
+      findContributor: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "not-found" });
+    expect(deps.acquireOLToken).not.toHaveBeenCalled();
+  });
+
+  it("returns already-has-image when contributor already has imagePath", async () => {
+    deps = createMockDeps({
+      findContributor: vi.fn().mockResolvedValue({ id: "c1", nameDisplay: "Tolkien", imagePath: "c1" }),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "already-has-image" });
+    expect(deps.acquireOLToken).not.toHaveBeenCalled();
+  });
+
+  it("falls back to Hardcover when OL has no results", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireHCToken: vi.fn().mockResolvedValue(undefined),
+      searchHCAuthors: vi.fn().mockResolvedValue([
+        { hardcoverId: "100", name: "J.R.R. Tolkien", imageUrl: "https://hardcover.app/authors/tolkien.jpg" },
+      ]),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(deps.acquireHCToken).toHaveBeenCalledTimes(1);
+    expect(deps.searchHCAuthors).toHaveBeenCalledWith("J.R.R. Tolkien");
+    expect(deps.applyPhoto).toHaveBeenCalledWith("c1", "https://hardcover.app/authors/tolkien.jpg");
+    expect(result).toEqual({ status: "enriched", authorOlid: "hc:100" });
+  });
+
+  it("falls back to Hardcover when OL photo is a placeholder", async () => {
+    deps = createMockDeps({
+      applyPhoto: vi.fn()
+        .mockRejectedValueOnce(new Error("Image too small (likely a placeholder)"))
+        .mockResolvedValueOnce({ success: true }),
+      acquireHCToken: vi.fn().mockResolvedValue(undefined),
+      searchHCAuthors: vi.fn().mockResolvedValue([
+        { hardcoverId: "100", name: "J.R.R. Tolkien", imageUrl: "https://hardcover.app/tolkien.jpg" },
+      ]),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(deps.applyPhoto).toHaveBeenCalledTimes(2);
+    expect(result).toEqual({ status: "enriched", authorOlid: "hc:100" });
+  });
+
+  it("returns no-results when both OL and HC have no results", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireHCToken: vi.fn().mockResolvedValue(undefined),
+      searchHCAuthors: vi.fn().mockResolvedValue([]),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "no-results", triedSources: ["openlibrary", "hardcover"] });
+  });
+
+  it("returns no-photo when HC photo is also invalid", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireHCToken: vi.fn().mockResolvedValue(undefined),
+      searchHCAuthors: vi.fn().mockResolvedValue([
+        { hardcoverId: "100", name: "Author", imageUrl: "https://hardcover.app/photo.jpg" },
+      ]),
+      applyPhoto: vi.fn().mockRejectedValue(new Error("Image too small (likely a placeholder)")),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "no-photo", triedSources: ["openlibrary", "hardcover"] });
+  });
+
+  it("returns no-photo when HC author has no image URL", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireHCToken: vi.fn().mockResolvedValue(undefined),
+      searchHCAuthors: vi.fn().mockResolvedValue([
+        { hardcoverId: "100", name: "Unknown", imageUrl: null },
+      ]),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "no-photo", triedSources: ["openlibrary", "hardcover"] });
+  });
+
+  it("skips HC fallback when HC is not configured", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      // no acquireHCToken or searchHCAuthors
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "no-results", triedSources: ["openlibrary"] });
+  });
+
+  it("returns no-results when OL returns null", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue(null),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "no-results", triedSources: ["openlibrary"] });
+  });
+
+  it("returns no-photo when OL photo is invalid and HC is not configured", async () => {
+    deps = createMockDeps({
+      applyPhoto: vi.fn().mockRejectedValue(new Error("Image too small (likely a placeholder)")),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "no-photo", triedSources: ["openlibrary"] });
+  });
+
+  it("falls back to Wikidata when OL and HC have no photo", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireHCToken: vi.fn().mockResolvedValue(undefined),
+      searchHCAuthors: vi.fn().mockResolvedValue([]),
+      acquireWDToken: vi.fn().mockResolvedValue(undefined),
+      searchWDAuthors: vi.fn().mockResolvedValue([
+        { qid: "Q2427544", name: "N. K. Jemisin", imageUrl: "https://upload.wikimedia.org/photo.jpg" },
+      ]),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(deps.acquireWDToken).toHaveBeenCalled();
+    expect(result).toEqual({ status: "enriched", authorOlid: "wd:Q2427544" });
+  });
+
+  it("returns no-photo when Wikidata photo is invalid", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireWDToken: vi.fn().mockResolvedValue(undefined),
+      searchWDAuthors: vi.fn().mockResolvedValue([
+        { qid: "Q99", name: "Author", imageUrl: "https://upload.wikimedia.org/bad.jpg" },
+      ]),
+      applyPhoto: vi.fn().mockRejectedValue(new Error("Image too small (likely a placeholder)")),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "no-photo", triedSources: ["wikidata", "openlibrary"] });
+  });
+
+  it("skips Wikidata results without imageUrl", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireWDToken: vi.fn().mockResolvedValue(undefined),
+      searchWDAuthors: vi.fn().mockResolvedValue([
+        { qid: "Q1", name: "No Photo", imageUrl: null },
+        { qid: "Q2", name: "Has Photo", imageUrl: "https://upload.wikimedia.org/photo.jpg" },
+      ]),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(deps.applyPhoto).toHaveBeenCalledWith("c1", "https://upload.wikimedia.org/photo.jpg");
+    expect(result).toEqual({ status: "enriched", authorOlid: "wd:Q2" });
+  });
+
+  it("returns no-results when all sources find nothing", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireWDToken: vi.fn().mockResolvedValue(undefined),
+      searchWDAuthors: vi.fn().mockResolvedValue([]),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "no-results", triedSources: ["wikidata", "openlibrary"] });
+  });
+
+  it("catches Wikidata errors and continues to OL", async () => {
+    deps = createMockDeps({
+      acquireWDToken: vi.fn().mockResolvedValue(undefined),
+      searchWDAuthors: vi.fn().mockRejectedValue(new Error("Wikidata API error: 429")),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result).toEqual({ status: "enriched", authorOlid: "OL34184A" });
+  });
+
+  it("catches Hardcover errors and continues gracefully", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockResolvedValue([]),
+      acquireHCToken: vi.fn().mockResolvedValue(undefined),
+      searchHCAuthors: vi.fn().mockRejectedValue(new Error("Hardcover API error")),
+      acquireWDToken: vi.fn().mockResolvedValue(undefined),
+      searchWDAuthors: vi.fn().mockResolvedValue([]),
+    });
+
+    const result = await enrichContributor("c1", deps);
+
+    expect(result.status).toBe("no-results");
+    if (result.status === "no-results") {
+      expect(result.triedSources).toContain("hardcover");
+    }
+  });
+
+  it("propagates OL search errors so BullMQ retries the job", async () => {
+    deps = createMockDeps({
+      searchOLAuthors: vi.fn().mockRejectedValue(new Error("Open Library API error: 500")),
+    });
+
+    await expect(enrichContributor("c1", deps)).rejects.toThrow("Open Library API error: 500");
+  });
+
+  it("propagates applyPhoto network errors so BullMQ retries the job", async () => {
+    deps = createMockDeps({
+      applyPhoto: vi.fn().mockRejectedValue(new Error("fetch failed")),
+    });
+
+    await expect(enrichContributor("c1", deps)).rejects.toThrow("fetch failed");
+  });
+
+  it("propagates non-Error throws from applyPhoto", async () => {
+    deps = createMockDeps({
+      applyPhoto: vi.fn().mockRejectedValue("string error"),
+    });
+
+    await expect(enrichContributor("c1", deps)).rejects.toBe("string error");
+  });
+});

--- a/packages/ingest/src/enrichment/enrich-contributor.ts
+++ b/packages/ingest/src/enrichment/enrich-contributor.ts
@@ -1,0 +1,123 @@
+import type { OLAuthorSearchResult } from "./open-library";
+import type { HCAuthor } from "./hardcover";
+import type { WDAuthor } from "./wikidata";
+
+interface ContributorRecord {
+  id: string;
+  nameDisplay: string;
+  imagePath: string | null;
+}
+
+export interface EnrichContributorDeps {
+  findContributor: (id: string) => Promise<ContributorRecord | null>;
+  acquireOLToken: () => Promise<void>;
+  searchOLAuthors: (name: string) => Promise<OLAuthorSearchResult[] | null>;
+  applyPhoto: (contributorId: string, imageUrl: string) => Promise<{ success: boolean }>;
+  acquireHCToken?: () => Promise<void>;
+  searchHCAuthors?: (name: string) => Promise<HCAuthor[] | null>;
+  acquireWDToken?: () => Promise<void>;
+  searchWDAuthors?: (name: string) => Promise<WDAuthor[]>;
+}
+
+export type EnrichContributorResult =
+  | { status: "enriched"; authorOlid: string }
+  | { status: "not-found" }
+  | { status: "no-results"; triedSources: string[] }
+  | { status: "already-has-image" }
+  | { status: "no-photo"; triedSources: string[] };
+
+const NO_PHOTO_PATTERNS = [
+  "too small",
+  "Invalid image type",
+  "not a valid image",
+];
+
+function isNoPhotoError(error: Error): boolean {
+  return NO_PHOTO_PATTERNS.some((pattern) => error.message.includes(pattern));
+}
+
+async function tryApplyPhoto(
+  deps: EnrichContributorDeps,
+  contributorId: string,
+  imageUrl: string,
+): Promise<"success" | "no-photo" | "error"> {
+  try {
+    await deps.applyPhoto(contributorId, imageUrl);
+    return "success";
+  } catch (error) {
+    if (error instanceof Error && isNoPhotoError(error)) {
+      return "no-photo";
+    }
+    throw error;
+  }
+}
+
+export async function enrichContributor(
+  contributorId: string,
+  deps: EnrichContributorDeps,
+): Promise<EnrichContributorResult> {
+  const contributor = await deps.findContributor(contributorId);
+  if (!contributor) return { status: "not-found" };
+  if (contributor.imagePath) return { status: "already-has-image" };
+
+  const triedSources: string[] = [];
+  let anyMatch = false;
+
+  // Try Wikidata first (best author photo coverage)
+  if (deps.searchWDAuthors && deps.acquireWDToken) {
+    try {
+      await deps.acquireWDToken();
+      const wdResults = await deps.searchWDAuthors(contributor.nameDisplay);
+      triedSources.push("wikidata");
+      const wdMatch = wdResults.find((r) => r.imageUrl !== null);
+      if (wdMatch?.imageUrl) {
+        anyMatch = true;
+        const wdResult = await tryApplyPhoto(deps, contributorId, wdMatch.imageUrl);
+        if (wdResult === "success") {
+          return { status: "enriched", authorOlid: `wd:${wdMatch.qid}` };
+        }
+      }
+    } catch {
+      triedSources.push("wikidata");
+    }
+  }
+
+  // Fall back to Open Library
+  await deps.acquireOLToken();
+  const searchResults = await deps.searchOLAuthors(contributor.nameDisplay);
+  const bestMatch = searchResults?.[0];
+  triedSources.push("openlibrary");
+
+  if (bestMatch) {
+    anyMatch = true;
+    const photoUrl = `https://covers.openlibrary.org/a/olid/${bestMatch.olid}-M.jpg`;
+    await deps.acquireOLToken();
+    const olResult = await tryApplyPhoto(deps, contributorId, photoUrl);
+    if (olResult === "success") {
+      return { status: "enriched", authorOlid: bestMatch.olid };
+    }
+  }
+
+  // Fall back to Hardcover if configured
+  if (deps.searchHCAuthors && deps.acquireHCToken) {
+    try {
+      await deps.acquireHCToken();
+      const hcResults = await deps.searchHCAuthors(contributor.nameDisplay);
+      const hcMatch = hcResults?.[0];
+      triedSources.push("hardcover");
+      if (hcMatch?.imageUrl) {
+        anyMatch = true;
+        const hcResult = await tryApplyPhoto(deps, contributorId, hcMatch.imageUrl);
+        if (hcResult === "success") {
+          return { status: "enriched", authorOlid: `hc:${hcMatch.hardcoverId}` };
+        }
+      } else if (hcMatch) {
+        anyMatch = true;
+      }
+    } catch {
+      triedSources.push("hardcover");
+    }
+  }
+
+  return anyMatch ? { status: "no-photo", triedSources } : { status: "no-results", triedSources };
+}

--- a/packages/ingest/src/enrichment/enrich-work.test.ts
+++ b/packages/ingest/src/enrichment/enrich-work.test.ts
@@ -1,7 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { enrichWork, type EnrichWorkDeps } from "./enrich-work";
 import type { OLSearchResult, OLWork } from "./open-library";
-import type { RateLimitResult } from "./rate-limiter";
 
 function makeDeps(overrides: Partial<EnrichWorkDeps> = {}): EnrichWorkDeps {
   return {
@@ -36,7 +35,7 @@ function makeDeps(overrides: Partial<EnrichWorkDeps> = {}): EnrichWorkDeps {
       subjects: ["Fantasy"],
     } satisfies OLWork),
     upsertExternalLink: vi.fn().mockResolvedValue({ id: "el1" }),
-    checkRateLimit: vi.fn().mockReturnValue({ allowed: true } satisfies RateLimitResult),
+    acquireOLToken: vi.fn().mockResolvedValue(undefined),
     ...overrides,
   };
 }
@@ -85,13 +84,10 @@ describe("enrichWork", () => {
     expect(result).toEqual({ status: "no-results" });
   });
 
-  it("returns rate-limited when rate limiter blocks", async () => {
-    const deps = makeDeps({
-      checkRateLimit: vi.fn().mockReturnValue({ allowed: false, retryAfterMs: 5000 }),
-    });
-    const result = await enrichWork("w1", deps);
-    expect(result).toEqual({ status: "rate-limited", retryAfterMs: 5000 });
-    expect(deps.searchOL).not.toHaveBeenCalled();
+  it("calls acquireOLToken before making API calls", async () => {
+    const deps = makeDeps();
+    await enrichWork("w1", deps);
+    expect(deps.acquireOLToken).toHaveBeenCalled();
   });
 
   it("uses first author from first edition for search", async () => {

--- a/packages/ingest/src/enrichment/enrich-work.ts
+++ b/packages/ingest/src/enrichment/enrich-work.ts
@@ -1,5 +1,4 @@
 import type { OLSearchResult, OLWork } from "./open-library";
-import type { RateLimitResult } from "./rate-limiter";
 
 interface WorkEdition {
   id: string;
@@ -34,7 +33,7 @@ export interface EnrichWorkDeps {
     externalId: string;
     metadata: ExternalLinkMetadata;
   }) => Promise<void>;
-  checkRateLimit: () => RateLimitResult;
+  acquireOLToken: () => Promise<void>;
 }
 
 export type EnrichWorkResult =
@@ -42,17 +41,13 @@ export type EnrichWorkResult =
   | { status: "not-found" }
   | { status: "no-results" }
   | { status: "no-editions" }
-  | { status: "already-enriched" }
-  | { status: "rate-limited"; retryAfterMs: number | undefined };
+  | { status: "already-enriched" };
 
 export async function enrichWork(
   workId: string,
   deps: EnrichWorkDeps,
 ): Promise<EnrichWorkResult> {
-  const rateCheck = deps.checkRateLimit();
-  if (!rateCheck.allowed) {
-    return { status: "rate-limited", retryAfterMs: rateCheck.retryAfterMs };
-  }
+  await deps.acquireOLToken();
 
   const work = await deps.findWork(workId);
   if (!work) return { status: "not-found" };

--- a/packages/ingest/src/enrichment/hardcover.test.ts
+++ b/packages/ingest/src/enrichment/hardcover.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { searchHardcover, getHardcoverBook, type HCBook } from "./hardcover";
+import { searchHardcover, getHardcoverBook, searchHardcoverAuthors, type HCBook } from "./hardcover";
 
 function fakeFetch(body: object | string | null, status = 200): typeof fetch {
   return vi.fn().mockResolvedValue({
@@ -333,5 +333,139 @@ describe("getHardcoverBook", () => {
     expect(book.authors).toEqual([]);
     expect(book.publisher).toBeNull();
     expect(book.isbn13).toBeNull();
+  });
+});
+
+describe("searchHardcoverAuthors", () => {
+  it("returns parsed author results with image URL", async () => {
+    const body = {
+      data: {
+        search: {
+          results: JSON.stringify([
+            { id: 100, name: "Frank Herbert", image: { url: "https://hardcover.app/authors/herbert.jpg" } },
+            { id: 101, name: "Brian Herbert", image: null },
+          ]),
+        },
+      },
+    };
+
+    const results = await searchHardcoverAuthors("Herbert", "test-key", fakeFetch(body));
+    expect(results).toEqual([
+      { hardcoverId: "100", name: "Frank Herbert", imageUrl: "https://hardcover.app/authors/herbert.jpg" },
+      { hardcoverId: "101", name: "Brian Herbert", imageUrl: null },
+    ]);
+  });
+
+  it("returns empty array when no results", async () => {
+    const body = {
+      data: {
+        search: { results: "[]" },
+      },
+    };
+
+    const results = await searchHardcoverAuthors("Nobody", "test-key", fakeFetch(body));
+    expect(results).toEqual([]);
+  });
+
+  it("handles missing image field", async () => {
+    const body = {
+      data: {
+        search: {
+          results: JSON.stringify([
+            { id: 200, name: "Unknown Author" },
+          ]),
+        },
+      },
+    };
+
+    const results = await searchHardcoverAuthors("Unknown", "test-key", fakeFetch(body));
+    expect(results).toEqual([
+      { hardcoverId: "200", name: "Unknown Author", imageUrl: null },
+    ]);
+  });
+
+  it("handles results as direct array", async () => {
+    const body = {
+      data: {
+        search: {
+          results: [
+            { id: 300, name: "Direct Author", image: { url: "https://hardcover.app/direct.jpg" } },
+          ],
+        },
+      },
+    };
+
+    const results = await searchHardcoverAuthors("Direct", "test-key", fakeFetch(body));
+    expect(results).toEqual([
+      { hardcoverId: "300", name: "Direct Author", imageUrl: "https://hardcover.app/direct.jpg" },
+    ]);
+  });
+
+  it("handles results as non-array, non-string type", async () => {
+    const body = {
+      data: {
+        search: {
+          results: { someKey: "value" },
+        },
+      },
+    };
+
+    const results = await searchHardcoverAuthors("Other", "test-key", fakeFetch(body));
+    expect(results).toEqual([]);
+  });
+
+  it("returns empty array when search field is missing", async () => {
+    const body = { data: {} };
+    const results = await searchHardcoverAuthors("test", "key", fakeFetch(body));
+    expect(results).toEqual([]);
+  });
+
+  it("returns empty array when results is null", async () => {
+    const body = { data: { search: { results: null } } };
+    const results = await searchHardcoverAuthors("test", "key", fakeFetch(body));
+    expect(results).toEqual([]);
+  });
+
+  it("handles non-array parsed JSON string", async () => {
+    const body = {
+      data: {
+        search: {
+          results: JSON.stringify({ someObj: true }),
+        },
+      },
+    };
+
+    const results = await searchHardcoverAuthors("Other", "test-key", fakeFetch(body));
+    expect(results).toEqual([]);
+  });
+
+  it("handles missing id and name in hit", async () => {
+    const body = {
+      data: {
+        search: {
+          results: JSON.stringify([
+            { image: { url: "https://hardcover.app/photo.jpg" } },
+          ]),
+        },
+      },
+    };
+
+    const results = await searchHardcoverAuthors("Unknown", "test-key", fakeFetch(body));
+    expect(results).toEqual([
+      { hardcoverId: "0", name: "", imageUrl: "https://hardcover.app/photo.jpg" },
+    ]);
+  });
+
+  it("throws when data is null", async () => {
+    const body = { data: null };
+    await expect(
+      searchHardcoverAuthors("test", "key", fakeFetch(body)),
+    ).rejects.toThrow("Hardcover returned no data");
+  });
+
+  it("throws on API error", async () => {
+    await expect(
+      searchHardcoverAuthors("test", "bad-key", fakeFetch("Unauthorized", 401)),
+    ).rejects.toThrow("Hardcover API error 401");
   });
 });

--- a/packages/ingest/src/enrichment/hardcover.ts
+++ b/packages/ingest/src/enrichment/hardcover.ts
@@ -13,6 +13,18 @@ export interface HCBook {
   isbn13: string | null;
 }
 
+export interface HCAuthor {
+  hardcoverId: string;
+  name: string;
+  imageUrl: string | null;
+}
+
+interface HCAuthorSearchHit {
+  id?: number;
+  name?: string;
+  image?: { url?: string } | null;
+}
+
 // The search endpoint returns a raw JSON blob in `results`.
 // Each result has these fields based on the Hardcover search index.
 interface HCSearchHit {
@@ -74,6 +86,14 @@ interface HCGraphQLResponse<T> {
 const SEARCH_QUERY = `
   query SearchBooks($query: String!) {
     search(query: $query, query_type: "Book", per_page: 5, page: 1) {
+      results
+    }
+  }
+`;
+
+const SEARCH_AUTHORS_QUERY = `
+  query SearchAuthors($query: String!) {
+    search(query: $query, query_type: "Author", per_page: 5, page: 1) {
       results
     }
   }
@@ -231,4 +251,34 @@ export async function getHardcoverBook(
   if (!books?.[0]) return null;
 
   return parseDetailBook(books[0]);
+}
+
+export async function searchHardcoverAuthors(
+  name: string,
+  apiKey: string,
+  fetcher: typeof fetch,
+): Promise<HCAuthor[]> {
+  const data = await graphqlRequest<HCSearchData>(SEARCH_AUTHORS_QUERY, { query: name }, apiKey, fetcher);
+  if (data === null) {
+    throw new Error("Hardcover returned no data (check API key and query)");
+  }
+
+  const search = data.search;
+  if (!search?.results) return [];
+
+  let hits: HCAuthorSearchHit[];
+  if (typeof search.results === "string") {
+    const parsed = JSON.parse(search.results) as HCAuthorSearchHit[];
+    hits = Array.isArray(parsed) ? parsed : [];
+  } else if (Array.isArray(search.results)) {
+    hits = search.results as HCAuthorSearchHit[];
+  } else {
+    hits = [];
+  }
+
+  return hits.map((hit) => ({
+    hardcoverId: String(hit.id ?? 0),
+    name: hit.name ?? "",
+    imageUrl: hit.image?.url ?? null,
+  }));
 }

--- a/packages/ingest/src/enrichment/open-library.test.ts
+++ b/packages/ingest/src/enrichment/open-library.test.ts
@@ -3,6 +3,8 @@ import {
   searchOpenLibrary,
   getOpenLibraryEdition,
   getOpenLibraryWork,
+  searchOpenLibraryAuthors,
+  createOLFetcher,
 } from "./open-library";
 
 function fakeFetch(body: object | string | null, status = 200): typeof fetch {
@@ -222,5 +224,122 @@ describe("getOpenLibraryWork", () => {
   it("throws on network error", async () => {
     const errorFetch = (() => Promise.reject(new Error("dns fail"))) as object as typeof fetch;
     await expect(getOpenLibraryWork("OL000W", errorFetch)).rejects.toThrow("dns fail");
+  });
+});
+
+describe("searchOpenLibraryAuthors", () => {
+  it("returns structured results from OL authors search API", async () => {
+    const body = {
+      docs: [
+        {
+          key: "OL34184A",
+          name: "J.R.R. Tolkien",
+          work_count: 200,
+          top_subjects: ["Fantasy fiction", "Adventure"],
+        },
+      ],
+    };
+    const results = await searchOpenLibraryAuthors("Tolkien", fakeFetch(body));
+    expect(results).toEqual([
+      {
+        olid: "OL34184A",
+        name: "J.R.R. Tolkien",
+        workCount: 200,
+      },
+    ]);
+  });
+
+  it("handles missing optional fields", async () => {
+    const body = {
+      docs: [
+        {
+          key: "OL555A",
+          name: "Unknown Author",
+        },
+      ],
+    };
+    const results = await searchOpenLibraryAuthors("Unknown", fakeFetch(body));
+    expect(results).toEqual([
+      {
+        olid: "OL555A",
+        name: "Unknown Author",
+        workCount: 0,
+      },
+    ]);
+  });
+
+  it("returns empty array when no docs found", async () => {
+    const results = await searchOpenLibraryAuthors("zzz", fakeFetch({ docs: [] }));
+    expect(results).toEqual([]);
+  });
+
+  it("returns null on 404", async () => {
+    const results = await searchOpenLibraryAuthors("zzz", fakeFetch({}, 404));
+    expect(results).toBeNull();
+  });
+
+  it("throws on non-404 error status", async () => {
+    await expect(searchOpenLibraryAuthors("test", fakeFetch({}, 500))).rejects.toThrow("Open Library API error: 500");
+  });
+
+  it("throws on network error", async () => {
+    const errorFetch = (() => Promise.reject(new Error("network down"))) as object as typeof fetch;
+    await expect(searchOpenLibraryAuthors("test", errorFetch)).rejects.toThrow("network down");
+  });
+
+  it("encodes query parameters", async () => {
+    let calledUrl = "";
+    const captureFetch = ((url: string) => {
+      calledUrl = url;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ docs: [] }),
+      });
+    }) as object as typeof fetch;
+
+    await searchOpenLibraryAuthors("O'Brien", captureFetch);
+    expect(calledUrl).toContain("search/authors.json");
+    expect(calledUrl).toContain("q=O");
+  });
+});
+
+describe("createOLFetcher", () => {
+  it("adds User-Agent header with app name and contact email", async () => {
+    let capturedInit: RequestInit | undefined;
+    const baseFetch = ((_url: string, init?: RequestInit) => {
+      capturedInit = init;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ docs: [] }),
+      });
+    }) as object as typeof fetch;
+
+    const olFetch = createOLFetcher("test@example.com", baseFetch);
+    await olFetch("https://openlibrary.org/search.json?title=test");
+
+    expect(capturedInit).toBeDefined();
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe("Bookhouse (test@example.com)");
+  });
+
+  it("preserves existing init options", async () => {
+    let capturedInit: RequestInit | undefined;
+    const baseFetch = ((_url: string, init?: RequestInit) => {
+      capturedInit = init;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({}),
+      });
+    }) as object as typeof fetch;
+
+    const olFetch = createOLFetcher("test@example.com", baseFetch);
+    await olFetch("https://openlibrary.org/test", { method: "POST" });
+
+    expect(capturedInit?.method).toBe("POST");
+    const headers = capturedInit?.headers as Record<string, string>;
+    expect(headers["User-Agent"]).toBe("Bookhouse (test@example.com)");
   });
 });

--- a/packages/ingest/src/enrichment/open-library.ts
+++ b/packages/ingest/src/enrichment/open-library.ts
@@ -1,5 +1,21 @@
 const OL_BASE = "https://openlibrary.org";
 
+export interface OLAuthorSearchResult {
+  olid: string;
+  name: string;
+  workCount: number;
+}
+
+interface OLRawAuthorSearchDoc {
+  key: string;
+  name: string;
+  work_count?: number;
+}
+
+interface OLRawAuthorSearchResponse {
+  docs: OLRawAuthorSearchDoc[];
+}
+
 export interface OLSearchResult {
   olid: string;
   title: string;
@@ -56,6 +72,17 @@ interface OLRawWork {
   description?: string | { value: string };
   covers?: number[];
   subjects?: string[];
+}
+
+export function createOLFetcher(contactEmail: string, baseFetch: typeof fetch = fetch): typeof fetch {
+  return ((url: string | URL | Request, init?: RequestInit) =>
+    baseFetch(url, {
+      ...init,
+      headers: {
+        ...(init?.headers as Record<string, string> | undefined),
+        "User-Agent": `Bookhouse (${contactEmail})`,
+      },
+    })) as typeof fetch;
 }
 
 function extractOlid(key: string): string {
@@ -134,4 +161,21 @@ export async function getOpenLibraryWork(
     coverIds: data.covers ?? [],
     subjects: data.subjects ?? [],
   };
+}
+
+export async function searchOpenLibraryAuthors(
+  name: string,
+  fetcher: typeof fetch,
+): Promise<OLAuthorSearchResult[] | null> {
+  const params = new URLSearchParams({ q: name, limit: "5" });
+
+  const response = await fetcher(`${OL_BASE}/search/authors.json?${params.toString()}`);
+  const data = await checkedJson<OLRawAuthorSearchResponse>(response);
+  if (data === null) return null;
+
+  return data.docs.map((doc) => ({
+    olid: doc.key,
+    name: doc.name,
+    workCount: doc.work_count ?? 0,
+  }));
 }

--- a/packages/ingest/src/enrichment/token-bucket.test.ts
+++ b/packages/ingest/src/enrichment/token-bucket.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { TokenBucketLimiter } from "./token-bucket";
+
+describe("TokenBucketLimiter", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("first call proceeds immediately without delay", async () => {
+    const limiter = new TokenBucketLimiter(3);
+    const start = Date.now();
+    await limiter.acquire();
+    expect(Date.now() - start).toBe(0);
+  });
+
+  it("spaces calls according to tokens per second", async () => {
+    const limiter = new TokenBucketLimiter(2); // 1 call per 500ms
+    await limiter.acquire(); // immediate
+
+    const promise = limiter.acquire(); // should wait ~500ms
+    await vi.advanceTimersByTimeAsync(500);
+    await promise;
+
+    // Should have waited 500ms
+    expect(Date.now()).toBeGreaterThanOrEqual(500);
+  });
+
+  it("handles 1 token per second rate", async () => {
+    const limiter = new TokenBucketLimiter(1); // 1 call per 1000ms
+    await limiter.acquire();
+
+    const promise = limiter.acquire();
+    await vi.advanceTimersByTimeAsync(1000);
+    await promise;
+
+    expect(Date.now()).toBeGreaterThanOrEqual(1000);
+  });
+
+  it("does not delay when enough time has passed naturally", async () => {
+    const limiter = new TokenBucketLimiter(2); // 500ms interval
+    await limiter.acquire();
+
+    vi.advanceTimersByTime(600); // advance past the interval
+    const start = Date.now();
+    await limiter.acquire();
+    expect(Date.now() - start).toBe(0);
+  });
+});

--- a/packages/ingest/src/enrichment/token-bucket.ts
+++ b/packages/ingest/src/enrichment/token-bucket.ts
@@ -1,0 +1,21 @@
+export class TokenBucketLimiter {
+  private readonly intervalMs: number;
+  private nextAllowedTime = 0;
+
+  constructor(tokensPerSecond: number) {
+    this.intervalMs = Math.ceil(1000 / tokensPerSecond);
+  }
+
+  async acquire(): Promise<void> {
+    const now = Date.now();
+
+    if (now >= this.nextAllowedTime) {
+      this.nextAllowedTime = now + this.intervalMs;
+      return;
+    }
+
+    const waitMs = this.nextAllowedTime - now;
+    this.nextAllowedTime += this.intervalMs;
+    await new Promise<void>((resolve) => setTimeout(resolve, waitMs));
+  }
+}

--- a/packages/ingest/src/enrichment/wikidata.test.ts
+++ b/packages/ingest/src/enrichment/wikidata.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from "vitest";
+import { searchWikidataAuthors, buildWikimediaThumbUrl } from "./wikidata";
+
+function fakeFetch(responses: Array<{ body: object; status?: number }>): typeof fetch {
+  let callIndex = 0;
+  return vi.fn((() => {
+    const resp = responses[callIndex++];
+    const status = resp?.status ?? 200;
+    return Promise.resolve({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(resp?.body),
+    });
+  }) as () => Promise<Response>) as typeof fetch;
+}
+
+describe("buildWikimediaThumbUrl", () => {
+  it("constructs a valid thumbnail URL", () => {
+    const url = buildWikimediaThumbUrl("N. K. Jemisin.jpg");
+    expect(url).toContain("upload.wikimedia.org/wikipedia/commons/thumb/");
+    expect(url).toContain("N._K._Jemisin.jpg");
+    expect(url).toContain("200px-");
+  });
+
+  it("handles filenames without spaces", () => {
+    const url = buildWikimediaThumbUrl("Example.jpg");
+    expect(url).toContain("Example.jpg");
+    expect(url).toContain("/200px-Example.jpg");
+  });
+});
+
+describe("searchWikidataAuthors", () => {
+  it("searches entities and fetches image claims", async () => {
+    const fetcher = fakeFetch([
+      // wbsearchentities response
+      {
+        body: {
+          search: [
+            { id: "Q2427544", display: { label: { value: "N. K. Jemisin" } } },
+          ],
+        },
+      },
+      // wbgetclaims P18 response
+      {
+        body: {
+          claims: {
+            P18: [{ mainsnak: { datavalue: { value: "N. K. Jemisin.jpg" } } }],
+          },
+        },
+      },
+    ]);
+
+    const results = await searchWikidataAuthors("N.K. Jemisin", fetcher);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.qid).toBe("Q2427544");
+    expect(results[0]?.name).toBe("N. K. Jemisin");
+    expect(results[0]?.imageUrl).toContain("N._K._Jemisin.jpg");
+  });
+
+  it("returns empty array when no search results", async () => {
+    const fetcher = fakeFetch([
+      { body: { search: [] } },
+    ]);
+
+    const results = await searchWikidataAuthors("Nobody", fetcher);
+
+    expect(results).toEqual([]);
+  });
+
+  it("returns author with null imageUrl when no P18 claim", async () => {
+    const fetcher = fakeFetch([
+      {
+        body: {
+          search: [
+            { id: "Q12345", display: { label: { value: "Some Author" } } },
+          ],
+        },
+      },
+      { body: { claims: {} } },
+    ]);
+
+    const results = await searchWikidataAuthors("Some Author", fetcher);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.imageUrl).toBeNull();
+  });
+
+  it("throws on search API error", async () => {
+    const fetcher = fakeFetch([
+      { body: {}, status: 500 },
+    ]);
+
+    await expect(searchWikidataAuthors("test", fetcher)).rejects.toThrow("Wikidata API error: 500");
+  });
+
+  it("returns null imageUrl when claims API fails", async () => {
+    const fetcher = fakeFetch([
+      {
+        body: {
+          search: [
+            { id: "Q99", display: { label: { value: "Author" } } },
+          ],
+        },
+      },
+      { body: {}, status: 500 },
+    ]);
+
+    const results = await searchWikidataAuthors("Author", fetcher);
+
+    expect(results).toHaveLength(1);
+    expect(results[0]?.imageUrl).toBeNull();
+  });
+
+  it("returns null imageUrl when claims response is invalid JSON", async () => {
+    let callIndex = 0;
+    const fetcher = vi.fn((() => {
+      callIndex++;
+      if (callIndex === 1) {
+        return Promise.resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({
+            search: [{ id: "Q99", display: { label: { value: "Author" } } }],
+          }),
+        });
+      }
+      // Claims call throws on json()
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: () => Promise.reject(new Error("invalid json")),
+      });
+    }) as () => Promise<Response>) as typeof fetch;
+
+    const results = await searchWikidataAuthors("Author", fetcher);
+
+    expect(results[0]?.imageUrl).toBeNull();
+  });
+
+  it("handles missing display label", async () => {
+    const fetcher = fakeFetch([
+      {
+        body: {
+          search: [
+            { id: "Q99" },
+          ],
+        },
+      },
+      { body: { claims: {} } },
+    ]);
+
+    const results = await searchWikidataAuthors("Unknown", fetcher);
+
+    expect(results[0]?.name).toBe("");
+  });
+});

--- a/packages/ingest/src/enrichment/wikidata.ts
+++ b/packages/ingest/src/enrichment/wikidata.ts
@@ -1,0 +1,86 @@
+import { createHash } from "node:crypto";
+
+const WD_API = "https://www.wikidata.org/w/api.php";
+
+export interface WDAuthor {
+  qid: string;
+  name: string;
+  imageUrl: string | null;
+}
+
+interface WDSearchResult {
+  id: string;
+  display?: { label?: { value?: string } };
+}
+
+interface WDSearchResponse {
+  search: WDSearchResult[];
+}
+
+interface WDClaimsResponse {
+  claims?: {
+    P18?: Array<{ mainsnak: { datavalue: { value: string } } }>;
+  };
+}
+
+export function buildWikimediaThumbUrl(filename: string): string {
+  const normalized = filename.replace(/ /g, "_");
+  const md5 = createHash("md5").update(normalized).digest("hex");
+  const encoded = encodeURIComponent(normalized);
+  const a = md5.charAt(0);
+  const ab = md5.slice(0, 2);
+  return `https://upload.wikimedia.org/wikipedia/commons/thumb/${a}/${ab}/${encoded}/200px-${encoded}`;
+}
+
+async function getImageUrl(qid: string, fetcher: typeof fetch): Promise<string | null> {
+  try {
+    const params = new URLSearchParams({
+      action: "wbgetclaims",
+      entity: qid,
+      property: "P18",
+      format: "json",
+    });
+    const response = await fetcher(`${WD_API}?${params.toString()}`);
+    if (!response.ok) return null;
+    const data = (await response.json()) as WDClaimsResponse;
+    const filename = data.claims?.P18?.[0]?.mainsnak.datavalue.value;
+    if (!filename) return null;
+    return buildWikimediaThumbUrl(filename);
+  } catch {
+    return null;
+  }
+}
+
+export async function searchWikidataAuthors(
+  name: string,
+  fetcher: typeof fetch,
+): Promise<WDAuthor[]> {
+  const params = new URLSearchParams({
+    action: "wbsearchentities",
+    search: name,
+    language: "en",
+    type: "item",
+    limit: "3",
+    format: "json",
+  });
+
+  const response = await fetcher(`${WD_API}?${params.toString()}`);
+  if (!response.ok) {
+    throw new Error(`Wikidata API error: ${String(response.status)}`);
+  }
+
+  const data = (await response.json()) as WDSearchResponse;
+  if (data.search.length === 0) return [];
+
+  const results: WDAuthor[] = [];
+  for (const hit of data.search) {
+    const imageUrl = await getImageUrl(hit.id, fetcher);
+    results.push({
+      qid: hit.id,
+      name: hit.display?.label?.value ?? "",
+      imageUrl,
+    });
+  }
+
+  return results;
+}

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -54,13 +54,13 @@ export type {
 
 export { extractEpubCover } from "./epub";
 export type { EpubCoverResult } from "./epub";
-export { detectAdjacentCover, resizeCoverImage, processCoverForWork, processCoverForWorkDefault } from "./covers";
+export { detectAdjacentCover, resizeCoverImage, resizeAndSaveCover, processCoverForWork, processCoverForWorkDefault } from "./covers";
 export type { CoverDependencies, ProcessCoverInput, ProcessCoverResult } from "./covers";
 export { PARTIAL_HASH_BYTES } from "./hashing";
 export { SCAN_PROGRESS_INTERVAL } from "./services";
 
-export { searchOpenLibrary, getOpenLibraryEdition, getOpenLibraryWork } from "./enrichment/open-library";
-export type { OLSearchResult, OLEdition, OLWork } from "./enrichment/open-library";
+export { searchOpenLibrary, getOpenLibraryEdition, getOpenLibraryWork, searchOpenLibraryAuthors, createOLFetcher } from "./enrichment/open-library";
+export type { OLSearchResult, OLEdition, OLWork, OLAuthorSearchResult } from "./enrichment/open-library";
 export { searchGoogleBooks, getGoogleBooksVolume } from "./enrichment/google-books";
 export type { GBVolume } from "./enrichment/google-books";
 export { searchHardcover, getHardcoverBook } from "./enrichment/hardcover";
@@ -82,6 +82,15 @@ export { RateLimiter } from "./enrichment/rate-limiter";
 export type { RateLimitResult } from "./enrichment/rate-limiter";
 export { enrichWork } from "./enrichment/enrich-work";
 export type { EnrichWorkDeps, EnrichWorkResult } from "./enrichment/enrich-work";
+export { enrichContributor } from "./enrichment/enrich-contributor";
+export type { EnrichContributorDeps, EnrichContributorResult } from "./enrichment/enrich-contributor";
+export { TokenBucketLimiter } from "./enrichment/token-bucket";
+export { searchHardcoverAuthors } from "./enrichment/hardcover";
+export type { HCAuthor } from "./enrichment/hardcover";
+export { searchWikidataAuthors, buildWikimediaThumbUrl } from "./enrichment/wikidata";
+export type { WDAuthor } from "./enrichment/wikidata";
+export { applyAuthorPhotoFromUrl } from "./author-photo";
+export type { AuthorPhotoDeps, AuthorPhotoDbDeps, AuthorPhotoInput, AuthorPhotoResult } from "./author-photo";
 export { levenshteinDistance, normalizedSimilarity, normalizeForTitleMatching, stripSubtitleForMatching } from "./similarity";
 export { cascadeCleanupOrphans } from "./cascade-cleanup";
 export type { CascadeCleanupInput, CascadeCleanupResult } from "./cascade-cleanup";
@@ -130,6 +139,7 @@ export const INGEST_PUBLIC_API = [
   "processCoverForWork",
   "processCoverForWorkDefault",
   "resizeCoverImage",
+  "resizeAndSaveCover",
   "searchOpenLibrary",
   "scanLibraryRoot",
   "walkRegularFiles",
@@ -140,4 +150,7 @@ export const INGEST_PUBLIC_API = [
   "isValidImageData",
   "isAllowedMimeType",
   "applyCoverFromUrl",
+  "searchOpenLibraryAuthors",
+  "enrichContributor",
+  "applyAuthorPhotoFromUrl",
 ] as const;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -3,6 +3,9 @@ export * from "./errors.js";
 export { createLogger } from "./logger.js";
 export {
   enqueueLibraryJob,
+  enqueueEnrichmentJob,
+  getActiveJobCountByName,
+  getActiveEnrichmentJobCount,
   getImportJobLiveActivity,
   getLibraryJobSnapshot,
   getLibraryJobState,

--- a/packages/shared/src/queue-client.test.ts
+++ b/packages/shared/src/queue-client.test.ts
@@ -683,3 +683,130 @@ describe("getImportJobLiveActivity", () => {
     expect(getJobsMock).toHaveBeenNthCalledWith(2, ["prioritized"], 0, 499, true);
   });
 });
+
+describe("getActiveJobCountByName", () => {
+  it("counts jobs matching the given name across all live states", async () => {
+    getJobsMock
+      .mockResolvedValueOnce([{ name: "enrich-contributor" }, { name: "refresh-metadata" }])
+      .mockResolvedValueOnce([{ name: "enrich-contributor" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const { getActiveJobCountByName } = await import("./index");
+    const count = await getActiveJobCountByName("enrich-contributor");
+
+    expect(count).toBe(2);
+  });
+
+  it("returns 0 when no jobs match", async () => {
+    getJobsMock.mockResolvedValue([]);
+
+    const { getActiveJobCountByName } = await import("./index");
+    const count = await getActiveJobCountByName("enrich-contributor");
+
+    expect(count).toBe(0);
+  });
+
+  it("paginates through batches when batch is full", async () => {
+    // First call for "active" state: return a full batch (500 items) then an empty batch
+    const fullBatch = Array.from({ length: 500 }, (_, i) => ({
+      name: i < 3 ? "enrich-contributor" : "other-job",
+    }));
+    getJobsMock
+      .mockResolvedValueOnce(fullBatch)    // active state, first batch (full)
+      .mockResolvedValueOnce([{ name: "enrich-contributor" }])  // active state, second batch
+      .mockResolvedValueOnce([])           // prioritized
+      .mockResolvedValueOnce([])           // waiting
+      .mockResolvedValueOnce([])           // waiting-children
+      .mockResolvedValueOnce([]);          // delayed
+
+    const { getActiveJobCountByName } = await import("./index");
+    const count = await getActiveJobCountByName("enrich-contributor");
+
+    expect(count).toBe(4); // 3 from first batch + 1 from second
+    // Should have requested second batch starting at offset 500
+    expect(getJobsMock).toHaveBeenCalledWith(["active"], 500, 999, true);
+  });
+});
+
+describe("enqueueEnrichmentJob", () => {
+  it("reuses the enrichment queue singleton on repeated calls", async () => {
+    addMock.mockResolvedValue({ id: "ej-0" });
+    const { enqueueEnrichmentJob, ENRICHMENT_JOB_NAMES } = await import("./index");
+    await enqueueEnrichmentJob(ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR, { contributorId: "c1" });
+    await enqueueEnrichmentJob(ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR, { contributorId: "c2" });
+    // IORedis constructor should only be called once for the enrichment queue
+    // (plus once for the library queue if it was initialized in the same test)
+  });
+
+  it("enqueues to the enrichment queue with retry config", async () => {
+    addMock.mockResolvedValue({ id: "ej-1" });
+    const { enqueueEnrichmentJob, ENRICHMENT_JOB_NAMES, ENRICHMENT_RETRY_CONFIG } = await import("./index");
+
+    const jobId = await enqueueEnrichmentJob(ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR, {
+      contributorId: "c1",
+    });
+
+    expect(jobId).toBe("ej-1");
+    const config = ENRICHMENT_RETRY_CONFIG[ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR];
+    expect(addMock).toHaveBeenCalledWith(
+      "enrich-contributor",
+      { contributorId: "c1" },
+      { attempts: config.attempts, backoff: config.backoff, priority: expect.any(Number) as number },
+    );
+  });
+
+  it("throws QueueError on failure", async () => {
+    addMock.mockRejectedValueOnce(new Error("redis down"));
+    const { enqueueEnrichmentJob, ENRICHMENT_JOB_NAMES } = await import("./index");
+
+    await expect(
+      enqueueEnrichmentJob(ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR, { contributorId: "c1" }),
+    ).rejects.toThrow("Failed to enqueue enrichment job");
+  });
+
+  it("returns 'unknown' when job id is null", async () => {
+    addMock.mockResolvedValueOnce({ id: null });
+    const { enqueueEnrichmentJob, ENRICHMENT_JOB_NAMES } = await import("./index");
+
+    const jobId = await enqueueEnrichmentJob(ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR, {
+      contributorId: "c1",
+    });
+    expect(jobId).toBe("unknown");
+  });
+});
+
+describe("getActiveEnrichmentJobCount", () => {
+  it("counts jobs in the enrichment queue", async () => {
+    getJobsMock
+      .mockResolvedValueOnce([{ name: "enrich-contributor" }, { name: "other" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const { getActiveEnrichmentJobCount } = await import("./index");
+    const count = await getActiveEnrichmentJobCount("enrich-contributor");
+
+    expect(count).toBe(1);
+  });
+
+  it("paginates through full batches", async () => {
+    const fullBatch = Array.from({ length: 500 }, (_, i) => ({
+      name: i === 0 ? "enrich-contributor" : "other",
+    }));
+    getJobsMock
+      .mockResolvedValueOnce(fullBatch)
+      .mockResolvedValueOnce([{ name: "enrich-contributor" }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+
+    const { getActiveEnrichmentJobCount } = await import("./index");
+    const count = await getActiveEnrichmentJobCount("enrich-contributor");
+
+    expect(count).toBe(2);
+  });
+});

--- a/packages/shared/src/queue-client.ts
+++ b/packages/shared/src/queue-client.ts
@@ -1,8 +1,8 @@
 import IORedis from "ioredis";
 import { Queue } from "bullmq";
 import { QUEUES, getQueueConnectionConfig } from "./queues.js";
-import type { LibraryJobName, LibraryJobPayload } from "./queues.js";
-import { JOB_PRIORITY, RETRY_CONFIG } from "./queues.js";
+import type { LibraryJobName, LibraryJobPayload, EnrichmentJobName, EnrichmentJobPayload } from "./queues.js";
+import { JOB_PRIORITY, RETRY_CONFIG, ENRICHMENT_JOB_PRIORITY, ENRICHMENT_RETRY_CONFIG } from "./queues.js";
 import { QueueError } from "./errors.js";
 import { createLogger } from "./logger.js";
 
@@ -24,6 +24,22 @@ function getQueue(): Queue {
   return queueSingleton.queue;
 }
 
+
+let enrichmentQueueSingleton:
+  | {
+      connection: IORedis;
+      queue: Queue;
+    }
+  | undefined;
+
+function getEnrichmentQueue(): Queue {
+  if (enrichmentQueueSingleton === undefined) {
+    const connection = new IORedis(getQueueConnectionConfig());
+    const queue = new Queue(QUEUES.ENRICHMENT, { connection });
+    enrichmentQueueSingleton = { connection, queue };
+  }
+  return enrichmentQueueSingleton.queue;
+}
 
 export interface EnqueueJobOpts {
   parent?: { id: string; queue: string };
@@ -216,6 +232,32 @@ function getQueueConnection(): IORedis {
   return (queueSingleton as NonNullable<typeof queueSingleton>).connection;
 }
 
+const LIVE_JOB_STATES = ["active", "prioritized", "waiting", "waiting-children", "delayed"] as const;
+const JOB_BATCH_SIZE = 500;
+
+export async function getActiveJobCountByName(jobName: string): Promise<number> {
+  const queue = getQueue();
+  let count = 0;
+
+  for (const state of LIVE_JOB_STATES) {
+    let start = 0;
+
+    for (;;) {
+      const jobs = await queue.getJobs([state], start, start + JOB_BATCH_SIZE - 1, true);
+      if (jobs.length === 0) break;
+
+      for (const job of jobs) {
+        if (job.name === jobName) count++;
+      }
+
+      if (jobs.length < JOB_BATCH_SIZE) break;
+      start += JOB_BATCH_SIZE;
+    }
+  }
+
+  return count;
+}
+
 export async function enqueueLibraryJob<TName extends LibraryJobName>(
   jobName: TName,
   payload: LibraryJobPayload<TName>,
@@ -242,4 +284,50 @@ export async function enqueueLibraryJob<TName extends LibraryJobName>(
       context: { jobName },
     });
   }
+}
+
+export async function enqueueEnrichmentJob<TName extends EnrichmentJobName>(
+  jobName: TName,
+  payload: EnrichmentJobPayload<TName>,
+): Promise<string> {
+  try {
+    const queue = getEnrichmentQueue();
+    const retryConfig = ENRICHMENT_RETRY_CONFIG[jobName];
+    const job = await queue.add(jobName, payload, {
+      attempts: retryConfig.attempts,
+      backoff: retryConfig.backoff,
+      priority: ENRICHMENT_JOB_PRIORITY[jobName],
+    });
+    const jobId = job.id ?? "unknown";
+    logger.info({ jobName, jobId }, "Enrichment job enqueued");
+    return jobId;
+  } catch (error) {
+    throw new QueueError(`Failed to enqueue enrichment job: ${jobName}`, {
+      cause: error as Error,
+      context: { jobName },
+    });
+  }
+}
+
+export async function getActiveEnrichmentJobCount(jobName: string): Promise<number> {
+  const queue = getEnrichmentQueue();
+  let count = 0;
+
+  for (const state of LIVE_JOB_STATES) {
+    let start = 0;
+
+    for (;;) {
+      const jobs = await queue.getJobs([state], start, start + JOB_BATCH_SIZE - 1, true);
+      if (jobs.length === 0) break;
+
+      for (const job of jobs) {
+        if (job.name === jobName) count++;
+      }
+
+      if (jobs.length < JOB_BATCH_SIZE) break;
+      start += JOB_BATCH_SIZE;
+    }
+  }
+
+  return count;
 }

--- a/packages/shared/src/queues.ts
+++ b/packages/shared/src/queues.ts
@@ -1,5 +1,6 @@
 export const QUEUES = {
   LIBRARY: "library",
+  ENRICHMENT: "enrichment",
 } as const;
 
 export const LIBRARY_JOB_NAMES = {
@@ -11,6 +12,10 @@ export const LIBRARY_JOB_NAMES = {
   REFRESH_METADATA: "refresh-metadata",
   DETECT_DUPLICATES: "detect-duplicates",
   MATCH_SUGGESTIONS: "match-suggestions",
+} as const;
+
+export const ENRICHMENT_JOB_NAMES = {
+  ENRICH_CONTRIBUTOR: "enrich-contributor",
 } as const;
 
 export interface BaseJobPayload {
@@ -56,6 +61,10 @@ export interface MatchSuggestionsJobPayload extends BaseJobPayload {
   fileAssetId: string;
 }
 
+export interface EnrichContributorJobPayload extends BaseJobPayload {
+  contributorId: string;
+}
+
 export interface LibraryJobPayloads {
   [LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT]: ScanLibraryRootJobPayload;
   [LIBRARY_JOB_NAMES.HASH_FILE_ASSET]: HashFileAssetJobPayload;
@@ -67,8 +76,15 @@ export interface LibraryJobPayloads {
   [LIBRARY_JOB_NAMES.MATCH_SUGGESTIONS]: MatchSuggestionsJobPayload;
 }
 
+export interface EnrichmentJobPayloads {
+  [ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR]: EnrichContributorJobPayload;
+}
+
 export type LibraryJobName = keyof LibraryJobPayloads;
 export type LibraryJobPayload<TName extends LibraryJobName> = LibraryJobPayloads[TName];
+
+export type EnrichmentJobName = keyof EnrichmentJobPayloads;
+export type EnrichmentJobPayload<TName extends EnrichmentJobName> = EnrichmentJobPayloads[TName];
 
 export interface JobRetryConfig {
   attempts: number;
@@ -110,6 +126,13 @@ export const RETRY_CONFIG: Record<LibraryJobName, JobRetryConfig> = {
   },
 };
 
+export const ENRICHMENT_RETRY_CONFIG: Record<EnrichmentJobName, JobRetryConfig> = {
+  [ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR]: {
+    attempts: 5,
+    backoff: { type: "exponential", delay: 10000 },
+  },
+};
+
 // Lower number = higher priority. BullMQ processes prioritized jobs before non-prioritized ones.
 export const JOB_PRIORITY: Record<LibraryJobName, number> = {
   [LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT]: 1,
@@ -120,6 +143,10 @@ export const JOB_PRIORITY: Record<LibraryJobName, number> = {
   [LIBRARY_JOB_NAMES.REFRESH_METADATA]: 5,
   [LIBRARY_JOB_NAMES.PROCESS_COVER]: 6,
   [LIBRARY_JOB_NAMES.HASH_FILE_ASSET]: 7,
+};
+
+export const ENRICHMENT_JOB_PRIORITY: Record<EnrichmentJobName, number> = {
+  [ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR]: 1,
 };
 
 export function getQueueUrl(): string {

--- a/workers/library-worker/src/enrichment-worker.test.ts
+++ b/workers/library-worker/src/enrichment-worker.test.ts
@@ -1,0 +1,597 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const addMock = vi.fn();
+const workerConstructorMock = vi.fn();
+const enrichContributorMock = vi.fn();
+const appSettingFindUniqueMock = vi.fn();
+const contributorFindUniqueMock = vi.fn();
+const contributorUpdateMock = vi.fn();
+const applyAuthorPhotoFromUrlMock = vi.fn().mockResolvedValue({ success: true });
+const resizeAndSaveCoverMock = vi.fn().mockResolvedValue(undefined);
+const searchOpenLibraryAuthorsMock = vi.fn();
+const searchHardcoverAuthorsMock = vi.fn();
+const searchWikidataAuthorsMock = vi.fn().mockResolvedValue([]);
+const importJobUpdateMock = vi.fn().mockResolvedValue({});
+const importJobFindUniqueMock = vi.fn();
+const redisConstructorMock = vi.fn();
+
+vi.mock("ioredis", () => ({
+  default: function FakeRedis(config: object) {
+    redisConstructorMock(config);
+  },
+}));
+
+vi.mock("bullmq", () => ({
+  Worker: class FakeWorker {
+    concurrency = 1;
+
+    constructor(...args: object[]) {
+      workerConstructorMock(...args);
+    }
+
+    on = vi.fn();
+    close = vi.fn();
+  },
+  Queue: class FakeQueue {
+    add = addMock;
+  },
+}));
+
+vi.mock("@bookhouse/db", () => ({
+  db: {
+    appSetting: { findUnique: appSettingFindUniqueMock },
+    contributor: {
+      findUnique: contributorFindUniqueMock,
+      update: contributorUpdateMock,
+    },
+    importJob: {
+      update: importJobUpdateMock,
+      findUnique: importJobFindUniqueMock,
+    },
+  },
+}));
+
+vi.mock("@bookhouse/ingest", () => ({
+  enrichContributor: enrichContributorMock,
+  searchOpenLibraryAuthors: searchOpenLibraryAuthorsMock,
+  searchHardcoverAuthors: searchHardcoverAuthorsMock,
+  searchWikidataAuthors: searchWikidataAuthorsMock,
+  applyAuthorPhotoFromUrl: applyAuthorPhotoFromUrlMock,
+  resizeAndSaveCover: resizeAndSaveCoverMock,
+  createOLFetcher: () => fetch,
+  TokenBucketLimiter: class { acquire = () => Promise.resolve(); },
+}));
+
+vi.mock("@bookhouse/shared", async () => {
+  const actual = await vi.importActual<Record<string, object>>("@bookhouse/shared");
+  return {
+    ...actual,
+    getQueueConnectionConfig: () => ({ host: "localhost", port: 6379 }),
+  };
+});
+
+
+beforeEach(() => {
+  enrichContributorMock.mockReset();
+  appSettingFindUniqueMock.mockReset();
+  contributorFindUniqueMock.mockReset();
+  contributorUpdateMock.mockReset();
+  applyAuthorPhotoFromUrlMock.mockReset();
+  applyAuthorPhotoFromUrlMock.mockResolvedValue({ success: true });
+  resizeAndSaveCoverMock.mockReset();
+  searchOpenLibraryAuthorsMock.mockReset();
+  searchHardcoverAuthorsMock.mockReset();
+  searchWikidataAuthorsMock.mockReset();
+  searchWikidataAuthorsMock.mockResolvedValue([]);
+  importJobUpdateMock.mockReset();
+  importJobUpdateMock.mockResolvedValue({});
+  importJobFindUniqueMock.mockReset();
+  delete process.env.COVER_CACHE_DIR;
+  delete process.env.NODE_ENV;
+  delete process.env.AUTH_SECRET;
+  process.env.QUEUE_URL = "redis://localhost:6379";
+});
+
+describe("enrichment worker", () => {
+  it("dispatches enrich-contributor jobs to enrichContributor handler", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "OL1A" });
+    appSettingFindUniqueMock.mockResolvedValue(null); // no HC key
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    const result = await processor({
+      id: "j1",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    expect(result).toEqual({ status: "enriched", authorOlid: "OL1A" });
+    expect(enrichContributorMock).toHaveBeenCalledWith("c1", expect.objectContaining({
+      findContributor: expect.any(Function) as (() => void),
+      acquireOLToken: expect.any(Function) as (() => void),
+      searchOLAuthors: expect.any(Function) as (() => void),
+      applyPhoto: expect.any(Function) as (() => void),
+    }));
+  });
+
+  it("includes HC deps when Hardcover API key is configured", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "hc:100" });
+    // Simulate an encrypted API key — the mock loadAuthConfig returns a fixed secret,
+    // but decryptValue will fail on a bad ciphertext. For testing we just verify the deps shape.
+    appSettingFindUniqueMock.mockResolvedValue(null); // no key = no HC
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "j2",
+      name: "enrich-contributor",
+      data: { contributorId: "c2" },
+      opts: {},
+    } as never);
+
+    // Without HC key, the deps should not include searchHCAuthors
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, Record<string, object | undefined>]];
+    expect(deps.searchHCAuthors).toBeUndefined();
+    expect(deps.acquireHCToken).toBeUndefined();
+  });
+
+  it("throws for unsupported job names", async () => {
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await expect(
+      processor({
+        id: "j3",
+        name: "unknown-job",
+        data: {},
+        opts: {},
+      } as never),
+    ).rejects.toThrow("Unsupported enrichment job");
+  });
+
+  it("exercises findContributor and applyPhoto deps", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "OL1A" });
+    appSettingFindUniqueMock.mockResolvedValue(null);
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "j4",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    type Deps = {
+      findContributor: (id: string) => Promise<object | null>;
+      applyPhoto: (id: string, url: string) => Promise<object>;
+      acquireOLToken: () => Promise<void>;
+      searchOLAuthors: (name: string) => Promise<object | null>;
+    };
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, Deps]];
+
+    // Exercise findContributor
+    contributorFindUniqueMock.mockResolvedValueOnce({ id: "c1", nameDisplay: "Author", imagePath: null });
+    await deps.findContributor("c1");
+    expect(contributorFindUniqueMock).toHaveBeenCalledWith({
+      where: { id: "c1" },
+      select: { id: true, nameDisplay: true, imagePath: true },
+    });
+
+    // Exercise acquireOLToken
+    await deps.acquireOLToken();
+
+    // Exercise searchOLAuthors
+    void deps.searchOLAuthors("Author");
+
+    // Exercise applyPhoto — the mock applyAuthorPhotoFromUrl handles it
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(new Uint8Array([0xff, 0xd8]).buffer),
+      headers: { get: () => "image/jpeg" },
+    }) as typeof fetch;
+    try {
+      await deps.applyPhoto("c1", "https://covers.openlibrary.org/a/olid/OL1A-M.jpg");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("startEnrichmentWorker creates a worker with concurrency 1", async () => {
+    const { startEnrichmentWorker } = await import("./enrichment-worker");
+    startEnrichmentWorker();
+
+    expect(workerConstructorMock).toHaveBeenCalledWith(
+      "enrichment",
+      expect.any(Function) as (() => void),
+      expect.objectContaining({ concurrency: 1 }),
+    );
+  });
+
+  it("uses COVER_CACHE_DIR env var when set", async () => {
+    process.env.COVER_CACHE_DIR = "/custom/covers";
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "OL1A" });
+    appSettingFindUniqueMock.mockResolvedValue(null);
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "j5",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    // The applyPhoto dep should use the custom dir — we verify by exercising it
+    type Deps = { applyPhoto: (id: string, url: string) => Promise<object> };
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, Deps]];
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(new Uint8Array([0xff, 0xd8]).buffer),
+      headers: { get: () => "image/jpeg" },
+    }) as typeof fetch;
+    try {
+      await deps.applyPhoto("c1", "https://example.com/photo.jpg");
+      expect(applyAuthorPhotoFromUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ coverCacheDir: "/custom/covers" }),
+        expect.any(Object) as object,
+        expect.any(Object) as object,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  it("exercises applyPhoto inner deps for coverage", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "OL1A" });
+    appSettingFindUniqueMock.mockResolvedValue(null);
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "jx",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    type Deps = { applyPhoto: (id: string, url: string) => Promise<object> };
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, Deps]];
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(new Uint8Array([0xff, 0xd8]).buffer),
+      headers: { get: () => "image/jpeg" },
+    }) as typeof fetch;
+    try {
+      await deps.applyPhoto("c1", "https://example.com/photo.jpg");
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+
+    // Verify inner deps were passed to applyAuthorPhotoFromUrl
+    expect(applyAuthorPhotoFromUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({ contributorId: "c1" }),
+      expect.objectContaining({
+        fetchUrl: expect.any(Function) as (() => void),
+        resizeAndSave: expect.any(Function) as (() => void),
+      }),
+      expect.objectContaining({
+        findContributor: expect.any(Function) as (() => void),
+        updateContributor: expect.any(Function) as (() => void),
+      }),
+    );
+
+    // Exercise the inner deps — since applyAuthorPhotoFromUrl is mocked, we extract its call args
+    type InnerDeps = { fetchUrl: (url: string) => Promise<{ buffer: Buffer; contentType: string | null }>; resizeAndSave: (buf: Buffer, dir: string) => Promise<void> };
+    type InnerDbDeps = { findContributor: (id: string) => Promise<object | null>; updateContributor: (id: string, data: object) => Promise<void> };
+    const [[, innerDeps, innerDbDeps]] = applyAuthorPhotoFromUrlMock.mock.calls as [[object, InnerDeps, InnerDbDeps]];
+
+    // fetchUrl — exercise with mocked globalThis.fetch
+    const savedFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(new Uint8Array([0xaa, 0xbb]).buffer),
+      headers: { get: () => "image/webp" },
+    }) as typeof fetch;
+    const fetchResult = await innerDeps.fetchUrl("https://example.com/test.jpg");
+    expect(fetchResult.contentType).toBe("image/webp");
+    expect(Buffer.isBuffer(fetchResult.buffer)).toBe(true);
+    globalThis.fetch = savedFetch;
+
+    // resizeAndSave
+    await innerDeps.resizeAndSave(Buffer.from([1]), "/tmp");
+    expect(resizeAndSaveCoverMock).toHaveBeenCalledWith(Buffer.from([1]), "/tmp");
+
+    // findContributor
+    contributorFindUniqueMock.mockResolvedValueOnce({ id: "c1" });
+    await innerDbDeps.findContributor("c1");
+    expect(contributorFindUniqueMock).toHaveBeenCalledWith({ where: { id: "c1" }, select: { id: true } });
+
+    // updateContributor
+    contributorUpdateMock.mockResolvedValueOnce({});
+    await innerDbDeps.updateContributor("c1", { imagePath: "c1" });
+    expect(contributorUpdateMock).toHaveBeenCalledWith({ where: { id: "c1" }, data: { imagePath: "c1" } });
+  });
+
+  it("updates ImportJob progress when importJobId is present", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "OL1A" });
+    appSettingFindUniqueMock.mockResolvedValue(null);
+    importJobFindUniqueMock.mockResolvedValue({ totalFiles: 10, processedFiles: 5 });
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "jp",
+      name: "enrich-contributor",
+      data: { contributorId: "c1", importJobId: "ij-1" },
+      opts: {},
+    } as never);
+
+    const updateCall = importJobUpdateMock.mock.calls[0] as [{ where: { id: string }; data: { status: string; processedFiles: { increment: number } } }];
+    expect(updateCall[0].where.id).toBe("ij-1");
+    expect(updateCall[0].data.status).toBe("RUNNING");
+    expect(updateCall[0].data.processedFiles).toEqual({ increment: 1 });
+  });
+
+  it("marks ImportJob as SUCCEEDED when all jobs are processed", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "OL1A" });
+    appSettingFindUniqueMock.mockResolvedValue(null);
+    importJobFindUniqueMock.mockResolvedValue({ totalFiles: 5, processedFiles: 5 });
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "jc",
+      name: "enrich-contributor",
+      data: { contributorId: "c1", importJobId: "ij-2" },
+      opts: {},
+    } as never);
+
+    // First call: increment progress. Second call: mark SUCCEEDED.
+    expect(importJobUpdateMock).toHaveBeenCalledTimes(2);
+    expect(importJobUpdateMock).toHaveBeenLastCalledWith({
+      where: { id: "ij-2" },
+      data: { status: "SUCCEEDED", finishedAt: expect.any(Date) as Date },
+    });
+  });
+
+  it("increments errorCount for no-results status", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "no-results", triedSources: ["openlibrary"] });
+    appSettingFindUniqueMock.mockResolvedValue(null);
+    importJobFindUniqueMock.mockResolvedValue({ totalFiles: 10, processedFiles: 3 });
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "je2",
+      name: "enrich-contributor",
+      data: { contributorId: "c1", importJobId: "ij-3" },
+      opts: {},
+    } as never);
+
+    const errCall = importJobUpdateMock.mock.calls[0] as [{ where: { id: string }; data: { errorCount: { increment: number } } }];
+    expect(errCall[0].where.id).toBe("ij-3");
+    expect(errCall[0].data.errorCount).toEqual({ increment: 1 });
+  });
+
+  it("updates ImportJob on error and re-throws", async () => {
+    enrichContributorMock.mockRejectedValueOnce(new Error("OL API error"));
+    appSettingFindUniqueMock.mockResolvedValue(null);
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await expect(
+      processor({
+        id: "jf",
+        name: "enrich-contributor",
+        data: { contributorId: "c1", importJobId: "ij-4" },
+        opts: {},
+      } as never),
+    ).rejects.toThrow("OL API error");
+
+    const failCall = importJobUpdateMock.mock.calls[0] as [{ where: { id: string }; data: { processedFiles: { increment: number }; errorCount: { increment: number } } }];
+    expect(failCall[0].where.id).toBe("ij-4");
+    expect(failCall[0].data.processedFiles).toEqual({ increment: 1 });
+    expect(failCall[0].data.errorCount).toEqual({ increment: 1 });
+  });
+
+  it("swallows ImportJob update error on job failure", async () => {
+    enrichContributorMock.mockRejectedValueOnce(new Error("OL down"));
+    appSettingFindUniqueMock.mockResolvedValue(null);
+    importJobUpdateMock.mockRejectedValueOnce(new Error("DB down"));
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await expect(
+      processor({
+        id: "jdb",
+        name: "enrich-contributor",
+        data: { contributorId: "c1", importJobId: "ij-5" },
+        opts: {},
+      } as never),
+    ).rejects.toThrow("OL down");
+
+    // ImportJob update was attempted but failed — should not block the error throw
+  });
+
+  it("always includes Wikidata deps (no API key needed)", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "wd:Q1" });
+    appSettingFindUniqueMock.mockResolvedValue(null);
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "jwd",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    type WDDeps = {
+      searchWDAuthors: (name: string) => Promise<object[]>;
+      acquireWDToken: () => Promise<void>;
+    };
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, WDDeps]];
+    expect(deps.searchWDAuthors).toBeDefined();
+    expect(deps.acquireWDToken).toBeDefined();
+
+    await deps.acquireWDToken();
+    void deps.searchWDAuthors("Test");
+  });
+
+  it("includes HC deps when a valid API key setting exists", async () => {
+    // Create an encrypted value using the same crypto pattern
+    const crypto = await import("node:crypto");
+    const secret = "a".repeat(32);
+    process.env.AUTH_SECRET = secret;
+    const key = crypto.createHash("sha256").update(secret).digest();
+    const iv = crypto.randomBytes(12);
+    const cipher = crypto.createCipheriv("aes-256-gcm", key, iv);
+    const encrypted = Buffer.concat([cipher.update("hc-test-key", "utf8"), cipher.final()]);
+    const authTag = cipher.getAuthTag();
+    const ciphertext = Buffer.concat([iv, authTag, encrypted]).toString("base64");
+
+    appSettingFindUniqueMock.mockResolvedValue({ value: ciphertext });
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "hc:100" });
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "jhc",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    type HCDeps = {
+      searchHCAuthors: (name: string) => Promise<object | null>;
+      acquireHCToken: () => Promise<void>;
+    };
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, HCDeps]];
+    expect(deps.searchHCAuthors).toBeDefined();
+    expect(deps.acquireHCToken).toBeDefined();
+
+    // Exercise them for coverage
+    await deps.acquireHCToken();
+    void deps.searchHCAuthors("Test Author");
+  });
+
+  it("warns and skips HC when AUTH_SECRET is not set but HC key exists", async () => {
+    appSettingFindUniqueMock.mockResolvedValue({ value: "some-encrypted-value" });
+    enrichContributorMock.mockResolvedValueOnce({ status: "no-results", triedSources: ["openlibrary"] });
+    // AUTH_SECRET is not set (cleared in beforeEach)
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "jns",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, Record<string, object | undefined>]];
+    expect(deps.searchHCAuthors).toBeUndefined();
+  });
+
+  it("getHardcoverApiKey returns null when appSetting throws", async () => {
+    enrichContributorMock.mockResolvedValueOnce({ status: "no-results", triedSources: ["openlibrary"] });
+    appSettingFindUniqueMock.mockRejectedValue(new Error("db error"));
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "je",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    // Should still work — HC deps just won't be included
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, Record<string, object | undefined>]];
+    expect(deps.searchHCAuthors).toBeUndefined();
+  });
+
+  it("uses /data/covers in production", async () => {
+    process.env.NODE_ENV = "production";
+    enrichContributorMock.mockResolvedValueOnce({ status: "enriched", authorOlid: "OL1A" });
+    appSettingFindUniqueMock.mockResolvedValue(null);
+
+    const { createEnrichmentWorkerProcessor } = await import("./enrichment-worker");
+    const processor = createEnrichmentWorkerProcessor({
+      enrichContributor: enrichContributorMock,
+    });
+
+    await processor({
+      id: "j6",
+      name: "enrich-contributor",
+      data: { contributorId: "c1" },
+      opts: {},
+    } as never);
+
+    type Deps = { applyPhoto: (id: string, url: string) => Promise<object> };
+    const [[, deps]] = enrichContributorMock.mock.calls as [[string, Deps]];
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      arrayBuffer: () => Promise.resolve(new Uint8Array([0xff, 0xd8]).buffer),
+      headers: { get: () => "image/jpeg" },
+    }) as typeof fetch;
+    try {
+      await deps.applyPhoto("c1", "https://example.com/photo.jpg");
+      expect(applyAuthorPhotoFromUrlMock).toHaveBeenCalledWith(
+        expect.objectContaining({ coverCacheDir: "/data/covers" }),
+        expect.any(Object) as object,
+        expect.any(Object) as object,
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+});

--- a/workers/library-worker/src/enrichment-worker.ts
+++ b/workers/library-worker/src/enrichment-worker.ts
@@ -1,0 +1,197 @@
+import IORedis from "ioredis";
+import { type Job, Worker } from "bullmq";
+import { db } from "@bookhouse/db";
+import {
+  enrichContributor,
+  searchOpenLibraryAuthors,
+  searchHardcoverAuthors,
+  searchWikidataAuthors,
+  applyAuthorPhotoFromUrl,
+  resizeAndSaveCover,
+  createOLFetcher,
+  TokenBucketLimiter,
+  type EnrichContributorDeps,
+  type EnrichContributorResult,
+} from "@bookhouse/ingest";
+import {
+  ENRICHMENT_JOB_NAMES,
+  type BaseJobPayload,
+  type EnrichmentJobName,
+  type EnrichmentJobPayload,
+  QUEUES,
+  createLogger,
+  getQueueConnectionConfig,
+} from "@bookhouse/shared";
+import { fileURLToPath } from "node:url";
+
+const logger = createLogger("enrichment-worker");
+
+const olLimiter = new TokenBucketLimiter(3);
+const hcLimiter = new TokenBucketLimiter(1);
+const wdLimiter = new TokenBucketLimiter(1);
+const olFetch = createOLFetcher("bookhouse@teamsnail.org");
+
+function getCoverCacheDir(): string {
+  if (process.env.COVER_CACHE_DIR) return process.env.COVER_CACHE_DIR;
+  if (process.env.NODE_ENV === "production") return "/data/covers";
+  return fileURLToPath(new URL("../../covers", import.meta.url));
+}
+
+async function decryptValue(ciphertext: string, secret: string): Promise<string> {
+  const { createHash, createDecipheriv } = await import("node:crypto");
+  const key = createHash("sha256").update(secret).digest();
+  const buf = Buffer.from(ciphertext, "base64");
+  const iv = buf.subarray(0, 12);
+  const authTag = buf.subarray(12, 28);
+  const encrypted = buf.subarray(28);
+  const decipher = createDecipheriv("aes-256-gcm", key, iv);
+  decipher.setAuthTag(authTag);
+  return decipher.update(encrypted, undefined, "utf8") + decipher.final("utf8");
+}
+
+async function getHardcoverApiKey(): Promise<string | null> {
+  try {
+    const setting = await db.appSetting.findUnique({ where: { key: "apiKey:hardcover" } });
+    if (!setting) return null;
+    const secret = process.env.AUTH_SECRET;
+    if (!secret) {
+      logger.warn("AUTH_SECRET not set — cannot decrypt Hardcover API key");
+      return null;
+    }
+    return await decryptValue(setting.value, secret);
+  } catch (err) {
+    logger.warn({ err }, "Failed to decrypt Hardcover API key");
+    return null;
+  }
+}
+
+function applyPhoto(contributorId: string, imageUrl: string) {
+  return applyAuthorPhotoFromUrl(
+    { contributorId, imageUrl, coverCacheDir: getCoverCacheDir() },
+    {
+      fetchUrl: async (url) => {
+        const response = await fetch(url);
+        const buffer = Buffer.from(await response.arrayBuffer());
+        const contentType = response.headers.get("content-type");
+        return { buffer, contentType };
+      },
+      resizeAndSave: (buf, dir) => resizeAndSaveCover(buf, dir),
+    },
+    {
+      findContributor: (id) => db.contributor.findUnique({ where: { id }, select: { id: true } }),
+      updateContributor: async (id, data) => { await db.contributor.update({ where: { id }, data }); },
+    },
+  );
+}
+
+export interface EnrichmentWorkerHandlers {
+  enrichContributor: typeof enrichContributor;
+}
+
+async function dispatch(
+  job: Job<EnrichmentJobPayload<EnrichmentJobName>, EnrichContributorResult, EnrichmentJobName>,
+  handlers: EnrichmentWorkerHandlers,
+): Promise<EnrichContributorResult> {
+  switch (job.name as string) {
+    case ENRICHMENT_JOB_NAMES.ENRICH_CONTRIBUTOR: {
+      const payload = job.data;
+      const hcKey = await getHardcoverApiKey();
+      const deps: EnrichContributorDeps = {
+        findContributor: (id) =>
+          db.contributor.findUnique({ where: { id }, select: { id: true, nameDisplay: true, imagePath: true } }),
+        acquireOLToken: () => olLimiter.acquire(),
+        searchOLAuthors: (name) => searchOpenLibraryAuthors(name, olFetch),
+        applyPhoto,
+        ...(hcKey ? {
+          acquireHCToken: () => hcLimiter.acquire(),
+          searchHCAuthors: (name: string) => searchHardcoverAuthors(name, hcKey, fetch),
+        } : {}),
+        acquireWDToken: () => wdLimiter.acquire(),
+        searchWDAuthors: (name: string) => searchWikidataAuthors(name, fetch),
+      };
+      return handlers.enrichContributor(payload.contributorId, deps);
+    }
+    default:
+      throw new Error(`Unsupported enrichment job: ${job.name}`);
+  }
+}
+
+const defaultHandlers: EnrichmentWorkerHandlers = {
+  enrichContributor,
+};
+
+async function checkBatchCompletion(importJobId: string): Promise<void> {
+  const job = await db.importJob.findUnique({
+    where: { id: importJobId },
+    select: { totalFiles: true, processedFiles: true },
+  });
+  if (job && job.totalFiles !== null && job.processedFiles !== null && job.processedFiles >= job.totalFiles) {
+    await db.importJob.update({
+      where: { id: importJobId },
+      data: { status: "SUCCEEDED", finishedAt: new Date() },
+    });
+    logger.info({ importJobId }, "Author photo enrichment batch completed");
+  }
+}
+
+export function createEnrichmentWorkerProcessor(
+  handlers: EnrichmentWorkerHandlers = defaultHandlers,
+) {
+  return async (
+    job: Job<EnrichmentJobPayload<EnrichmentJobName>, EnrichContributorResult, EnrichmentJobName>,
+  ) => {
+    const importJobId = (job.data as BaseJobPayload).importJobId;
+    logger.info({ jobId: job.id, jobName: job.name }, "Processing enrichment job");
+    try {
+      const result = await dispatch(job, handlers);
+      const extra = "triedSources" in result ? { triedSources: result.triedSources } : {};
+      logger.info({ jobId: job.id, jobName: job.name, status: result.status, ...extra }, "Enrichment job completed");
+      if (importJobId) {
+        const isError = result.status === "no-results" || result.status === "no-photo";
+        await db.importJob.update({
+          where: { id: importJobId },
+          data: {
+            status: "RUNNING",
+            startedAt: new Date(),
+            processedFiles: { increment: 1 },
+            ...(isError ? { errorCount: { increment: 1 } } : {}),
+          },
+        });
+        await checkBatchCompletion(importJobId);
+      }
+      return result;
+    } catch (error) {
+      logger.error({ jobId: job.id, jobName: job.name, err: error }, "Enrichment job failed");
+      if (importJobId) {
+        await db.importJob.update({
+          where: { id: importJobId },
+          data: {
+            status: "RUNNING",
+            processedFiles: { increment: 1 },
+            errorCount: { increment: 1 },
+          },
+        }).catch(() => { /* ImportJob update is best-effort */ });
+      }
+      throw error;
+    }
+  };
+}
+
+export function startEnrichmentWorker() {
+  const connection = new IORedis(getQueueConnectionConfig());
+
+  const worker = new Worker(
+    QUEUES.ENRICHMENT,
+    createEnrichmentWorkerProcessor(),
+    {
+      connection,
+      concurrency: 1,
+      removeOnComplete: { count: 1000 },
+      removeOnFail: { count: 5000 },
+    },
+  );
+
+  logger.info({ queue: QUEUES.ENRICHMENT, concurrency: 1 }, "enrichment-worker listening");
+
+  return { worker, connection };
+}

--- a/workers/library-worker/src/index.test.ts
+++ b/workers/library-worker/src/index.test.ts
@@ -10,7 +10,7 @@ type EnrichDeps = {
   searchOL: (title: string, author: string) => Promise<object | null>;
   getOLWork: (olid: string) => Promise<object | null>;
   upsertExternalLink: (data: { editionId: string; provider: string; externalId: string; metadata: Record<string, string | number | boolean | null> }) => Promise<object>;
-  checkRateLimit: () => { allowed: boolean };
+  acquireOLToken: () => Promise<void>;
 };
 
 const addMock = vi.fn();
@@ -114,8 +114,15 @@ vi.mock("@bookhouse/ingest", () => ({
   matchSuggestions: matchSuggestionsMock,
   searchOpenLibrary: vi.fn(),
   getOpenLibraryWork: vi.fn(),
-  RateLimiter: class { check = () => ({ allowed: true }); },
+  TokenBucketLimiter: class { acquire = () => Promise.resolve(); },
   cascadeCleanupOrphans: cascadeCleanupOrphansMock,
+  createOLFetcher: () => fetch,
+  enrichContributor: vi.fn(),
+  searchOpenLibraryAuthors: vi.fn(),
+  searchHardcoverAuthors: vi.fn(),
+  searchWikidataAuthors: vi.fn().mockResolvedValue([]),
+  applyAuthorPhotoFromUrl: vi.fn(),
+  resizeAndSaveCover: vi.fn(),
 }));
 
 vi.mock("@bookhouse/shared", async () => {
@@ -660,7 +667,7 @@ describe("library worker", () => {
       searchOL: expect.any(Function) as (() => void),
       getOLWork: expect.any(Function) as (() => void),
       upsertExternalLink: expect.any(Function) as (() => void),
-      checkRateLimit: expect.any(Function) as (() => void),
+      acquireOLToken: expect.any(Function) as (() => void),
     }));
 
     // Exercise the deps callbacks for coverage
@@ -711,8 +718,7 @@ describe("library worker", () => {
       },
     });
 
-    const rateResult = deps.checkRateLimit();
-    expect(rateResult).toEqual({ allowed: true });
+    await deps.acquireOLToken();
   });
 
   it("fails unknown jobs", async () => {
@@ -1252,7 +1258,8 @@ describe("library worker", () => {
     const sigtermHandler = processOnSpy.mock.calls.find(([event]) => event === "SIGTERM")?.[1] as () => void;
     sigtermHandler();
     // Allow the async shutdown() chain to complete (workerClose + quit + process.exit)
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    // Allow the async shutdown() and dynamic enrichment worker import to complete
+    await new Promise((resolve) => setTimeout(resolve, 200));
 
     expect(processExitSpy).toHaveBeenCalledWith(0);
 
@@ -1269,6 +1276,18 @@ describe("library worker", () => {
 
     processOnSpy.mockRestore();
     processExitSpy.mockRestore();
+  });
+
+  it("logEnrichmentWorkerError logs the error", async () => {
+    const { logEnrichmentWorkerError } = await import("./index");
+    logEnrichmentWorkerError(new Error("test error"));
+  });
+
+  it("handleEnrichmentWorkerModule calls startEnrichmentWorker", async () => {
+    const { handleEnrichmentWorkerModule } = await import("./index");
+    const mock = { startEnrichmentWorker: vi.fn() };
+    handleEnrichmentWorkerModule(mock);
+    expect(mock.startEnrichmentWorker).toHaveBeenCalled();
   });
 
   it("polls DB for concurrency using onDemand key when no scan is active", async () => {

--- a/workers/library-worker/src/index.ts
+++ b/workers/library-worker/src/index.ts
@@ -2,7 +2,7 @@ import { fileURLToPath, pathToFileURL } from "node:url";
 import IORedis from "ioredis";
 import { type Job, WaitingChildrenError, Worker } from "bullmq";
 import { db } from "@bookhouse/db";
-import { cascadeCleanupOrphans, createIngestServices, matchSuggestions, matchFileAssetToEdition, parseFileAssetMetadata, processCoverForWorkDefault, scanLibraryRoot, type ScanProgressData, type ScanLibraryRootResult, enrichWork, searchOpenLibrary, getOpenLibraryWork, RateLimiter, type EnrichWorkDeps, detectDuplicates, hashFileAsset, type ProcessCoverResult, type HashFileAssetResult, type ParseFileAssetMetadataResult, type MatchFileAssetToEditionResult, type DetectDuplicatesResult, type MatchSuggestionsResult, type EnrichWorkResult } from "@bookhouse/ingest";
+import { cascadeCleanupOrphans, createIngestServices, matchSuggestions, matchFileAssetToEdition, parseFileAssetMetadata, processCoverForWorkDefault, scanLibraryRoot, enrichWork, searchOpenLibrary, getOpenLibraryWork, TokenBucketLimiter, createOLFetcher, detectDuplicates, hashFileAsset, type ScanProgressData, type ScanLibraryRootResult, type EnrichWorkDeps, type ProcessCoverResult, type HashFileAssetResult, type ParseFileAssetMetadataResult, type MatchFileAssetToEditionResult, type DetectDuplicatesResult, type MatchSuggestionsResult, type EnrichWorkResult } from "@bookhouse/ingest";
 import {
   LIBRARY_JOB_NAMES,
   type BaseJobPayload,
@@ -25,7 +25,8 @@ import {
 const logger = createLogger("library-worker");
 
 const processCoverForWork = processCoverForWorkDefault(db);
-const rateLimiter = new RateLimiter();
+const olLimiter = new TokenBucketLimiter(3);
+const olFetch = createOLFetcher("bookhouse@teamsnail.org");
 
 export type LibraryJobResult =
   | ScanLibraryRootResult
@@ -196,8 +197,8 @@ async function dispatch(
               },
             },
           }),
-        searchOL: (title, author) => searchOpenLibrary(title, author, fetch),
-        getOLWork: (olid) => getOpenLibraryWork(olid, fetch),
+        searchOL: (title, author) => searchOpenLibrary(title, author, olFetch),
+        getOLWork: (olid) => getOpenLibraryWork(olid, olFetch),
         upsertExternalLink: async (data) => {
           await db.externalLink.upsert({
             where: {
@@ -211,7 +212,7 @@ async function dispatch(
             update: { metadata: data.metadata as object, lastSyncedAt: new Date() },
           });
         },
-        checkRateLimit: () => rateLimiter.check(),
+        acquireOLToken: () => olLimiter.acquire(),
       };
       return handlers.enrichWork(refreshPayload.workId, deps);
     }
@@ -421,6 +422,14 @@ export async function shutdownLibraryWorker(
   clearTimeout(forceExit);
 }
 
+export function logEnrichmentWorkerError(err: Error): void {
+  logger.error({ err }, "Failed to start enrichment worker");
+}
+
+export function handleEnrichmentWorkerModule(m: { startEnrichmentWorker: () => void }): void {
+  m.startEnrichmentWorker();
+}
+
 export function bootstrapLibraryWorker(): void {
   const { connection, pollInterval, worker } = createLibraryWorker();
 
@@ -440,6 +449,8 @@ export function bootstrapLibraryWorker(): void {
   process.on("SIGTERM", () => { void shutdown(); });
 
   logger.info({ queue: QUEUES.LIBRARY }, "library-worker listening");
+
+  void import("./enrichment-worker").then(handleEnrichmentWorkerModule, logEnrichmentWorkerError);
 }
 
 // Coverage: defaultHandlers referenced to ensure the import is exercised
@@ -451,6 +462,7 @@ export { pollConcurrency as _pollConcurrency, getActiveScanType as _getActiveSca
 export function _setActiveScanType(scanType: ScanType | null): void {
   activeScanType = scanType;
 }
+
 
 if (process.argv[1] !== undefined && import.meta.url === pathToFileURL(process.argv[1]).href) {
   bootstrapLibraryWorker();


### PR DESCRIPTION
## Summary

- Fetch author photos automatically from **Wikidata** (primary), **Open Library**, and **Hardcover** via a dedicated enrichment queue with single-concurrency worker and per-service token bucket rate limiting
- Display author photos on the **authors list** and **author detail** pages
- **"Fetch Photos" button** on authors page with SSE-driven progress tracking and ImportJob visibility on the Settings jobs page
- **Manual photo upload** (file picker) and **URL fetch** on the author detail page
- **Tag-style author input** with autocomplete on the book detail page, replacing comma-separated text editing that corrupted names containing commas (e.g., "Julie Schwartz Gottman, PhD")
- **Open Library User-Agent identification** for 3x rate limit (3 req/s vs 1 req/s)

Closes #123