### PR TITLE
Replace hex text input with native color picker

### DIFF
--- a/apps/web/src/routes/_authenticated/settings/-index.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-index.test.tsx
@@ -947,6 +947,65 @@ describe("ColorCard", () => {
     const input = screen.getByPlaceholderText("#3366cc");
     expect((input as HTMLInputElement).value).toBe("#aabbcc");
   });
+
+  it("renders a color picker when colorMode is accent", async () => {
+    mockColorMode = "accent";
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    const colorInput = document.querySelector("input[type='color']");
+    expect(colorInput).toBeTruthy();
+  });
+
+  it("does not render a color picker when colorMode is not accent", async () => {
+    mockColorMode = "book";
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    const colorInput = document.querySelector("input[type='color']");
+    expect(colorInput).toBeNull();
+  });
+
+  it("color picker has the current accent color as value", async () => {
+    mockColorMode = "accent";
+    mockAccentColor = "#ff5500";
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    const colorInput = document.querySelector("input[type='color']") as HTMLInputElement;
+    expect(colorInput.value).toBe("#ff5500");
+  });
+
+  it("color picker uses default color when accentColor is null", async () => {
+    mockColorMode = "accent";
+    mockAccentColor = null;
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    const colorInput = document.querySelector("input[type='color']") as HTMLInputElement;
+    expect(colorInput.value).toBe("#3366cc");
+  });
+
+  it("calls setAccentColor when color picker value changes", async () => {
+    mockColorMode = "accent";
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    const colorInput = document.querySelector("input[type='color']") as HTMLInputElement;
+    fireEvent.input(colorInput, { target: { value: "#00ff00" } });
+    expect(mockSetAccentColor).toHaveBeenCalledWith("#00ff00");
+  });
+
+  it("hex input syncs when color picker changes", async () => {
+    mockColorMode = "accent";
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    const colorInput = document.querySelector("input[type='color']") as HTMLInputElement;
+    fireEvent.input(colorInput, { target: { value: "#abcdef" } });
+    const hexInput = screen.getByPlaceholderText("#3366cc");
+    expect((hexInput as HTMLInputElement).value).toBe("#abcdef");
+  });
 });
 
 describe("JobsTab", () => {

--- a/apps/web/src/routes/_authenticated/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/settings/index.tsx
@@ -291,9 +291,15 @@ function ColorCard() {
         </div>
         {colorMode === "accent" && (
           <div className="flex items-center gap-3 pl-6">
-            <div
-              className="size-8 rounded-md border"
-              style={{ backgroundColor: hexInput }}
+            <input
+              type="color"
+              value={hexInput}
+              onInput={(e) => {
+                const value = (e.target as HTMLInputElement).value;
+                setHexInput(value);
+                setAccentColor(value);
+              }}
+              className="size-8 cursor-pointer rounded-md border-0 p-0"
             />
             <Input
               type="text"


### PR DESCRIPTION
## Summary
- Replaced the static color preview swatch with a native `<input type="color">` picker in the Custom accent color settings
- Hex text input remains as a secondary option for users who prefer typing exact values
- Both inputs share state and stay in sync

Closes #121

## Test plan
- 6 new tests added covering color picker rendering, value binding, change handling, and hex input sync
- All 98 settings tests pass, 100% coverage maintained
- Lint and typecheck clean