### PR TITLE
Convert Series page to DataTable with authors and book list popover

### DIFF
--- a/apps/web/src/components/ui/popover.tsx
+++ b/apps/web/src/components/ui/popover.tsx
@@ -1,0 +1,42 @@
+"use client"
+
+import * as React from "react"
+import { Popover as PopoverPrimitive } from "radix-ui"
+
+import { cn } from "~/lib/utils"
+
+function Popover({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Root>) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />
+}
+
+function PopoverTrigger({
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Trigger>) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />
+}
+
+function PopoverContent({
+  className,
+  align = "center",
+  sideOffset = 4,
+  ...props
+}: React.ComponentProps<typeof PopoverPrimitive.Content>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Content
+        data-slot="popover-content"
+        align={align}
+        sideOffset={sideOffset}
+        className={cn(
+          "z-50 w-72 rounded-md border bg-popover p-4 text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2",
+          className,
+        )}
+        {...props}
+      />
+    </PopoverPrimitive.Portal>
+  )
+}
+
+export { Popover, PopoverTrigger, PopoverContent }

--- a/apps/web/src/lib/server-fns/series.test.ts
+++ b/apps/web/src/lib/server-fns/series.test.ts
@@ -41,7 +41,26 @@ describe("getSeriesListServerFn", () => {
     expect(findManyMock).toHaveBeenCalledWith({
       include: {
         _count: { select: { works: true } },
-        works: { take: 1, select: { coverPath: true } },
+        works: {
+          orderBy: { seriesPosition: "asc" },
+          select: {
+            id: true,
+            titleDisplay: true,
+            seriesPosition: true,
+            editions: {
+              select: {
+                contributors: {
+                  select: {
+                    role: true,
+                    contributor: {
+                      select: { nameDisplay: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
       },
       orderBy: { name: "asc" },
     });

--- a/apps/web/src/lib/server-fns/series.ts
+++ b/apps/web/src/lib/server-fns/series.ts
@@ -8,7 +8,26 @@ export const getSeriesListServerFn = createServerFn({
   return db.series.findMany({
     include: {
       _count: { select: { works: true } },
-      works: { take: 1, select: { coverPath: true } },
+      works: {
+          orderBy: { seriesPosition: "asc" },
+          select: {
+            id: true,
+            titleDisplay: true,
+            seriesPosition: true,
+            editions: {
+              select: {
+                contributors: {
+                  select: {
+                    role: true,
+                    contributor: {
+                      select: { nameDisplay: true },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
     },
     orderBy: { name: "asc" },
   });

--- a/apps/web/src/routes/_authenticated/-series.index.test.tsx
+++ b/apps/web/src/routes/_authenticated/-series.index.test.tsx
@@ -1,16 +1,30 @@
 // @vitest-environment happy-dom
+import type * as DataTableModule from "~/components/data-table";
 import type * as TanstackRouter from "@tanstack/react-router";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-let mockLoaderData: {
-  seriesList: {
-    id: string;
-    name: string;
-    _count: { works: number };
-    works: { coverPath: string | null }[];
+type SeriesWork = {
+  id: string;
+  titleDisplay: string;
+  seriesPosition: number | null;
+  editions: {
+    contributors: {
+      role: string;
+      contributor: { nameDisplay: string };
+    }[];
   }[];
-} = { seriesList: [] };
+};
+
+type SeriesListItem = {
+  id: string;
+  name: string;
+  _count: { works: number };
+  works: SeriesWork[];
+};
+
+let mockLoaderData: { seriesList: SeriesListItem[] } = { seriesList: [] };
 
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual<typeof TanstackRouter>("@tanstack/react-router");
@@ -34,8 +48,14 @@ vi.mock("@tanstack/react-router", async () => {
   };
 });
 
-vi.mock("~/components/skeletons/grid-page-skeleton", () => ({
-  GridPageSkeleton: () => <div>Loading grid...</div>,
+// Use real DataTable so column cell renderers execute
+vi.mock("~/components/data-table", async () => {
+  const actual = await vi.importActual<typeof DataTableModule>("~/components/data-table");
+  return actual;
+});
+
+vi.mock("~/components/skeletons/table-page-skeleton", () => ({
+  TablePageSkeleton: () => <div>Loading...</div>,
 }));
 
 const getSeriesListServerFnMock = vi.fn();
@@ -43,11 +63,33 @@ vi.mock("~/lib/server-fns/series", () => ({
   getSeriesListServerFn: getSeriesListServerFnMock,
 }));
 
-const makeSeries = (name: string, workCount: number, coverPath: string | null = null) => ({
+const makeWork = (
+  id: string,
+  title: string,
+  position: number | null,
+  authorNames: string[],
+): SeriesWork => ({
+  id,
+  titleDisplay: title,
+  seriesPosition: position,
+  editions: [
+    {
+      contributors: authorNames.map((name) => ({
+        role: "AUTHOR",
+        contributor: { nameDisplay: name },
+      })),
+    },
+  ],
+});
+
+const makeSeries = (
+  name: string,
+  works: SeriesWork[],
+): SeriesListItem => ({
   id: `series-${name.toLowerCase().replace(/\s/g, "-")}`,
   name,
-  _count: { works: workCount },
-  works: coverPath ? [{ coverPath }] : [],
+  _count: { works: works.length },
+  works,
 });
 
 describe("SeriesListPage", () => {
@@ -71,9 +113,12 @@ describe("SeriesListPage", () => {
     expect(screen.getByText("Series")).toBeTruthy();
   });
 
-  it("renders series names", async () => {
+  it("renders series names in table", async () => {
     mockLoaderData = {
-      seriesList: [makeSeries("Discworld", 41), makeSeries("Foundation", 7)],
+      seriesList: [
+        makeSeries("Discworld", [makeWork("w1", "The Colour of Magic", 1, ["Terry Pratchett"])]),
+        makeSeries("Foundation", [makeWork("w2", "Foundation", 1, ["Isaac Asimov"])]),
+      ],
     };
     const { Route } = await import("./series.index");
     const Page = Route.options.component as React.ComponentType;
@@ -82,29 +127,11 @@ describe("SeriesListPage", () => {
     expect(screen.getByText("Foundation")).toBeTruthy();
   });
 
-  it("renders work count for each series", async () => {
+  it("series names link to /series/$seriesId", async () => {
     mockLoaderData = {
-      seriesList: [makeSeries("Discworld", 41)],
-    };
-    const { Route } = await import("./series.index");
-    const Page = Route.options.component as React.ComponentType;
-    render(<Page />);
-    expect(screen.getByText(/41 books/)).toBeTruthy();
-  });
-
-  it("renders singular 'book' for series with one work", async () => {
-    mockLoaderData = {
-      seriesList: [makeSeries("Standalone", 1)],
-    };
-    const { Route } = await import("./series.index");
-    const Page = Route.options.component as React.ComponentType;
-    render(<Page />);
-    expect(screen.getByText(/1 book$/)).toBeTruthy();
-  });
-
-  it("links each series card to /series/$seriesId", async () => {
-    mockLoaderData = {
-      seriesList: [makeSeries("Discworld", 41)],
+      seriesList: [
+        makeSeries("Discworld", [makeWork("w1", "The Colour of Magic", 1, ["Terry Pratchett"])]),
+      ],
     };
     const { Route } = await import("./series.index");
     const Page = Route.options.component as React.ComponentType;
@@ -113,45 +140,129 @@ describe("SeriesListPage", () => {
     expect(link?.getAttribute("href")).toBe("/series/series-discworld");
   });
 
-  it("renders cover thumbnail when first work has coverPath", async () => {
+  it("renders deduplicated authors for each series", async () => {
     mockLoaderData = {
-      seriesList: [makeSeries("Discworld", 41, "/covers/disc.jpg")],
+      seriesList: [
+        makeSeries("Discworld", [
+          makeWork("w1", "The Colour of Magic", 1, ["Terry Pratchett"]),
+          makeWork("w2", "The Light Fantastic", 2, ["Terry Pratchett"]),
+        ]),
+      ],
     };
     const { Route } = await import("./series.index");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
-    const img = screen.getByAltText("Discworld");
-    expect(img).toBeTruthy();
+    // "Terry Pratchett" deduped — appears exactly once
+    const matches = screen.getAllByText("Terry Pratchett");
+    expect(matches).toHaveLength(1);
   });
 
-  it("renders placeholder when no cover", async () => {
+  it("renders multiple authors joined by comma", async () => {
     mockLoaderData = {
-      seriesList: [makeSeries("Discworld", 41)],
+      seriesList: [
+        makeSeries("Good Omens", [
+          makeWork("w1", "Good Omens", 1, ["Terry Pratchett", "Neil Gaiman"]),
+        ]),
+      ],
     };
     const { Route } = await import("./series.index");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
-    expect(screen.getByTestId("series-cover-placeholder-series-discworld")).toBeTruthy();
+    expect(screen.getByText("Terry Pratchett, Neil Gaiman")).toBeTruthy();
   });
 
-  it("shows empty state when no series", async () => {
-    mockLoaderData = { seriesList: [] };
-    const { Route } = await import("./series.index");
-    const Page = Route.options.component as React.ComponentType;
-    render(<Page />);
-    expect(screen.getByText("No series found")).toBeTruthy();
-  });
-
-  it("search filters series by name", async () => {
+  it("renders — when series has no authors", async () => {
     mockLoaderData = {
-      seriesList: [makeSeries("Discworld", 41), makeSeries("Foundation", 7)],
+      seriesList: [
+        makeSeries("Unknown", [
+          makeWork("w1", "Mystery Book", 1, []),
+        ]),
+      ],
     };
     const { Route } = await import("./series.index");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
-    const input = screen.getByPlaceholderText("Search series...");
-    fireEvent.change(input, { target: { value: "disc" } });
-    expect(screen.getByText("Discworld")).toBeTruthy();
-    expect(screen.queryByText("Foundation")).toBeNull();
+    expect(screen.getByText("—")).toBeTruthy();
+  });
+
+  it("renders book count as a button", async () => {
+    mockLoaderData = {
+      seriesList: [
+        makeSeries("Discworld", [
+          makeWork("w1", "The Colour of Magic", 1, ["Terry Pratchett"]),
+          makeWork("w2", "The Light Fantastic", 2, ["Terry Pratchett"]),
+        ]),
+      ],
+    };
+    const { Route } = await import("./series.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByRole("button", { name: "2" })).toBeTruthy();
+  });
+
+  it("clicking book count shows book list with links to /library/$workId", async () => {
+    const user = userEvent.setup();
+    mockLoaderData = {
+      seriesList: [
+        makeSeries("Discworld", [
+          makeWork("w1", "The Colour of Magic", 1, ["Terry Pratchett"]),
+          makeWork("w2", "The Light Fantastic", 2, ["Terry Pratchett"]),
+        ]),
+      ],
+    };
+    const { Route } = await import("./series.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    await user.click(screen.getByRole("button", { name: "2" }));
+    expect(screen.getByText("1. The Colour of Magic")).toBeTruthy();
+    expect(screen.getByText("2. The Light Fantastic")).toBeTruthy();
+    const link = screen.getByText("1. The Colour of Magic").closest("a");
+    expect(link?.getAttribute("href")).toBe("/library/w1");
+  });
+
+  it("book list shows series position prefix when available", async () => {
+    const user = userEvent.setup();
+    mockLoaderData = {
+      seriesList: [
+        makeSeries("Discworld", [
+          makeWork("w1", "The Colour of Magic", 1, ["Terry Pratchett"]),
+        ]),
+      ],
+    };
+    const { Route } = await import("./series.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    await user.click(screen.getByRole("button", { name: "1" }));
+    expect(screen.getByText("1. The Colour of Magic")).toBeTruthy();
+  });
+
+  it("book list omits position prefix when seriesPosition is null", async () => {
+    const user = userEvent.setup();
+    mockLoaderData = {
+      seriesList: [
+        makeSeries("Discworld", [
+          makeWork("w1", "The Colour of Magic", null, ["Terry Pratchett"]),
+        ]),
+      ],
+    };
+    const { Route } = await import("./series.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    await user.click(screen.getByRole("button", { name: "1" }));
+    expect(screen.getByText("The Colour of Magic")).toBeTruthy();
+  });
+
+  it("renders filter input", async () => {
+    const { Route } = await import("./series.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByPlaceholderText("Filter series...")).toBeTruthy();
+  });
+
+  it("shows 'No results.' when empty", async () => {
+    const { Route } = await import("./series.index");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByText("No results.")).toBeTruthy();
   });
 });

--- a/apps/web/src/routes/_authenticated/series.index.tsx
+++ b/apps/web/src/routes/_authenticated/series.index.tsx
@@ -1,9 +1,12 @@
-import { useState, useMemo } from "react";
 import { createFileRoute, Link } from "@tanstack/react-router";
-import { BookOpen } from "lucide-react";
-import { Badge } from "~/components/ui/badge";
-import { Input } from "~/components/ui/input";
-import { GridPageSkeleton } from "~/components/skeletons/grid-page-skeleton";
+import type { ColumnDef } from "@tanstack/react-table";
+import { DataTable, DataTableColumnHeader } from "~/components/data-table";
+import { TablePageSkeleton } from "~/components/skeletons/table-page-skeleton";
+import {
+  Popover,
+  PopoverTrigger,
+  PopoverContent,
+} from "~/components/ui/popover";
 import {
   getSeriesListServerFn,
   type SeriesListItem,
@@ -14,89 +17,98 @@ export const Route = createFileRoute("/_authenticated/series/")({
     const seriesList = await getSeriesListServerFn();
     return { seriesList };
   },
-  pendingComponent: GridPageSkeleton,
+  pendingComponent: TablePageSkeleton,
   component: SeriesListPage,
 });
 
-function SeriesListPage() {
-  const { seriesList } = Route.useLoaderData();
-  const [search, setSearch] = useState("");
-
-  const filtered = useMemo(() => {
-    if (!search) return seriesList;
-    const q = search.toLowerCase();
-    return seriesList.filter((s: SeriesListItem) =>
-      s.name.toLowerCase().includes(q),
-    );
-  }, [seriesList, search]);
-
-  return (
-    <div className="space-y-6">
-      <div>
-        <h1 className="text-2xl font-bold">Series</h1>
-        <p className="mt-2 text-muted-foreground">
-          Browse series in your library.
-        </p>
-      </div>
-
-      <Input
-        placeholder="Search series..."
-        value={search}
-        onChange={(e) => { setSearch(e.target.value); }}
-        className="max-w-sm"
-      />
-
-      {filtered.length === 0 ? (
-        <div className="flex flex-col items-center justify-center py-16 text-center text-muted-foreground">
-          <BookOpen className="size-12" />
-          <p className="mt-4">No series found</p>
-        </div>
-      ) : (
-        <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
-          {filtered.map((series: SeriesListItem) => (
-            <SeriesCard key={series.id} series={series} />
-          ))}
-        </div>
-      )}
-    </div>
-  );
+function getAuthors(series: SeriesListItem): string {
+  const seen = new Set<string>();
+  const names: string[] = [];
+  for (const work of series.works) {
+    for (const edition of work.editions) {
+      for (const c of edition.contributors) {
+        if (c.role === "AUTHOR" && !seen.has(c.contributor.nameDisplay)) {
+          seen.add(c.contributor.nameDisplay);
+          names.push(c.contributor.nameDisplay);
+        }
+      }
+    }
+  }
+  return names.join(", ") || "—";
 }
 
-function SeriesCard({ series }: { series: SeriesListItem }) {
-  const coverWork = series.works[0];
-  const hasCover = Boolean(coverWork?.coverPath);
+const columns: ColumnDef<SeriesListItem>[] = [
+  {
+    accessorKey: "name",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Name" />
+    ),
+    cell: ({ row }) => (
+      <Link
+        to="/series/$seriesId"
+        params={{ seriesId: row.original.id }}
+        className="hover:underline"
+      >
+        {row.original.name}
+      </Link>
+    ),
+  },
+  {
+    id: "authors",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Author(s)" />
+    ),
+    accessorFn: (row) => getAuthors(row),
+  },
+  {
+    id: "books",
+    header: () => <span className="text-sm font-medium">Books</span>,
+    cell: ({ row }) => {
+      const works = row.original.works;
+      const count = row.original._count.works;
+      return (
+        <Popover>
+          <PopoverTrigger asChild>
+            <button className="hover:underline">{count}</button>
+          </PopoverTrigger>
+          <PopoverContent className="w-80" align="start">
+            <ul className="space-y-1.5">
+              {works.map((work) => (
+                <li key={work.id}>
+                  <Link
+                    to="/library/$workId"
+                    params={{ workId: work.id }}
+                    className="text-sm hover:underline"
+                  >
+                    {work.seriesPosition != null
+                      ? `${String(work.seriesPosition)}. ${work.titleDisplay}`
+                      : work.titleDisplay}
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </PopoverContent>
+        </Popover>
+      );
+    },
+  },
+];
+
+function SeriesListPage() {
+  const { seriesList } = Route.useLoaderData();
 
   return (
-    <Link
-      to="/series/$seriesId"
-      params={{ seriesId: series.id }}
-      className="flex flex-col overflow-hidden rounded-lg border bg-card"
-    >
-      <div className="aspect-[2/3] bg-muted">
-        {hasCover ? (
-          <img
-            src={`/api/covers/${series.id}/thumb`}
-            alt={series.name}
-            loading="lazy"
-            className="size-full object-cover"
-          />
-        ) : (
-          <div
-            data-testid={`series-cover-placeholder-${series.id}`}
-            className="flex size-full items-center justify-center text-muted-foreground"
-          >
-            <BookOpen className="size-12" />
-          </div>
-        )}
-      </div>
-      <div className="space-y-1 p-3">
-        <h3 className="line-clamp-2 text-sm font-medium leading-tight">
-          {series.name}
-        </h3>
-        <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
-          {series._count.works} {series._count.works === 1 ? "book" : "books"}
-        </Badge>
-      </div>
-    </Link>
+    <div>
+      <h1 className="text-2xl font-bold">Series</h1>
+      <p className="mb-6 mt-2 text-muted-foreground">
+        Browse series in your library.
+      </p>
+      <DataTable
+        columns={columns}
+        data={seriesList}
+        filterColumn="name"
+        filterPlaceholder="Filter series..."
+      />
+    </div>
   );
 }


### PR DESCRIPTION
## Summary

- Replaces the card grid with a `DataTable` (Name, Author(s), Books columns)
- Author(s) column deduplicates contributors across all works in the series
- Books column shows the count as a clickable button that opens a popover listing all books in series order with links to `/library/$workId`
- Adds a reusable `Popover` UI component following the existing shadcn/ui pattern
- Updates `getSeriesListServerFn` to fetch works with titles, positions, and contributor data (replaces the old cover-only query)

Closes #135