### PR TITLE
Fix filter preset counts to reflect active filters

### DIFF
--- a/apps/web/src/components/library-filters.test.tsx
+++ b/apps/web/src/components/library-filters.test.tsx
@@ -19,6 +19,7 @@ const defaultFacetCounts: FacetCounts = {
 
 const defaultProps = {
   facetCounts: defaultFacetCounts,
+  totalFacetCounts: defaultFacetCounts,
   filters: {},
   onFiltersChange: vi.fn(),
 };
@@ -273,5 +274,130 @@ describe("LibraryFilters", () => {
   it("does not show clear all for empty arrays", () => {
     render(<LibraryFilters {...defaultProps} filters={{ format: [], authorId: [], seriesId: [], publisher: [] }} />);
     expect(screen.queryByText("Clear All")).toBeNull();
+  });
+
+  it("shows single count when filtered equals total", () => {
+    render(<LibraryFilters {...defaultProps} />);
+    expect(screen.getByText("EBOOK (10)")).toBeTruthy();
+    expect(screen.queryByText(/\//)).toBeNull();
+  });
+
+  it("shows filtered / total when format counts differ", () => {
+    const filteredCounts: FacetCounts = {
+      ...defaultFacetCounts,
+      format: [
+        { formatFamily: "EBOOK", _count: { _all: 4 } },
+        { formatFamily: "AUDIOBOOK", _count: { _all: 2 } },
+      ],
+    };
+    render(
+      <LibraryFilters
+        {...defaultProps}
+        facetCounts={filteredCounts}
+        totalFacetCounts={defaultFacetCounts}
+        filters={{ hasCover: true }}
+      />,
+    );
+    expect(screen.getByText("EBOOK (4 / 10)")).toBeTruthy();
+    expect(screen.getByText("AUDIOBOOK (2 / 5)")).toBeTruthy();
+  });
+
+  it("shows filtered / total for boolean facets when counts differ", () => {
+    const filteredCounts: FacetCounts = {
+      ...defaultFacetCounts,
+      hasCover: { withCover: 4, withoutCover: 1 },
+    };
+    render(
+      <LibraryFilters
+        {...defaultProps}
+        facetCounts={filteredCounts}
+        totalFacetCounts={defaultFacetCounts}
+        filters={{ format: ["EBOOK"] }}
+      />,
+    );
+    expect(screen.getByText("With Cover (4 / 12)")).toBeTruthy();
+    expect(screen.getByText("Without Cover (1 / 3)")).toBeTruthy();
+  });
+
+  it("shows single count for boolean facets when counts match", () => {
+    render(<LibraryFilters {...defaultProps} />);
+    expect(screen.getByText("With Cover (12)")).toBeTruthy();
+    expect(screen.getByText("Without Cover (3)")).toBeTruthy();
+  });
+
+  it("falls back to filtered count when format not found in totalFacetCounts", () => {
+    const filteredCounts: FacetCounts = {
+      ...defaultFacetCounts,
+      format: [
+        { formatFamily: "EBOOK", _count: { _all: 4 } },
+      ],
+    };
+    const totalCounts: FacetCounts = {
+      ...defaultFacetCounts,
+      format: [], // no matching format in totals
+    };
+    render(
+      <LibraryFilters
+        {...defaultProps}
+        facetCounts={filteredCounts}
+        totalFacetCounts={totalCounts}
+        filters={{ hasCover: true }}
+      />,
+    );
+    // Falls back to filtered count since total format not found
+    expect(screen.getByText("EBOOK (4)")).toBeTruthy();
+  });
+
+  it("always reserves space for clear all button", () => {
+    const { container } = render(<LibraryFilters {...defaultProps} filters={{}} />);
+    // Clear All button should exist but be invisible when no filters active
+    const clearAllWrapper = container.querySelector("[data-testid='clear-all-spacer']");
+    expect(clearAllWrapper).toBeTruthy();
+  });
+
+  it("makes clear all button visible when filters active", () => {
+    const { container } = render(<LibraryFilters {...defaultProps} filters={{ format: ["EBOOK"] }} />);
+    const clearAllBtn = container.querySelector("[data-testid='clear-all-spacer']");
+    expect(clearAllBtn).toBeTruthy();
+    expect(screen.getByText("Clear All")).toBeTruthy();
+  });
+
+  it("marks zero-count buttons as disabled-looking via data-empty", () => {
+    const filteredCounts: FacetCounts = {
+      ...defaultFacetCounts,
+      hasCover: { withCover: 0, withoutCover: 5 },
+    };
+    render(
+      <LibraryFilters
+        {...defaultProps}
+        facetCounts={filteredCounts}
+        totalFacetCounts={defaultFacetCounts}
+        filters={{ format: ["EBOOK"] }}
+      />,
+    );
+    const withCoverBtn = screen.getByText("With Cover (0 / 12)").closest("button");
+    expect(withCoverBtn?.getAttribute("data-empty")).toBe("true");
+    const withoutCoverBtn = screen.getByText("Without Cover (5 / 3)").closest("button");
+    expect(withoutCoverBtn?.getAttribute("data-empty")).toBe("false");
+  });
+
+  it("marks zero-count format buttons as disabled-looking via data-empty", () => {
+    const filteredCounts: FacetCounts = {
+      ...defaultFacetCounts,
+      format: [
+        { formatFamily: "EBOOK", _count: { _all: 0 } },
+        { formatFamily: "AUDIOBOOK", _count: { _all: 5 } },
+      ],
+    };
+    render(
+      <LibraryFilters
+        {...defaultProps}
+        facetCounts={filteredCounts}
+        totalFacetCounts={defaultFacetCounts}
+        filters={{ hasCover: true }}
+      />,
+    );
+    const ebookBtn = screen.getByText("EBOOK (0 / 10)").closest("button");
+    expect(ebookBtn?.getAttribute("data-empty")).toBe("true");
   });
 });

--- a/apps/web/src/components/library-filters.tsx
+++ b/apps/web/src/components/library-filters.tsx
@@ -24,8 +24,13 @@ export interface LibraryFilterValues {
 
 interface LibraryFiltersProps {
   facetCounts: FacetCounts;
+  totalFacetCounts: FacetCounts;
   filters: LibraryFilterValues;
   onFiltersChange: (filters: LibraryFilterValues) => void;
+}
+
+function formatCount(filtered: number, total: number): string {
+  return filtered === total ? String(filtered) : `${String(filtered)} / ${String(total)}`;
 }
 
 function hasActiveFilters(filters: LibraryFilterValues): boolean {
@@ -44,6 +49,7 @@ function hasActiveFilters(filters: LibraryFilterValues): boolean {
 
 export function LibraryFilters({
   facetCounts,
+  totalFacetCounts,
   filters,
   onFiltersChange,
 }: LibraryFiltersProps) {
@@ -68,14 +74,18 @@ export function LibraryFilters({
     onFiltersChange({});
   }
 
+  const filtersActive = hasActiveFilters(filters);
+
   return (
     <div className="space-y-4">
-      {hasActiveFilters(filters) && (
-        <Button variant="ghost" size="sm" onClick={clearAll} className="gap-1">
-          <X className="size-3" />
-          Clear All
-        </Button>
-      )}
+      <div data-testid="clear-all-spacer" className="h-8">
+        {filtersActive && (
+          <Button variant="ghost" size="sm" onClick={clearAll} className="gap-1">
+            <X className="size-3" />
+            Clear All
+          </Button>
+        )}
+      </div>
 
       <div className="space-y-2">
         <h3 className="text-sm font-medium">Format</h3>
@@ -86,10 +96,11 @@ export function LibraryFilters({
               variant="outline"
               size="sm"
               data-active={filters.format?.includes(f.formatFamily) ?? false}
+              data-empty={f._count._all === 0}
               onClick={() => { toggleFormat(f.formatFamily); }}
-              className="data-[active=true]:bg-accent"
+              className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
             >
-              {f.formatFamily} ({String(f._count._all)})
+              {f.formatFamily} ({formatCount(f._count._all, totalFacetCounts.format.find((t) => t.formatFamily === f.formatFamily)?._count._all ?? f._count._all)})
             </Button>
           ))}
         </div>
@@ -102,19 +113,21 @@ export function LibraryFilters({
             variant="outline"
             size="sm"
             data-active={filters.hasCover === true}
+            data-empty={facetCounts.hasCover.withCover === 0}
             onClick={() => { toggleBoolean("hasCover", true); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            With Cover ({String(facetCounts.hasCover.withCover)})
+            With Cover ({formatCount(facetCounts.hasCover.withCover, totalFacetCounts.hasCover.withCover)})
           </Button>
           <Button
             variant="outline"
             size="sm"
             data-active={filters.hasCover === false}
+            data-empty={facetCounts.hasCover.withoutCover === 0}
             onClick={() => { toggleBoolean("hasCover", false); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            Without Cover ({String(facetCounts.hasCover.withoutCover)})
+            Without Cover ({formatCount(facetCounts.hasCover.withoutCover, totalFacetCounts.hasCover.withoutCover)})
           </Button>
         </div>
       </div>
@@ -126,19 +139,21 @@ export function LibraryFilters({
             variant="outline"
             size="sm"
             data-active={filters.enriched === true}
+            data-empty={facetCounts.enrichment.enriched === 0}
             onClick={() => { toggleBoolean("enriched", true); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            Enriched ({String(facetCounts.enrichment.enriched)})
+            Enriched ({formatCount(facetCounts.enrichment.enriched, totalFacetCounts.enrichment.enriched)})
           </Button>
           <Button
             variant="outline"
             size="sm"
             data-active={filters.enriched === false}
+            data-empty={facetCounts.enrichment.unenriched === 0}
             onClick={() => { toggleBoolean("enriched", false); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            Unenriched ({String(facetCounts.enrichment.unenriched)})
+            Unenriched ({formatCount(facetCounts.enrichment.unenriched, totalFacetCounts.enrichment.unenriched)})
           </Button>
         </div>
       </div>
@@ -150,19 +165,21 @@ export function LibraryFilters({
             variant="outline"
             size="sm"
             data-active={filters.hasDescription === true}
+            data-empty={facetCounts.description.withDescription === 0}
             onClick={() => { toggleBoolean("hasDescription", true); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            Has Description ({String(facetCounts.description.withDescription)})
+            Has Description ({formatCount(facetCounts.description.withDescription, totalFacetCounts.description.withDescription)})
           </Button>
           <Button
             variant="outline"
             size="sm"
             data-active={filters.hasDescription === false}
+            data-empty={facetCounts.description.withoutDescription === 0}
             onClick={() => { toggleBoolean("hasDescription", false); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            No Description ({String(facetCounts.description.withoutDescription)})
+            No Description ({formatCount(facetCounts.description.withoutDescription, totalFacetCounts.description.withoutDescription)})
           </Button>
         </div>
       </div>
@@ -174,19 +191,21 @@ export function LibraryFilters({
             variant="outline"
             size="sm"
             data-active={filters.inSeries === true}
+            data-empty={facetCounts.series.inSeries === 0}
             onClick={() => { toggleBoolean("inSeries", true); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            In Series ({String(facetCounts.series.inSeries)})
+            In Series ({formatCount(facetCounts.series.inSeries, totalFacetCounts.series.inSeries)})
           </Button>
           <Button
             variant="outline"
             size="sm"
             data-active={filters.inSeries === false}
+            data-empty={facetCounts.series.standalone === 0}
             onClick={() => { toggleBoolean("inSeries", false); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            Standalone ({String(facetCounts.series.standalone)})
+            Standalone ({formatCount(facetCounts.series.standalone, totalFacetCounts.series.standalone)})
           </Button>
         </div>
       </div>
@@ -198,19 +217,21 @@ export function LibraryFilters({
             variant="outline"
             size="sm"
             data-active={filters.hasIsbn === true}
+            data-empty={facetCounts.isbn.withIsbn === 0}
             onClick={() => { toggleBoolean("hasIsbn", true); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            Has ISBN ({String(facetCounts.isbn.withIsbn)})
+            Has ISBN ({formatCount(facetCounts.isbn.withIsbn, totalFacetCounts.isbn.withIsbn)})
           </Button>
           <Button
             variant="outline"
             size="sm"
             data-active={filters.hasIsbn === false}
+            data-empty={facetCounts.isbn.withoutIsbn === 0}
             onClick={() => { toggleBoolean("hasIsbn", false); }}
-            className="data-[active=true]:bg-accent"
+            className="data-[active=true]:bg-primary data-[active=true]:text-primary-foreground data-[active=true]:border-primary dark:data-[active=true]:bg-primary dark:data-[active=true]:text-primary-foreground data-[empty=true]:opacity-50"
           >
-            No ISBN ({String(facetCounts.isbn.withoutIsbn)})
+            No ISBN ({formatCount(facetCounts.isbn.withoutIsbn, totalFacetCounts.isbn.withoutIsbn)})
           </Button>
         </div>
       </div>

--- a/apps/web/src/lib/server-fns/library.test.ts
+++ b/apps/web/src/lib/server-fns/library.test.ts
@@ -92,17 +92,22 @@ describe("getFilteredLibraryWorksServerFn", () => {
       }),
     );
     expect(countMock).toHaveBeenCalled();
+    const expectedFacetCounts = {
+      format: [
+        { formatFamily: "EBOOK", _count: { _all: 0 } },
+        { formatFamily: "AUDIOBOOK", _count: { _all: 0 } },
+      ],
+      hasCover: { withCover: 0, withoutCover: 0 },
+      enrichment: { enriched: 0, unenriched: 0 },
+      description: { withDescription: 0, withoutDescription: 0 },
+      series: { inSeries: 0, standalone: 0 },
+      isbn: { withIsbn: 0, withoutIsbn: 0 },
+    };
     expect(result).toEqual({
       works: [],
       totalCount: 0,
-      facetCounts: {
-        format: [],
-        hasCover: { withCover: 0, withoutCover: 0 },
-        enrichment: { enriched: 0, unenriched: 0 },
-        description: { withDescription: 0, withoutDescription: 0 },
-        series: { inSeries: 0, standalone: 0 },
-        isbn: { withIsbn: 0, withoutIsbn: 0 },
-      },
+      facetCounts: expectedFacetCounts,
+      totalFacetCounts: expectedFacetCounts,
     });
   });
 
@@ -690,6 +695,37 @@ describe("getFilteredLibraryWorksServerFn", () => {
     ]);
   });
 
+  it("fills in missing format families with zero counts", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    // groupBy only returns AUDIOBOOK — EBOOK is missing
+    editionGroupByMock.mockResolvedValue([
+      { formatFamily: "AUDIOBOOK", _count: { _all: 5 } },
+    ]);
+    const result = await getFilteredLibraryWorksServerFn({ data: {} });
+
+    expect(result.facetCounts.format).toEqual([
+      { formatFamily: "EBOOK", _count: { _all: 0 } },
+      { formatFamily: "AUDIOBOOK", _count: { _all: 5 } },
+    ]);
+  });
+
+  it("returns format families in stable EBOOK, AUDIOBOOK order", async () => {
+    findManyMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+    // groupBy returns AUDIOBOOK first
+    editionGroupByMock.mockResolvedValue([
+      { formatFamily: "AUDIOBOOK", _count: { _all: 3 } },
+      { formatFamily: "EBOOK", _count: { _all: 10 } },
+    ]);
+    const result = await getFilteredLibraryWorksServerFn({ data: {} });
+
+    expect(result.facetCounts.format).toEqual([
+      { formatFamily: "EBOOK", _count: { _all: 10 } },
+      { formatFamily: "AUDIOBOOK", _count: { _all: 3 } },
+    ]);
+  });
+
   it("returns facet counts for hasCover", async () => {
     findManyMock.mockResolvedValue([]);
     editionGroupByMock.mockResolvedValue([]);
@@ -728,7 +764,7 @@ describe("getFilteredLibraryWorksServerFn", () => {
     expect(result.facetCounts.hasCover.withoutCover).toBeGreaterThanOrEqual(0);
   });
 
-  it("scopes cover facet counts to active search filter (excludes hasCover)", async () => {
+  it("scopes cover facet counts to full active filter set", async () => {
     findManyMock.mockResolvedValue([]);
     editionGroupByMock.mockResolvedValue([]);
 
@@ -736,77 +772,38 @@ describe("getFilteredLibraryWorksServerFn", () => {
 
     await getFilteredLibraryWorksServerFn({ data: { q: "wind" } });
 
-    // Cover count queries should include the search filter but NOT hasCover
-    // countMock calls: [0] = totalCount, [1] = withCover, [2] = withoutCover
-    const availabilityAnd = [
-      {
-        editions: {
-          some: {
-            editionFiles: {
-              some: {
-                fileAsset: { availabilityStatus: "PRESENT" },
-              },
-            },
-          },
-        },
-      },
-    ];
+    // Cover count queries use AND to combine with full filter set
+    const findManyWhere = (findManyMock.mock.calls[0]?.[0] as { where: object }).where;
     expect(countMock).toHaveBeenNthCalledWith(2, {
-      where: {
-        OR: [
-          { titleDisplay: { contains: "wind", mode: "insensitive" } },
-          { titleCanonical: { contains: "wind", mode: "insensitive" } },
-        ],
-        AND: availabilityAnd,
-        coverPath: { not: null },
-      },
+      where: { AND: [findManyWhere, { coverPath: { not: null } }] },
     });
     expect(countMock).toHaveBeenNthCalledWith(3, {
-      where: {
-        OR: [
-          { titleDisplay: { contains: "wind", mode: "insensitive" } },
-          { titleCanonical: { contains: "wind", mode: "insensitive" } },
-        ],
-        AND: availabilityAnd,
-        coverPath: null,
-      },
+      where: { AND: [findManyWhere, { coverPath: null }] },
     });
   });
 
-  it("scopes format facet counts to active search filter (excludes format)", async () => {
+  it("format facet counts include active format filter", async () => {
     findManyMock.mockResolvedValue([]);
     countMock.mockResolvedValue(0);
     editionGroupByMock.mockResolvedValue([]);
-    await getFilteredLibraryWorksServerFn({ data: { q: "wind" } });
+    await getFilteredLibraryWorksServerFn({ data: { format: ["EBOOK"] } });
 
-    expect(editionGroupByMock).toHaveBeenCalledWith({
+    // Format facet groupBy should include the format filter in the work where clause
+    const findManyWhere = (findManyMock.mock.calls[0]?.[0] as { where: object }).where;
+    expect(editionGroupByMock).toHaveBeenNthCalledWith(1, {
       by: ["formatFamily"],
       _count: { _all: true },
-      where: {
-        work: {
-          OR: [
-            { titleDisplay: { contains: "wind", mode: "insensitive" } },
-            { titleCanonical: { contains: "wind", mode: "insensitive" } },
-          ],
-          AND: [
-            {
-              editions: {
-                some: {
-                  editionFiles: {
-                    some: {
-                      fileAsset: { availabilityStatus: "PRESENT" },
-                    },
-                  },
-                },
-              },
-            },
-          ],
-        },
-      },
+      where: { work: findManyWhere },
     });
+    // Verify that the where clause actually contains the format filter
+    expect(findManyWhere).toEqual(
+      expect.objectContaining({
+        editions: { some: { formatFamily: { in: ["EBOOK"] } } },
+      }),
+    );
   });
 
-  it("cover facet counts exclude hasCover filter but include format filter", async () => {
+  it("cover facet counts include both hasCover and format filters", async () => {
     findManyMock.mockResolvedValue([]);
     editionGroupByMock.mockResolvedValue([]);
 
@@ -816,33 +813,13 @@ describe("getFilteredLibraryWorksServerFn", () => {
       data: { format: ["EBOOK"], hasCover: false },
     });
 
-    // Cover count queries should include format but NOT hasCover
-    const availabilityAnd = [
-      {
-        editions: {
-          some: {
-            editionFiles: {
-              some: {
-                fileAsset: { availabilityStatus: "PRESENT" },
-              },
-            },
-          },
-        },
-      },
-    ];
+    // Cover count queries use AND to properly intersect with active filters
+    const findManyWhere = (findManyMock.mock.calls[0]?.[0] as { where: object }).where;
     expect(countMock).toHaveBeenNthCalledWith(2, {
-      where: {
-        editions: { some: { formatFamily: { in: ["EBOOK"] } } },
-        AND: availabilityAnd,
-        coverPath: { not: null },
-      },
+      where: { AND: [findManyWhere, { coverPath: { not: null } }] },
     });
     expect(countMock).toHaveBeenNthCalledWith(3, {
-      where: {
-        editions: { some: { formatFamily: { in: ["EBOOK"] } } },
-        AND: availabilityAnd,
-        coverPath: null,
-      },
+      where: { AND: [findManyWhere, { coverPath: null }] },
     });
   });
 
@@ -1086,5 +1063,96 @@ describe("getFilteredLibraryWorksServerFn", () => {
         },
       }),
     );
+  });
+
+  it("returns totalFacetCounts using base where (no user filters)", async () => {
+    findManyMock.mockResolvedValue([]);
+    editionGroupByMock
+      .mockResolvedValueOnce([]) // filtered format counts
+      .mockResolvedValueOnce([   // unfiltered format counts
+        { formatFamily: "EBOOK", _count: { _all: 10 } },
+        { formatFamily: "AUDIOBOOK", _count: { _all: 5 } },
+      ]);
+
+    // 22 count calls: 11 filtered + 11 unfiltered
+    countMock
+      .mockResolvedValueOnce(3)   // totalCount (filtered)
+      .mockResolvedValueOnce(2)   // withCover (filtered)
+      .mockResolvedValueOnce(1)   // withoutCover (filtered)
+      .mockResolvedValueOnce(1)   // enriched (filtered)
+      .mockResolvedValueOnce(2)   // unenriched (filtered)
+      .mockResolvedValueOnce(1)   // withDescription (filtered)
+      .mockResolvedValueOnce(2)   // withoutDescription (filtered)
+      .mockResolvedValueOnce(1)   // inSeries (filtered)
+      .mockResolvedValueOnce(2)   // standalone (filtered)
+      .mockResolvedValueOnce(2)   // withIsbn (filtered)
+      .mockResolvedValueOnce(1)   // withoutIsbn (filtered)
+      .mockResolvedValueOnce(12)  // withCover (unfiltered)
+      .mockResolvedValueOnce(3)   // withoutCover (unfiltered)
+      .mockResolvedValueOnce(8)   // enriched (unfiltered)
+      .mockResolvedValueOnce(7)   // unenriched (unfiltered)
+      .mockResolvedValueOnce(6)   // withDescription (unfiltered)
+      .mockResolvedValueOnce(9)   // withoutDescription (unfiltered)
+      .mockResolvedValueOnce(4)   // inSeries (unfiltered)
+      .mockResolvedValueOnce(11)  // standalone (unfiltered)
+      .mockResolvedValueOnce(10)  // withIsbn (unfiltered)
+      .mockResolvedValueOnce(5);  // withoutIsbn (unfiltered)
+
+    const result = await getFilteredLibraryWorksServerFn({
+      data: { format: ["EBOOK"] },
+    });
+
+    expect(result.totalFacetCounts).toEqual({
+      format: [
+        { formatFamily: "EBOOK", _count: { _all: 10 } },
+        { formatFamily: "AUDIOBOOK", _count: { _all: 5 } },
+      ],
+      hasCover: { withCover: 12, withoutCover: 3 },
+      enrichment: { enriched: 8, unenriched: 7 },
+      description: { withDescription: 6, withoutDescription: 9 },
+      series: { inSeries: 4, standalone: 11 },
+      isbn: { withIsbn: 10, withoutIsbn: 5 },
+    });
+  });
+
+  it("totalFacetCounts queries use only base availability where", async () => {
+    findManyMock.mockResolvedValue([]);
+    editionGroupByMock.mockResolvedValue([]);
+    countMock.mockResolvedValue(0);
+
+    await getFilteredLibraryWorksServerFn({
+      data: { format: ["EBOOK"], hasCover: true, enriched: false },
+    });
+
+    const baseWhere = {
+      AND: [
+        {
+          editions: {
+            some: {
+              editionFiles: {
+                some: {
+                  fileAsset: { availabilityStatus: "PRESENT" },
+                },
+              },
+            },
+          },
+        },
+      ],
+    };
+
+    // Second editionGroupByMock call is for totalFacetCounts
+    expect(editionGroupByMock).toHaveBeenNthCalledWith(2, {
+      by: ["formatFamily"],
+      _count: { _all: true },
+      where: { work: baseWhere },
+    });
+
+    // Unfiltered cover counts (calls 12 and 13 of countMock)
+    expect(countMock).toHaveBeenNthCalledWith(12, {
+      where: { AND: [baseWhere, { coverPath: { not: null } }] },
+    });
+    expect(countMock).toHaveBeenNthCalledWith(13, {
+      where: { AND: [baseWhere, { coverPath: null }] },
+    });
   });
 });

--- a/apps/web/src/lib/server-fns/library.ts
+++ b/apps/web/src/lib/server-fns/library.ts
@@ -2,6 +2,20 @@ import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import type { Prisma } from "@bookhouse/db";
 
+const FORMAT_FAMILIES = ["EBOOK", "AUDIOBOOK"] as const;
+
+type FormatCount = { formatFamily: string; _count: { _all: number } };
+
+function normalizeFormatCounts(
+  raw: FormatCount[],
+): FormatCount[] {
+  const map = new Map(raw.map((r) => [r.formatFamily, r._count._all]));
+  return FORMAT_FAMILIES.map((ff) => ({
+    formatFamily: ff,
+    _count: { _all: map.get(ff) ?? 0 },
+  }));
+}
+
 const WORK_INCLUDE = {
   series: true,
   editions: {
@@ -84,6 +98,14 @@ function buildWhere(data: z.infer<typeof filterSchema>): Prisma.WorkWhereInput {
     editionConditions.push({ publisher: { in: data.publisher } });
   }
 
+  if (data.hasIsbn === true) {
+    editionConditions.push({
+      OR: [{ isbn13: { not: null } }, { isbn10: { not: null } }],
+    });
+  } else if (data.hasIsbn === false) {
+    editionConditions.push({ isbn13: null, isbn10: null });
+  }
+
   if (editionConditions.length === 1) {
     where.editions = { some: editionConditions[0] };
   } else if (editionConditions.length > 1) {
@@ -116,14 +138,6 @@ function buildWhere(data: z.infer<typeof filterSchema>): Prisma.WorkWhereInput {
     where.seriesId = { not: null };
   } else if (data.inSeries === false) {
     where.seriesId = null;
-  }
-
-  if (data.hasIsbn === true) {
-    editionConditions.push({
-      OR: [{ isbn13: { not: null } }, { isbn10: { not: null } }],
-    });
-  } else if (data.hasIsbn === false) {
-    editionConditions.push({ isbn13: null, isbn10: null });
   }
 
   where.AND = [
@@ -288,13 +302,8 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
           include: WORK_INCLUDE,
         });
 
-    // Facet counts exclude their own filter to show meaningful counts
-    const whereForCoverFacets = buildWhere({ ...parsed, hasCover: undefined });
-    const whereForFormatFacets = buildWhere({ ...parsed, format: undefined });
-    const whereForEnrichmentFacets = buildWhere({ ...parsed, enriched: undefined });
-    const whereForDescriptionFacets = buildWhere({ ...parsed, hasDescription: undefined });
-    const whereForSeriesFacets = buildWhere({ ...parsed, inSeries: undefined, seriesId: undefined });
-    const whereForIsbnFacets = buildWhere({ ...parsed, hasIsbn: undefined });
+    // Facet counts use full filter set so counts always match the filtered view
+    const baseWhere = buildWhere(filterSchema.parse({}));
 
     const [
       works, totalCount, formatCounts,
@@ -303,33 +312,54 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
       withDescriptionCount, withoutDescriptionCount,
       inSeriesCount, standaloneCount,
       withIsbnCount, withoutIsbnCount,
+      totalFormatCounts,
+      totalWithCoverCount, totalWithoutCoverCount,
+      totalEnrichedCount, totalUnenrichedCount,
+      totalWithDescriptionCount, totalWithoutDescriptionCount,
+      totalInSeriesCount, totalStandaloneCount,
+      totalWithIsbnCount, totalWithoutIsbnCount,
     ] = await Promise.all([
       worksPromise,
       db.work.count({ where }),
       db.edition.groupBy({
         by: ["formatFamily"],
         _count: { _all: true },
-        where: { work: whereForFormatFacets },
+        where: { work: where },
       }),
-      db.work.count({ where: { ...whereForCoverFacets, coverPath: { not: null } } }),
-      db.work.count({ where: { ...whereForCoverFacets, coverPath: null } }),
-      db.work.count({ where: { ...whereForEnrichmentFacets, enrichmentStatus: "ENRICHED" } }),
-      db.work.count({ where: { ...whereForEnrichmentFacets, enrichmentStatus: "STUB" } }),
-      db.work.count({ where: { ...whereForDescriptionFacets, description: { not: null } } }),
-      db.work.count({ where: { ...whereForDescriptionFacets, description: null } }),
-      db.work.count({ where: { ...whereForSeriesFacets, seriesId: { not: null } } }),
-      db.work.count({ where: { ...whereForSeriesFacets, seriesId: null } }),
+      // Use AND to combine so facet conditions don't override active filter conditions
+      db.work.count({ where: { AND: [where, { coverPath: { not: null } }] } }),
+      db.work.count({ where: { AND: [where, { coverPath: null }] } }),
+      db.work.count({ where: { AND: [where, { enrichmentStatus: "ENRICHED" }] } }),
+      db.work.count({ where: { AND: [where, { enrichmentStatus: "STUB" }] } }),
+      db.work.count({ where: { AND: [where, { description: { not: null } }] } }),
+      db.work.count({ where: { AND: [where, { description: null }] } }),
+      db.work.count({ where: { AND: [where, { seriesId: { not: null } }] } }),
+      db.work.count({ where: { AND: [where, { seriesId: null }] } }),
       db.work.count({
-        where: {
-          ...whereForIsbnFacets,
-          editions: { some: { OR: [{ isbn13: { not: null } }, { isbn10: { not: null } }] } },
-        },
+        where: { AND: [where, { editions: { some: { OR: [{ isbn13: { not: null } }, { isbn10: { not: null } }] } } }] },
       }),
       db.work.count({
-        where: {
-          ...whereForIsbnFacets,
-          editions: { every: { isbn13: null, isbn10: null } },
-        },
+        where: { AND: [where, { editions: { every: { isbn13: null, isbn10: null } } }] },
+      }),
+      // Unfiltered totals for showing "filtered / total" in the UI
+      db.edition.groupBy({
+        by: ["formatFamily"],
+        _count: { _all: true },
+        where: { work: baseWhere },
+      }),
+      db.work.count({ where: { AND: [baseWhere, { coverPath: { not: null } }] } }),
+      db.work.count({ where: { AND: [baseWhere, { coverPath: null }] } }),
+      db.work.count({ where: { AND: [baseWhere, { enrichmentStatus: "ENRICHED" }] } }),
+      db.work.count({ where: { AND: [baseWhere, { enrichmentStatus: "STUB" }] } }),
+      db.work.count({ where: { AND: [baseWhere, { description: { not: null } }] } }),
+      db.work.count({ where: { AND: [baseWhere, { description: null }] } }),
+      db.work.count({ where: { AND: [baseWhere, { seriesId: { not: null } }] } }),
+      db.work.count({ where: { AND: [baseWhere, { seriesId: null }] } }),
+      db.work.count({
+        where: { AND: [baseWhere, { editions: { some: { OR: [{ isbn13: { not: null } }, { isbn10: { not: null } }] } } }] },
+      }),
+      db.work.count({
+        where: { AND: [baseWhere, { editions: { every: { isbn13: null, isbn10: null } } }] },
       }),
     ]);
 
@@ -337,7 +367,7 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
       works,
       totalCount,
       facetCounts: {
-        format: formatCounts,
+        format: normalizeFormatCounts(formatCounts),
         hasCover: {
           withCover: withCoverCount,
           withoutCover: withoutCoverCount,
@@ -357,6 +387,29 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
         isbn: {
           withIsbn: withIsbnCount,
           withoutIsbn: withoutIsbnCount,
+        },
+      },
+      totalFacetCounts: {
+        format: normalizeFormatCounts(totalFormatCounts),
+        hasCover: {
+          withCover: totalWithCoverCount,
+          withoutCover: totalWithoutCoverCount,
+        },
+        enrichment: {
+          enriched: totalEnrichedCount,
+          unenriched: totalUnenrichedCount,
+        },
+        description: {
+          withDescription: totalWithDescriptionCount,
+          withoutDescription: totalWithoutDescriptionCount,
+        },
+        series: {
+          inSeries: totalInSeriesCount,
+          standalone: totalStandaloneCount,
+        },
+        isbn: {
+          withIsbn: totalWithIsbnCount,
+          withoutIsbn: totalWithoutIsbnCount,
         },
       },
     };

--- a/apps/web/src/routes/_authenticated/-library.index.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.index.test.tsx
@@ -48,6 +48,7 @@ let mockLoaderData: {
     }[];
     totalCount: number;
     facetCounts: typeof defaultFacetCounts;
+    totalFacetCounts: typeof defaultFacetCounts;
   };
   activeJobCount: number;
   progressMap: Record<string, number>;
@@ -56,6 +57,7 @@ let mockLoaderData: {
     works: [],
     totalCount: 0,
     facetCounts: defaultFacetCounts,
+    totalFacetCounts: defaultFacetCounts,
   },
   activeJobCount: 0,
   progressMap: {},
@@ -291,6 +293,7 @@ describe("LibraryPage", () => {
         works: [],
         totalCount: 0,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -306,7 +309,7 @@ describe("LibraryPage", () => {
   });
 
   it("loader calls getFilteredLibraryWorksServerFn, getActiveJobCountServerFn, and getBulkReadingProgressServerFn", async () => {
-    getFilteredLibraryWorksServerFnMock.mockResolvedValueOnce({ works: [], totalCount: 0, facetCounts: defaultFacetCounts });
+    getFilteredLibraryWorksServerFnMock.mockResolvedValueOnce({ works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts });
     getActiveJobCountServerFnMock.mockResolvedValueOnce(0);
     getBulkReadingProgressServerFnMock.mockResolvedValueOnce({});
     const { Route } = await import("./library.index");
@@ -316,7 +319,7 @@ describe("LibraryPage", () => {
     expect(getActiveJobCountServerFnMock).toHaveBeenCalled();
     expect(getBulkReadingProgressServerFnMock).toHaveBeenCalled();
     expect(result).toEqual({
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     });
@@ -324,7 +327,7 @@ describe("LibraryPage", () => {
 
   it("renders 'Library' heading", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -341,6 +344,7 @@ describe("LibraryPage", () => {
         works: [makeWork("The Great Gatsby", ["F. Scott Fitzgerald"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -358,6 +362,7 @@ describe("LibraryPage", () => {
         works: [makeWork("The Great Gatsby", ["F. Scott Fitzgerald"], ["EBOOK"]), makeWork("Moby Dick", [], [])],
         totalCount: 2,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -377,6 +382,7 @@ describe("LibraryPage", () => {
         works: [makeWork("The Great Gatsby", ["F. Scott Fitzgerald"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -396,6 +402,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Unknown Author Book", [])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -425,6 +432,7 @@ describe("LibraryPage", () => {
         }],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -442,6 +450,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author"], ["AUDIOBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -459,6 +468,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -477,6 +487,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -495,6 +506,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -513,6 +525,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -531,6 +544,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -548,6 +562,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -566,6 +581,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author A"], ["EBOOK"]), makeWork("Other Book", ["Author B"], ["EBOOK"])],
         totalCount: 2,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -584,6 +600,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Ebook", [], ["EBOOK"]), makeWork("Audio", [], ["AUDIOBOOK"])],
         totalCount: 2,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -602,6 +619,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Book A"), makeWork("Book B")],
         totalCount: 2,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -633,6 +651,7 @@ describe("LibraryPage", () => {
         ],
         totalCount: 2,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -677,6 +696,7 @@ describe("LibraryPage", () => {
         ],
         totalCount: 3,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -697,6 +717,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Book A"), makeWork("Book B")],
         totalCount: 2,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -715,6 +736,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book")],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -734,6 +756,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Test Book", ["Author"], ["EBOOK"])],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -749,7 +772,7 @@ describe("LibraryPage", () => {
 
   it("renders LibraryToolbar", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -761,7 +784,7 @@ describe("LibraryPage", () => {
 
   it("renders LibraryFilters", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -773,7 +796,7 @@ describe("LibraryPage", () => {
 
   it("renders LibraryPagination", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -785,7 +808,7 @@ describe("LibraryPage", () => {
 
   it("shows empty state when no works and not scanning with no filters", async () => {
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -798,7 +821,7 @@ describe("LibraryPage", () => {
 
   it("empty state links to settings/libraries", async () => {
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -811,7 +834,7 @@ describe("LibraryPage", () => {
 
   it("does not show empty state when scanning with no works", async () => {
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 1,
       progressMap: {},
     };
@@ -825,7 +848,7 @@ describe("LibraryPage", () => {
   it("does not show empty state when filters are active and results are empty", async () => {
     mockSearch = { ...mockSearch, q: "something" } as typeof mockSearch;
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -837,7 +860,7 @@ describe("LibraryPage", () => {
 
   it("shows scanning indicator when activeJobCount > 0", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 2,
       progressMap: {},
     };
@@ -849,7 +872,7 @@ describe("LibraryPage", () => {
 
   it("shows scanning indicator with new count when totalCount > prevCount", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Old Book")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Old Book")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -860,7 +883,7 @@ describe("LibraryPage", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Old Book"), makeWork("New Book")], totalCount: 2, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Old Book"), makeWork("New Book")], totalCount: 2, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 1,
       progressMap: {},
     };
@@ -876,6 +899,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Stub Book", ["Author"], ["EBOOK"], "STUB")],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 1,
       progressMap: {},
@@ -893,6 +917,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Stub Book", ["Author"], ["EBOOK"], "STUB")],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -910,6 +935,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Enriched Book", ["Author"], ["EBOOK"], "ENRICHED")],
         totalCount: 1,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: {},
@@ -923,7 +949,7 @@ describe("LibraryPage", () => {
   it("passes progressMap to LibraryGrid", async () => {
     mockView = "grid";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: { "work-test": 42 },
     };
@@ -936,7 +962,7 @@ describe("LibraryPage", () => {
 
   it("does not show scanning indicator when activeJobCount is 0", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -948,7 +974,7 @@ describe("LibraryPage", () => {
 
   it("navigates with search text when onSearchChange is called", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -965,7 +991,7 @@ describe("LibraryPage", () => {
 
   it("navigates with empty q when search is cleared", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -979,7 +1005,7 @@ describe("LibraryPage", () => {
 
   it("navigates with sort when onSortChange is called", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -993,7 +1019,7 @@ describe("LibraryPage", () => {
 
   it("navigates with filters when onFiltersChange is called", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1007,7 +1033,7 @@ describe("LibraryPage", () => {
 
   it("navigates with page when onPageChange is called", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 100, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 100, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1021,7 +1047,7 @@ describe("LibraryPage", () => {
 
   it("navigates with pageSize and page 1 when onPageSizeChange is called", async () => {
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 100, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 100, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1040,6 +1066,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Unread"), makeWork("Reading"), makeWork("Done")],
         totalCount: 3,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: { "work-reading": 50, "work-done": 100 },
@@ -1065,6 +1092,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Unread"), makeWork("Done")],
         totalCount: 2,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: { "work-done": 100 },
@@ -1087,6 +1115,7 @@ describe("LibraryPage", () => {
         works: [makeWork("Unread"), makeWork("Done")],
         totalCount: 2,
         facetCounts: defaultFacetCounts,
+        totalFacetCounts: defaultFacetCounts,
       },
       activeJobCount: 0,
       progressMap: { "work-done": 100 },
@@ -1105,7 +1134,7 @@ describe("LibraryPage", () => {
   it("does not show empty state when format filter is active", async () => {
     mockSearch = { ...mockSearch, format: ["EBOOK"] } as typeof mockSearch;
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1118,7 +1147,7 @@ describe("LibraryPage", () => {
   it("does not show empty state when authorId filter is active", async () => {
     mockSearch = { ...mockSearch, authorId: ["a1"] } as typeof mockSearch;
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1131,7 +1160,7 @@ describe("LibraryPage", () => {
   it("does not show empty state when seriesId filter is active", async () => {
     mockSearch = { ...mockSearch, seriesId: ["s1"] } as typeof mockSearch;
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1144,7 +1173,7 @@ describe("LibraryPage", () => {
   it("does not show empty state when publisher filter is active", async () => {
     mockSearch = { ...mockSearch, publisher: ["Penguin"] } as typeof mockSearch;
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1157,7 +1186,7 @@ describe("LibraryPage", () => {
   it("does not show empty state when hasCover filter is active", async () => {
     mockSearch = { ...mockSearch, hasCover: true } as typeof mockSearch;
     mockLoaderData = {
-      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1170,7 +1199,7 @@ describe("LibraryPage", () => {
   it("passes search params as toolbar search value", async () => {
     mockSearch = { ...mockSearch, q: "test query" } as typeof mockSearch;
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1183,7 +1212,7 @@ describe("LibraryPage", () => {
   it("passes current filters from search to LibraryFilters", async () => {
     mockSearch = { ...mockSearch, format: ["EBOOK"], hasCover: true } as typeof mockSearch;
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1198,7 +1227,7 @@ describe("LibraryPage", () => {
   it("renders column picker and text overflow toggle in table view", async () => {
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1212,7 +1241,7 @@ describe("LibraryPage", () => {
   it("does not render column picker or text overflow toggle in grid view", async () => {
     mockView = "grid";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1228,7 +1257,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockTablePrefs = { columnVisibility: { isbn: false }, textOverflow: "truncate" };
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1242,7 +1271,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockTablePrefs = { columnVisibility: {}, textOverflow: "truncate" };
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1261,7 +1290,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockTablePrefs = { columnVisibility: {}, textOverflow: "truncate" };
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1280,7 +1309,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockTablePrefs = { columnVisibility: {}, textOverflow: "wrap" };
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1300,7 +1329,7 @@ describe("LibraryPage", () => {
   it("renders select-all checkbox in table view", async () => {
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1314,7 +1343,7 @@ describe("LibraryPage", () => {
   it("shows floating action bar with delete button when rows are selected", async () => {
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1337,7 +1366,7 @@ describe("LibraryPage", () => {
     bulkDeleteWorksServerFnMock.mockResolvedValue({ deletedWorkIds: ["work-book-a"] });
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1373,7 +1402,7 @@ describe("LibraryPage", () => {
     bulkDeleteWorksServerFnMock.mockResolvedValue({ deletedWorkIds: ["work-book-a", "work-book-b"] });
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A"), makeWork("Book B")], totalCount: 2, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A"), makeWork("Book B")], totalCount: 2, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1402,7 +1431,7 @@ describe("LibraryPage", () => {
   it("selects all rows when select-all header checkbox is clicked", async () => {
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A"), makeWork("Book B")], totalCount: 2, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A"), makeWork("Book B")], totalCount: 2, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1423,7 +1452,7 @@ describe("LibraryPage", () => {
     bulkDeleteWorksServerFnMock.mockRejectedValue(new Error("Bulk delete failed"));
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1454,7 +1483,7 @@ describe("LibraryPage", () => {
     bulkDeleteWorksServerFnMock.mockRejectedValue("something went wrong");
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1484,7 +1513,7 @@ describe("LibraryPage", () => {
   it("closes bulk delete dialog when cancel button is clicked", async () => {
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };
@@ -1510,7 +1539,7 @@ describe("LibraryPage", () => {
   it("clears selection when Clear button is clicked", async () => {
     mockView = "table";
     mockLoaderData = {
-      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts },
+      libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
     };

--- a/apps/web/src/routes/_authenticated/library.index.tsx
+++ b/apps/web/src/routes/_authenticated/library.index.tsx
@@ -250,7 +250,7 @@ export function columnSortToParam(
 
 function LibraryPage() {
   const { libraryResult, activeJobCount, progressMap } = Route.useLoaderData();
-  const { works, totalCount, facetCounts } = libraryResult;
+  const { works, totalCount, facetCounts, totalFacetCounts } = libraryResult;
   const search = Route.useSearch();
   const navigate = useNavigate();
   const [view, setView] = useLibraryViewPreference();
@@ -467,6 +467,7 @@ function LibraryPage() {
         <aside className="w-56 shrink-0">
           <LibraryFilters
             facetCounts={facetCounts}
+            totalFacetCounts={totalFacetCounts}
             filters={currentFilters}
             onFiltersChange={handleFiltersChange}
           />


### PR DESCRIPTION
## Summary

- Facet counts now reflect the full active filter set instead of excluding their own filter, so clicking "Without Cover" correctly shows 0 for "With Cover"
- Shows both filtered and total counts (`4 / 12`) when filters are active, single count (`12`) when no filters reduce the count
- Fixed ISBN filter being silently dropped (condition was added after the edition conditions merge)
- Format buttons always show in stable EBOOK/AUDIOBOOK order and never disappear when their count is 0
- Reserved space for Clear All button to prevent layout shift
- Active filters use `bg-primary` styling; zero-count buttons fade to 50% opacity

Closes #136