### PR TITLE
Add small/large tile size toggle and fix cover height consistency

### DIFF
--- a/apps/web/src/components/library-grid.test.tsx
+++ b/apps/web/src/components/library-grid.test.tsx
@@ -28,8 +28,8 @@ vi.mock("@tanstack/react-virtual", () => ({
 }));
 
 vi.mock("~/components/work-card", () => ({
-  WorkCard: ({ title, progressPercent }: { title: string; progressPercent?: number }) => (
-    <div data-testid="work-card" data-progress={progressPercent != null ? String(progressPercent) : undefined}>{title}</div>
+  WorkCard: ({ title, progressPercent, tileSize }: { title: string; progressPercent?: number; tileSize?: string }) => (
+    <div data-testid="work-card" data-progress={progressPercent != null ? String(progressPercent) : undefined} data-tile-size={tileSize ?? "small"}>{title}</div>
   ),
 }));
 
@@ -56,24 +56,48 @@ const makeWork = (title: string, authors: string[] = [], enrichmentStatus = "ENR
 });
 
 describe("getColumnCount", () => {
-  it("returns 2 for width < 480", () => {
-    expect(_getColumnCount(400)).toBe(2);
+  describe("large tiles", () => {
+    it("returns 2 for width < 480", () => {
+      expect(_getColumnCount(400, "large")).toBe(2);
+    });
+
+    it("returns 3 for width 480-639", () => {
+      expect(_getColumnCount(500, "large")).toBe(3);
+    });
+
+    it("returns 4 for width 640-1023", () => {
+      expect(_getColumnCount(800, "large")).toBe(4);
+    });
+
+    it("returns 5 for width 1024-1279", () => {
+      expect(_getColumnCount(1100, "large")).toBe(5);
+    });
+
+    it("returns 6 for width >= 1280", () => {
+      expect(_getColumnCount(1400, "large")).toBe(6);
+    });
   });
 
-  it("returns 3 for width 480-639", () => {
-    expect(_getColumnCount(500)).toBe(3);
-  });
+  describe("small tiles", () => {
+    it("returns 3 for width < 480", () => {
+      expect(_getColumnCount(400, "small")).toBe(3);
+    });
 
-  it("returns 4 for width 640-1023", () => {
-    expect(_getColumnCount(800)).toBe(4);
-  });
+    it("returns 4 for width 480-639", () => {
+      expect(_getColumnCount(500, "small")).toBe(4);
+    });
 
-  it("returns 5 for width 1024-1279", () => {
-    expect(_getColumnCount(1100)).toBe(5);
-  });
+    it("returns 6 for width 640-1023", () => {
+      expect(_getColumnCount(800, "small")).toBe(6);
+    });
 
-  it("returns 6 for width >= 1280", () => {
-    expect(_getColumnCount(1400)).toBe(6);
+    it("returns 7 for width 1024-1279", () => {
+      expect(_getColumnCount(1100, "small")).toBe(7);
+    });
+
+    it("returns 8 for width >= 1280", () => {
+      expect(_getColumnCount(1400, "small")).toBe(8);
+    });
   });
 });
 
@@ -114,8 +138,8 @@ describe("LibraryGrid", () => {
 
   it("passes correct row count to virtualizer for partial last row", async () => {
     const { LibraryGrid } = await import("./library-grid");
-    // With 1200px width => 5 columns, 7 works => ceil(7/5) = 2 rows
-    const works = Array.from({ length: 7 }, (_, i) => makeWork(`Work ${String(i)}`));
+    // With 1200px width + small tiles => 7 columns, 8 works => ceil(8/7) = 2 rows
+    const works = Array.from({ length: 8 }, (_, i) => makeWork(`Work ${String(i)}`));
     render(<LibraryGrid works={works as never[]} />);
     expect(mockVirtualizerArgs.count).toBe(2);
   });
@@ -177,6 +201,22 @@ describe("LibraryGrid", () => {
     const cards = screen.getAllByTestId("work-card");
     expect(cards[0]?.getAttribute("data-progress")).toBe("42");
     expect(cards[1]?.getAttribute("data-progress")).toBeNull();
+  });
+
+  it("passes tileSize to WorkCard", async () => {
+    const { LibraryGrid } = await import("./library-grid");
+    const works = [makeWork("Alpha")];
+    render(<LibraryGrid works={works as never[]} tileSize="large" />);
+    const card = screen.getByTestId("work-card");
+    expect(card.getAttribute("data-tile-size")).toBe("large");
+  });
+
+  it("defaults tileSize to small", async () => {
+    const { LibraryGrid } = await import("./library-grid");
+    const works = [makeWork("Alpha")];
+    render(<LibraryGrid works={works as never[]} />);
+    const card = screen.getByTestId("work-card");
+    expect(card.getAttribute("data-tile-size")).toBe("small");
   });
 
   it("handles ResizeObserver with empty entries", async () => {

--- a/apps/web/src/components/library-grid.tsx
+++ b/apps/web/src/components/library-grid.tsx
@@ -2,11 +2,13 @@ import { useRef, useState, useCallback } from "react";
 import { useVirtualizer } from "@tanstack/react-virtual";
 import { WorkCard } from "~/components/work-card";
 import type { LibraryWork } from "~/lib/server-fns/library";
+import type { GridTileSize } from "~/hooks/use-grid-tile-size";
 
 interface LibraryGridProps {
   works: LibraryWork[];
   progressMap?: Record<string, number>;
   scanActive?: boolean;
+  tileSize?: GridTileSize;
 }
 
 function getAuthors(work: LibraryWork): string {
@@ -21,7 +23,14 @@ function getFormats(work: LibraryWork): string[] {
   return [...new Set(work.editions.map((e) => e.formatFamily))];
 }
 
-export function getColumnCount(width: number): number {
+export function getColumnCount(width: number, tileSize: GridTileSize = "small"): number {
+  if (tileSize === "small") {
+    if (width < 480) return 3;
+    if (width < 640) return 4;
+    if (width < 1024) return 6;
+    if (width < 1280) return 7;
+    return 8;
+  }
   if (width < 480) return 2;
   if (width < 640) return 3;
   if (width < 1024) return 4;
@@ -29,7 +38,7 @@ export function getColumnCount(width: number): number {
   return 6;
 }
 
-export function LibraryGrid({ works, progressMap, scanActive }: LibraryGridProps) {
+export function LibraryGrid({ works, progressMap, scanActive, tileSize = "small" }: LibraryGridProps) {
   const scrollRef = useRef<HTMLDivElement>(null);
   const [columnCount, setColumnCount] = useState(5);
   const observerRef = useRef<ResizeObserver | null>(null);
@@ -46,20 +55,20 @@ export function LibraryGrid({ works, progressMap, scanActive }: LibraryGridProps
       const observer = new ResizeObserver((entries) => {
         const entry = entries[0];
         if (entry) {
-          setColumnCount(getColumnCount(entry.contentRect.width));
+          setColumnCount(getColumnCount(entry.contentRect.width, tileSize));
         }
       });
       observer.observe(node);
       observerRef.current = observer;
     }
-  }, []);
+  }, [tileSize]);
 
   const rowCount = works.length > 0 ? Math.ceil(works.length / columnCount) : 0;
 
   const virtualizer = useVirtualizer({
     count: rowCount,
     getScrollElement: () => scrollRef.current,
-    estimateSize: () => 400,
+    estimateSize: () => tileSize === "small" ? 280 : 400,
     overscan: 3,
     measureElement: (el) => el.getBoundingClientRect().height,
   });
@@ -70,7 +79,7 @@ export function LibraryGrid({ works, progressMap, scanActive }: LibraryGridProps
   return (
     <div
       ref={containerRef}
-      className="overflow-auto"
+      className="overflow-auto pr-2"
       style={{ maxHeight: "70vh" }}
     >
       {works.length === 0 ? (
@@ -108,6 +117,7 @@ export function LibraryGrid({ works, progressMap, scanActive }: LibraryGridProps
                     series={work.series?.name}
                     coverPath={work.coverPath}
                     progressPercent={progressMap?.[work.id]}
+                    tileSize={tileSize}
                   />
                 ))}
               </div>

--- a/apps/web/src/components/library-toolbar.test.tsx
+++ b/apps/web/src/components/library-toolbar.test.tsx
@@ -5,6 +5,7 @@ import { describe, it, expect, vi } from "vitest";
 import { LibraryToolbar, type SortValue } from "./library-toolbar";
 import type { ReadingFilter } from "~/lib/sort-filter-works";
 import type { LibraryView } from "~/hooks/use-library-view-preference";
+import type { GridTileSize } from "~/hooks/use-grid-tile-size";
 
 const defaultProps = {
   searchValue: "",
@@ -15,6 +16,8 @@ const defaultProps = {
   onViewChange: vi.fn(),
   filterValue: "all" as ReadingFilter,
   onFilterChange: vi.fn(),
+  tileSize: "small" as GridTileSize,
+  onTileSizeChange: vi.fn(),
 };
 
 describe("LibraryToolbar", () => {
@@ -124,5 +127,52 @@ describe("LibraryToolbar", () => {
     await user.click(filterCombobox as HTMLElement);
     await user.click(screen.getByText("Currently Reading"));
     expect(onFilterChange).toHaveBeenCalledWith("reading");
+  });
+
+  it("renders tile size toggle buttons when view is grid", () => {
+    render(<LibraryToolbar {...defaultProps} view="grid" />);
+    expect(screen.getByLabelText("Small tiles")).toBeTruthy();
+    expect(screen.getByLabelText("Large tiles")).toBeTruthy();
+  });
+
+  it("does not render tile size toggle when view is table", () => {
+    render(<LibraryToolbar {...defaultProps} view="table" />);
+    expect(screen.queryByLabelText("Small tiles")).toBeNull();
+    expect(screen.queryByLabelText("Large tiles")).toBeNull();
+  });
+
+  it("calls onTileSizeChange when large tile toggle is clicked", async () => {
+    const onTileSizeChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryToolbar {...defaultProps} tileSize="small" onTileSizeChange={onTileSizeChange} />);
+    await user.click(screen.getByLabelText("Large tiles"));
+    expect(onTileSizeChange).toHaveBeenCalledWith("large");
+  });
+
+  it("calls onTileSizeChange when small tile toggle is clicked", async () => {
+    const onTileSizeChange = vi.fn();
+    const user = userEvent.setup();
+    render(<LibraryToolbar {...defaultProps} tileSize="large" onTileSizeChange={onTileSizeChange} />);
+    await user.click(screen.getByLabelText("Small tiles"));
+    expect(onTileSizeChange).toHaveBeenCalledWith("small");
+  });
+
+  it("applies active state to small tile button when tileSize is small", () => {
+    render(<LibraryToolbar {...defaultProps} tileSize="small" />);
+    expect(screen.getByLabelText("Small tiles").getAttribute("data-active")).toBe("true");
+    expect(screen.getByLabelText("Large tiles").getAttribute("data-active")).toBe("false");
+  });
+
+  it("applies active state to large tile button when tileSize is large", () => {
+    render(<LibraryToolbar {...defaultProps} tileSize="large" />);
+    expect(screen.getByLabelText("Small tiles").getAttribute("data-active")).toBe("false");
+    expect(screen.getByLabelText("Large tiles").getAttribute("data-active")).toBe("true");
+  });
+
+  it("does not render tile size toggle when props are not provided", () => {
+    const { tileSize: _ts, onTileSizeChange: _otsc, ...propsWithoutTileSize } = defaultProps;
+    render(<LibraryToolbar {...propsWithoutTileSize} view="grid" />);
+    expect(screen.queryByLabelText("Small tiles")).toBeNull();
+    expect(screen.queryByLabelText("Large tiles")).toBeNull();
   });
 });

--- a/apps/web/src/components/library-toolbar.tsx
+++ b/apps/web/src/components/library-toolbar.tsx
@@ -1,4 +1,4 @@
-import { LayoutGrid, Table2, X } from "lucide-react";
+import { Grid2x2, Grid3x3, LayoutGrid, Table2, X } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
 import {
@@ -10,6 +10,7 @@ import {
 } from "~/components/ui/select";
 import type { ReadingFilter } from "~/lib/sort-filter-works";
 import type { LibraryView } from "~/hooks/use-library-view-preference";
+import type { GridTileSize } from "~/hooks/use-grid-tile-size";
 
 export type SortValue = "title-asc" | "title-desc" | "author-asc" | "author-desc" | "publisher-asc" | "publisher-desc" | "format-asc" | "format-desc" | "isbn-asc" | "isbn-desc" | "recent";
 
@@ -23,6 +24,8 @@ interface LibraryToolbarProps {
   filterValue: ReadingFilter;
   onFilterChange: (value: ReadingFilter) => void;
   showSort?: boolean;
+  tileSize?: GridTileSize;
+  onTileSizeChange?: (size: GridTileSize) => void;
 }
 
 const FILTER_OPTIONS: { value: ReadingFilter; label: string }[] = [
@@ -52,6 +55,8 @@ export function LibraryToolbar({
   filterValue,
   onFilterChange,
   showSort = true,
+  tileSize,
+  onTileSizeChange,
 }: LibraryToolbarProps) {
   return (
     <div className="flex items-center justify-between gap-2">
@@ -122,6 +127,30 @@ export function LibraryToolbar({
             <Table2 className="size-4" />
           </Button>
         </div>
+        {view === "grid" && tileSize && onTileSizeChange && (
+          <div className="flex items-center rounded-md border">
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => { onTileSizeChange("small"); }}
+              aria-label="Small tiles"
+              data-active={tileSize === "small"}
+              className="rounded-r-none data-[active=true]:bg-muted"
+            >
+              <Grid3x3 className="size-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => { onTileSizeChange("large"); }}
+              aria-label="Large tiles"
+              data-active={tileSize === "large"}
+              className="rounded-l-none data-[active=true]:bg-muted"
+            >
+              <Grid2x2 className="size-4" />
+            </Button>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/apps/web/src/components/work-card.test.tsx
+++ b/apps/web/src/components/work-card.test.tsx
@@ -50,11 +50,23 @@ describe("WorkCard", () => {
     expect(screen.queryByTestId("series-badge")).toBeNull();
   });
 
-  it("renders cover image with correct src and lazy loading when coverPath is set", () => {
-    render(<WorkCard {...baseProps} coverPath="work-123" />);
+  it("renders cover image with thumb src for small tiles", () => {
+    render(<WorkCard {...baseProps} coverPath="work-123" tileSize="small" />);
     const img = screen.getByRole("img", { name: "The Great Gatsby" });
     expect(img.getAttribute("src")).toBe("/api/covers/work-123/thumb");
     expect(img.getAttribute("loading")).toBe("lazy");
+  });
+
+  it("renders cover image with medium src for large tiles", () => {
+    render(<WorkCard {...baseProps} coverPath="work-123" tileSize="large" />);
+    const img = screen.getByRole("img", { name: "The Great Gatsby" });
+    expect(img.getAttribute("src")).toBe("/api/covers/work-123/medium");
+  });
+
+  it("defaults to thumb src when tileSize is not provided", () => {
+    render(<WorkCard {...baseProps} coverPath="work-123" />);
+    const img = screen.getByRole("img", { name: "The Great Gatsby" });
+    expect(img.getAttribute("src")).toBe("/api/covers/work-123/thumb");
   });
 
   it("renders placeholder when coverPath is null", () => {
@@ -106,6 +118,38 @@ describe("WorkCard", () => {
   it("does not show processing badge when enrichmentStatus is not provided", () => {
     render(<WorkCard {...baseProps} />);
     expect(screen.queryByText("Processing\u2026")).toBeNull();
+  });
+
+  it("renders series badge with large tile styling", () => {
+    const { container } = render(<WorkCard {...baseProps} series="Classics" tileSize="large" />);
+    const badge = container.querySelector("[class*='text-[10px]']");
+    expect(badge).toBeTruthy();
+  });
+
+  it("renders processing badge with large tile styling", () => {
+    const { container } = render(<WorkCard {...baseProps} enrichmentStatus="STUB" scanActive tileSize="large" />);
+    const badge = container.querySelector("[class*='animate-pulse']");
+    expect(badge?.className).toContain("text-[10px]");
+  });
+
+  it("renders cover container with shrink-0 and overflow-hidden to ensure consistent height", () => {
+    const { container } = render(<WorkCard {...baseProps} />);
+    const coverDiv = container.querySelector("[class*='aspect-']");
+    expect(coverDiv?.className).toContain("shrink-0");
+    expect(coverDiv?.className).toContain("overflow-hidden");
+    expect(coverDiv?.className).toContain("relative");
+  });
+
+  it("uses compact padding for small tiles", () => {
+    const { container } = render(<WorkCard {...baseProps} tileSize="small" />);
+    const contentDiv = container.querySelector("[class*='p-2']");
+    expect(contentDiv).toBeTruthy();
+  });
+
+  it("uses standard padding for large tiles", () => {
+    const { container } = render(<WorkCard {...baseProps} tileSize="large" />);
+    const contentDiv = container.querySelector("[class*='p-3']");
+    expect(contentDiv).toBeTruthy();
   });
 
   it("renders progress bar when progressPercent is provided", () => {

--- a/apps/web/src/components/work-card.tsx
+++ b/apps/web/src/components/work-card.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { BookOpen } from "lucide-react";
 import { Badge } from "~/components/ui/badge";
 import { ProgressBar } from "~/components/progress-bar";
+import type { GridTileSize } from "~/hooks/use-grid-tile-size";
 
 export interface WorkCardProps {
   id: string;
@@ -14,45 +15,48 @@ export interface WorkCardProps {
   series?: string | null;
   coverPath?: string | null;
   progressPercent?: number | null;
+  tileSize?: GridTileSize;
 }
 
-export function WorkCard({ id, title, authors, enrichmentStatus, scanActive, formats, series, coverPath, progressPercent }: WorkCardProps) {
+export function WorkCard({ id, title, authors, enrichmentStatus, scanActive, formats, series, coverPath, progressPercent, tileSize = "small" }: WorkCardProps) {
   const [imgFailed, setImgFailed] = useState(false);
   const showPlaceholder = !coverPath || imgFailed;
+  const coverSize = tileSize === "large" ? "medium" : "thumb";
+  const isSmall = tileSize === "small";
 
   return (
     <Link to="/library/$workId" params={{ workId: id }} search={{ page: 1, pageSize: 50, sort: "title-asc" as const }} className="flex flex-col overflow-hidden rounded-lg border bg-card">
-      <div className="aspect-[2/3] bg-muted">
+      <div className="relative aspect-[2/3] shrink-0 overflow-hidden bg-muted">
         {showPlaceholder ? (
-          <div className="flex size-full items-center justify-center text-muted-foreground">
-            <BookOpen className="size-12" />
+          <div className="absolute inset-0 flex items-center justify-center text-muted-foreground">
+            <BookOpen className={isSmall ? "size-8" : "size-12"} />
           </div>
         ) : (
           <img
-            src={`/api/covers/${id}/thumb`}
+            src={`/api/covers/${id}/${coverSize}`}
             alt={title}
             loading="lazy"
             onError={() => { setImgFailed(true); }}
-            className="size-full object-cover"
+            className="absolute inset-0 size-full object-cover"
           />
         )}
       </div>
-      <div className="space-y-1 p-3">
-        <h3 className="line-clamp-2 text-sm font-medium leading-tight">{title}</h3>
-        <p className="line-clamp-1 text-xs text-muted-foreground">{authors}</p>
+      <div className={isSmall ? "space-y-0.5 p-2" : "space-y-1 p-3"}>
+        <h3 className={isSmall ? "line-clamp-2 text-xs font-medium leading-tight" : "line-clamp-2 text-sm font-medium leading-tight"}>{title}</h3>
+        <p className={isSmall ? "line-clamp-1 text-[10px] text-muted-foreground" : "line-clamp-1 text-xs text-muted-foreground"}>{authors}</p>
         <div className="flex flex-wrap gap-1">
           {formats.map((f) => (
-            <Badge key={f} variant="secondary" className="px-1.5 py-0 text-[10px]">
+            <Badge key={f} variant="secondary" className={isSmall ? "px-1 py-0 text-[8px]" : "px-1.5 py-0 text-[10px]"}>
               {f}
             </Badge>
           ))}
           {series && (
-            <Badge data-testid="series-badge" variant="outline" className="px-1.5 py-0 text-[10px]">
+            <Badge data-testid="series-badge" variant="outline" className={isSmall ? "px-1 py-0 text-[8px]" : "px-1.5 py-0 text-[10px]"}>
               {series}
             </Badge>
           )}
           {enrichmentStatus === "STUB" && scanActive && (
-            <Badge variant="outline" className="animate-pulse px-1.5 py-0 text-[10px]">
+            <Badge variant="outline" className={isSmall ? "animate-pulse px-1 py-0 text-[8px]" : "animate-pulse px-1.5 py-0 text-[10px]"}>
               Processing&hellip;
             </Badge>
           )}

--- a/apps/web/src/hooks/use-grid-tile-size.test.ts
+++ b/apps/web/src/hooks/use-grid-tile-size.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from "@testing-library/react";
+import { createElement } from "react";
+import { renderToString } from "react-dom/server";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { useGridTileSize } from "./use-grid-tile-size";
+
+const STORAGE_KEY = "grid-tile-size";
+
+function makeStorage(): Storage {
+  const store = new Map<string, string>();
+  return {
+    getItem: (key: string) => store.get(key) ?? null,
+    setItem: (key: string, value: string) => { store.set(key, value); },
+    removeItem: (key: string) => { store.delete(key); },
+    clear: () => { store.clear(); },
+    get length() { return store.size; },
+    key: (index: number) => [...store.keys()][index] ?? null,
+  };
+}
+
+describe("useGridTileSize", () => {
+  beforeEach(() => {
+    vi.stubGlobal("localStorage", makeStorage());
+  });
+
+  it("defaults to 'small' when localStorage is empty", () => {
+    const { result } = renderHook(() => useGridTileSize());
+    expect(result.current[0]).toBe("small");
+  });
+
+  it("reads 'large' from localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, "large");
+    const { result } = renderHook(() => useGridTileSize());
+    expect(result.current[0]).toBe("large");
+  });
+
+  it("reads 'small' from localStorage", () => {
+    localStorage.setItem(STORAGE_KEY, "small");
+    const { result } = renderHook(() => useGridTileSize());
+    expect(result.current[0]).toBe("small");
+  });
+
+  it("ignores invalid localStorage values and defaults to 'small'", () => {
+    localStorage.setItem(STORAGE_KEY, "bogus");
+    const { result } = renderHook(() => useGridTileSize());
+    expect(result.current[0]).toBe("small");
+  });
+
+  it("persists to localStorage when setTileSize is called", () => {
+    const { result } = renderHook(() => useGridTileSize());
+    act(() => {
+      result.current[1]("large");
+    });
+    expect(result.current[0]).toBe("large");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("large");
+  });
+
+  it("updates state when toggling back to small", () => {
+    localStorage.setItem(STORAGE_KEY, "large");
+    const { result } = renderHook(() => useGridTileSize());
+    act(() => {
+      result.current[1]("small");
+    });
+    expect(result.current[0]).toBe("small");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("small");
+  });
+
+  it("re-reads on storage events", () => {
+    const { result } = renderHook(() => useGridTileSize());
+    expect(result.current[0]).toBe("small");
+
+    act(() => {
+      localStorage.setItem(STORAGE_KEY, "large");
+      window.dispatchEvent(new Event("storage"));
+    });
+    expect(result.current[0]).toBe("large");
+  });
+
+  it("cleans up storage listener on unmount", () => {
+    const removeSpy = vi.spyOn(window, "removeEventListener");
+    const { unmount } = renderHook(() => useGridTileSize());
+    unmount();
+    expect(removeSpy).toHaveBeenCalledWith("storage", expect.any(Function));
+    removeSpy.mockRestore();
+  });
+
+  it("returns 'small' during SSR via getServerSnapshot", () => {
+    function TestComponent() {
+      const [tileSize] = useGridTileSize();
+      return createElement("span", null, tileSize);
+    }
+    const html = renderToString(createElement(TestComponent));
+    expect(html).toContain("small");
+  });
+});

--- a/apps/web/src/hooks/use-grid-tile-size.ts
+++ b/apps/web/src/hooks/use-grid-tile-size.ts
@@ -1,0 +1,29 @@
+import { useState, useCallback, useSyncExternalStore } from "react";
+
+export type GridTileSize = "small" | "large";
+
+const STORAGE_KEY = "grid-tile-size";
+
+function getSnapshot(): GridTileSize {
+  const stored = localStorage.getItem(STORAGE_KEY);
+  return stored === "large" ? "large" : "small";
+}
+
+function subscribe(callback: () => void): () => void {
+  window.addEventListener("storage", callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+  };
+}
+
+export function useGridTileSize(): [GridTileSize, (v: GridTileSize) => void] {
+  const tileSize = useSyncExternalStore(subscribe, getSnapshot, () => "small" as GridTileSize);
+  const [, setTick] = useState(0);
+
+  const setTileSize = useCallback((v: GridTileSize) => {
+    localStorage.setItem(STORAGE_KEY, v);
+    setTick((t) => t + 1);
+  }, []);
+
+  return [tileSize, setTileSize];
+}

--- a/apps/web/src/routes/_authenticated/-library.index.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.index.test.tsx
@@ -139,6 +139,12 @@ vi.mock("~/hooks/use-library-view-preference", () => ({
   useLibraryViewPreference: () => [mockView, mockSetView],
 }));
 
+let mockTileSize = "small" as "small" | "large";
+const mockSetTileSize = vi.fn();
+vi.mock("~/hooks/use-grid-tile-size", () => ({
+  useGridTileSize: () => [mockTileSize, mockSetTileSize],
+}));
+
 let mockTablePrefs: { columnVisibility: Record<string, boolean>; textOverflow: "wrap" | "truncate" } = { columnVisibility: {}, textOverflow: "truncate" };
 const mockSetTablePrefs = vi.fn();
 vi.mock("~/hooks/use-library-table-preferences", () => ({
@@ -146,8 +152,8 @@ vi.mock("~/hooks/use-library-table-preferences", () => ({
 }));
 
 vi.mock("~/components/library-grid", () => ({
-  LibraryGrid: ({ works, progressMap }: { works: object[]; progressMap?: Record<string, number> }) => (
-    <div data-testid="library-grid" data-progress-map={progressMap ? JSON.stringify(progressMap) : undefined}>Grid: {String(works.length)} works</div>
+  LibraryGrid: ({ works, progressMap, tileSize }: { works: object[]; progressMap?: Record<string, number>; tileSize?: string }) => (
+    <div data-testid="library-grid" data-progress-map={progressMap ? JSON.stringify(progressMap) : undefined} data-tile-size={tileSize ?? "small"}>Grid: {String(works.length)} works</div>
   ),
 }));
 
@@ -958,6 +964,36 @@ describe("LibraryPage", () => {
     render(<LibraryPage />);
     const grid = screen.getByTestId("library-grid");
     expect(grid.getAttribute("data-progress-map")).toBe(JSON.stringify({ "work-test": 42 }));
+  });
+
+  it("passes tileSize to LibraryGrid", async () => {
+    mockView = "grid";
+    mockTileSize = "large";
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    const grid = screen.getByTestId("library-grid");
+    expect(grid.getAttribute("data-tile-size")).toBe("large");
+  });
+
+  it("passes tileSize and onTileSizeChange to LibraryToolbar", async () => {
+    mockView = "grid";
+    mockTileSize = "small";
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      activeJobCount: 0,
+      progressMap: {},
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+    expect(capturedToolbarProps.tileSize).toBe("small");
+    expect(typeof capturedToolbarProps.onTileSizeChange).toBe("function");
   });
 
   it("does not show scanning indicator when activeJobCount is 0", async () => {

--- a/apps/web/src/routes/_authenticated/library.index.tsx
+++ b/apps/web/src/routes/_authenticated/library.index.tsx
@@ -4,6 +4,7 @@ import { toast } from "sonner";
 import { useSSE } from "~/hooks/use-sse";
 import { useLibraryViewPreference } from "~/hooks/use-library-view-preference";
 import { useLibraryTablePreferences } from "~/hooks/use-library-table-preferences";
+import { useGridTileSize } from "~/hooks/use-grid-tile-size";
 import type { ColumnDef, RowSelectionState, SortingState, Updater } from "@tanstack/react-table";
 import { AlignJustify, BookOpen, Loader2, Pencil, Trash2, WrapText, X } from "lucide-react";
 import { VirtualizedDataTable, DataTableColumnHeader } from "~/components/data-table";
@@ -254,6 +255,7 @@ function LibraryPage() {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const [view, setView] = useLibraryViewPreference();
+  const [tileSize, setTileSize] = useGridTileSize();
   const [tablePrefs, setTablePrefs] = useLibraryTablePreferences();
   const [readingFilter, setReadingFilter] = useState<ReadingFilter>("all");
   const [prevCount, setPrevCount] = useState(totalCount);
@@ -483,6 +485,8 @@ function LibraryPage() {
             filterValue={readingFilter}
             onFilterChange={setReadingFilter}
             showSort={view !== "table"}
+            tileSize={tileSize}
+            onTileSizeChange={setTileSize}
           />
           {view === "table" && (
             <div className="flex items-center gap-2 justify-end">
@@ -517,7 +521,7 @@ function LibraryPage() {
             </div>
           )}
           {view === "grid" ? (
-            <LibraryGrid works={filteredByReading} progressMap={progressMap} scanActive={isScanning} />
+            <LibraryGrid works={filteredByReading} progressMap={progressMap} scanActive={isScanning} tileSize={tileSize} />
           ) : (
             <VirtualizedDataTable
               columns={getColumns(isScanning, editMode, router)}


### PR DESCRIPTION
## Summary

- Adds a small/large tile size toggle to the library grid toolbar (only visible in grid view), persisted to localStorage via a new `useGridTileSize` hook
- Small tiles (new default) show more columns (3/4/6/7/8 breakpoints) with compact text/padding; large tiles use the existing column counts with the higher-quality `/medium` thumbnail
- Fixes cover height inconsistency by using `relative` + `absolute inset-0` on the cover container so child elements don't interfere with `aspect-[2/3]` height calculation
- Adds `pr-2` padding between the grid and the scrollbar

Closes #140