### PR TITLE
Add Send to Kindle feature

### DIFF
--- a/apps/web/src/components/edition-tab-panel.test.tsx
+++ b/apps/web/src/components/edition-tab-panel.test.tsx
@@ -1,13 +1,21 @@
 // @vitest-environment happy-dom
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { updateEditionServerFnMock } = vi.hoisted(() => ({
+const mockToast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({ toast: mockToast }));
+
+const { updateEditionServerFnMock, sendToKindleServerFnMock } = vi.hoisted(() => ({
   updateEditionServerFnMock: vi.fn(),
+  sendToKindleServerFnMock: vi.fn(),
 }));
 
 vi.mock("~/lib/server-fns/editing", () => ({
   updateEditionServerFn: updateEditionServerFnMock,
+}));
+
+vi.mock("~/lib/server-fns/kindle", () => ({
+  sendToKindleServerFn: sendToKindleServerFnMock,
 }));
 
 import { EditionTabPanel } from "./edition-tab-panel";
@@ -17,6 +25,7 @@ type EditionType = WorkDetail["editions"][number];
 
 beforeEach(() => {
   updateEditionServerFnMock.mockReset();
+  sendToKindleServerFnMock.mockReset();
 });
 
 const baseEdition = {
@@ -74,6 +83,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -93,6 +104,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -107,6 +120,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -121,6 +136,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -135,6 +152,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={onDelete}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -149,6 +168,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -162,6 +183,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -175,6 +198,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -191,6 +216,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={onFieldSaved}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -221,6 +248,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={onFieldSaved}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -246,6 +275,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -261,6 +292,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -275,6 +308,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -299,6 +334,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -331,6 +368,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -356,6 +395,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -381,6 +422,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -397,6 +440,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={onFieldSaved}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -425,6 +470,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={onFieldSaved}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -452,6 +499,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={onFieldSaved}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -479,6 +528,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={onFieldSaved}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -506,6 +557,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={onFieldSaved}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -530,6 +583,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -557,6 +612,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -582,6 +639,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -613,6 +672,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -648,6 +709,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -680,6 +743,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -724,6 +789,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -769,6 +836,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -803,6 +872,8 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
@@ -831,9 +902,329 @@ describe("EditionTabPanel", () => {
         isLastEdition={false}
         onEditionFieldSaved={vi.fn()}
         onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
       />,
     );
 
     expect(screen.getByText("MISSING")).toBeTruthy();
+  });
+
+  describe("Send to Kindle", () => {
+    it("does not show Send to Kindle when kindleConfigured is false", () => {
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={false}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: /send to kindle/i })).toBeNull();
+    });
+
+    it("does not show Send to Kindle when smtpConfigured is false", () => {
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={false}
+          kindleConfigured={true}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: /send to kindle/i })).toBeNull();
+    });
+
+    it("shows Send to Kindle for EPUB file when both configured", () => {
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: /send to kindle/i })).toBeTruthy();
+    });
+
+    it("shows Send to Kindle for PDF file when both configured", () => {
+      const pdfEdition = {
+        ...baseEdition,
+        editionFiles: [
+          {
+            ...baseEdition.editionFiles[0],
+            fileAsset: {
+              ...(baseEdition.editionFiles[0] as (typeof baseEdition.editionFiles)[number]).fileAsset,
+              basename: "book.pdf",
+              mediaKind: "PDF",
+            },
+          },
+        ],
+      } as EditionType;
+      render(
+        <EditionTabPanel
+          edition={pdfEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      expect(screen.getByRole("button", { name: /send to kindle/i })).toBeTruthy();
+    });
+
+    it("does not show Send to Kindle for CBZ file", () => {
+      const cbzEdition = {
+        ...baseEdition,
+        editionFiles: [
+          {
+            ...baseEdition.editionFiles[0],
+            fileAsset: {
+              ...(baseEdition.editionFiles[0] as (typeof baseEdition.editionFiles)[number]).fileAsset,
+              basename: "comic.cbz",
+              mediaKind: "CBZ",
+            },
+          },
+        ],
+      } as EditionType;
+      render(
+        <EditionTabPanel
+          edition={cbzEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: /send to kindle/i })).toBeNull();
+    });
+
+    it("does not show Send to Kindle for AUDIO file", () => {
+      const audioEdition = {
+        ...baseEdition,
+        editionFiles: [
+          {
+            ...baseEdition.editionFiles[0],
+            fileAsset: {
+              ...(baseEdition.editionFiles[0] as (typeof baseEdition.editionFiles)[number]).fileAsset,
+              basename: "track.mp3",
+              mediaKind: "AUDIO",
+            },
+          },
+        ],
+      } as EditionType;
+      render(
+        <EditionTabPanel
+          edition={audioEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: /send to kindle/i })).toBeNull();
+    });
+
+    it("does not show Send to Kindle for MISSING file", () => {
+      const missingEdition = {
+        ...baseEdition,
+        editionFiles: [
+          {
+            ...baseEdition.editionFiles[0],
+            fileAsset: {
+              ...(baseEdition.editionFiles[0] as (typeof baseEdition.editionFiles)[number]).fileAsset,
+              availabilityStatus: "MISSING",
+            },
+          },
+        ],
+      } as EditionType;
+      render(
+        <EditionTabPanel
+          edition={missingEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: /send to kindle/i })).toBeNull();
+    });
+
+    it("calls sendToKindleServerFn with correct editionFileId on click", async () => {
+      sendToKindleServerFnMock.mockResolvedValue({ success: true });
+
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send to kindle/i }));
+
+      await waitFor(() => {
+        expect(sendToKindleServerFnMock).toHaveBeenCalledWith({
+          data: { editionFileId: "ef1" },
+        });
+      });
+    });
+
+    it("shows success toast on successful send", async () => {
+      sendToKindleServerFnMock.mockResolvedValue({ success: true });
+
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send to kindle/i }));
+
+      await waitFor(() => {
+        expect(mockToast.success).toHaveBeenCalledWith("Sent to Kindle");
+      });
+    });
+
+    it("shows error toast on failed send", async () => {
+      sendToKindleServerFnMock.mockResolvedValue({ success: false, error: "File too large" });
+
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send to kindle/i }));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith("File too large");
+      });
+    });
+
+    it("shows error toast when sendToKindleServerFn throws", async () => {
+      sendToKindleServerFnMock.mockRejectedValue(new Error("Network error"));
+
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send to kindle/i }));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith("Network error");
+      });
+    });
+
+    it("shows Sending state while in progress", async () => {
+      let resolveSend!: () => void;
+      sendToKindleServerFnMock.mockReturnValue(
+        new Promise<{ success: boolean }>((resolve) => {
+          resolveSend = () => { resolve({ success: true }); };
+        }),
+      );
+
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send to kindle/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Sending…")).toBeTruthy();
+      });
+
+      resolveSend();
+
+      await waitFor(() => {
+        expect(screen.queryByText("Sending…")).toBeNull();
+      });
+    });
+
+    it("shows fallback error when send fails without error message", async () => {
+      sendToKindleServerFnMock.mockResolvedValue({ success: false });
+
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send to kindle/i }));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith("Failed to send to Kindle");
+      });
+    });
+
+    it("shows generic error when send throws non-Error", async () => {
+      sendToKindleServerFnMock.mockRejectedValue("string-error");
+
+      render(
+        <EditionTabPanel
+          edition={baseEdition}
+          isLastEdition={false}
+          onEditionFieldSaved={vi.fn()}
+          onDeleteEdition={vi.fn()}
+          smtpConfigured={true}
+          kindleConfigured={true}
+        />,
+      );
+
+      fireEvent.click(screen.getByRole("button", { name: /send to kindle/i }));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith("Failed to send to Kindle");
+      });
+    });
   });
 });

--- a/apps/web/src/components/edition-tab-panel.tsx
+++ b/apps/web/src/components/edition-tab-panel.tsx
@@ -1,22 +1,29 @@
-import { Download, Trash2 } from "lucide-react";
+import { useState } from "react";
+import { Download, Loader2, TabletSmartphone, Trash2 } from "lucide-react";
+import { toast } from "sonner";
 import { Badge } from "~/components/ui/badge";
 import { Button } from "~/components/ui/button";
 import { EditableField } from "~/components/editable-field";
 import { MetadataItem } from "~/components/metadata-item";
 import { updateEditionServerFn } from "~/lib/server-fns/editing";
+import { sendToKindleServerFn } from "~/lib/server-fns/kindle";
 import type { WorkDetail } from "~/lib/server-fns/work-detail";
 
 type EditionType = WorkDetail["editions"][number];
+
+const KINDLE_COMPATIBLE_MEDIA_KINDS = new Set(["EPUB", "PDF"]);
 
 interface EditionTabPanelProps {
   edition: EditionType;
   isLastEdition: boolean;
   onEditionFieldSaved: () => void;
   onDeleteEdition: () => void;
+  smtpConfigured: boolean;
+  kindleConfigured: boolean;
 }
 
 function formatBytes(bytes: bigint | number | null): string {
-  if (bytes === null) return "—";
+  if (bytes === null) return "\u2014";
   const n = Number(bytes);
   if (n < 1024) return `${String(n)} B`;
   if (n < 1024 * 1024) return `${(n / 1024).toFixed(1)} KB`;
@@ -27,36 +34,58 @@ export function EditionTabPanel({
   edition,
   onEditionFieldSaved,
   onDeleteEdition,
+  smtpConfigured,
+  kindleConfigured,
 }: EditionTabPanelProps) {
+  const [sendingFileId, setSendingFileId] = useState<string | null>(null);
+
   async function saveField(field: string, val: string) {
     await updateEditionServerFn({ data: { editionId: edition.id, fields: { [field]: val || null } } });
     onEditionFieldSaved();
   }
+
+  async function handleSendToKindle(editionFileId: string) {
+    setSendingFileId(editionFileId);
+    try {
+      const result = await sendToKindleServerFn({ data: { editionFileId } }) as { success: boolean; error?: string };
+      if (result.success) {
+        toast.success("Sent to Kindle");
+      } else {
+        toast.error(result.error ?? "Failed to send to Kindle");
+      }
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to send to Kindle");
+    } finally {
+      setSendingFileId(null);
+    }
+  }
+
+  const canSendToKindle = smtpConfigured && kindleConfigured;
 
   return (
     <div className="space-y-6 py-4">
       {/* Metadata Grid */}
       <div className="grid grid-cols-2 gap-x-8 gap-y-3 text-sm sm:grid-cols-3">
         <MetadataItem label="Publisher">
-          <EditableField value={edition.publisher ?? ""} onSave={(val) => saveField("publisher", val)} placeholder="—" />
+          <EditableField value={edition.publisher ?? ""} onSave={(val) => saveField("publisher", val)} placeholder="\u2014" />
         </MetadataItem>
         <MetadataItem label="Published">
-          <EditableField value={edition.publishedAt ? new Date(edition.publishedAt).toLocaleDateString() : ""} onSave={(val) => saveField("publishedAt", val)} placeholder="—" />
+          <EditableField value={edition.publishedAt ? new Date(edition.publishedAt).toLocaleDateString() : ""} onSave={(val) => saveField("publishedAt", val)} placeholder="\u2014" />
         </MetadataItem>
         <MetadataItem label="Pages">
-          <EditableField value={edition.pageCount != null ? String(edition.pageCount) : ""} onSave={(val) => saveField("pageCount", val)} placeholder="—" />
+          <EditableField value={edition.pageCount != null ? String(edition.pageCount) : ""} onSave={(val) => saveField("pageCount", val)} placeholder="\u2014" />
         </MetadataItem>
         <MetadataItem label="ISBN-13">
-          <EditableField value={edition.isbn13 ?? ""} onSave={(val) => saveField("isbn13", val)} placeholder="—" />
+          <EditableField value={edition.isbn13 ?? ""} onSave={(val) => saveField("isbn13", val)} placeholder="\u2014" />
         </MetadataItem>
         <MetadataItem label="ISBN-10">
-          <EditableField value={edition.isbn10 ?? ""} onSave={(val) => saveField("isbn10", val)} placeholder="—" />
+          <EditableField value={edition.isbn10 ?? ""} onSave={(val) => saveField("isbn10", val)} placeholder="\u2014" />
         </MetadataItem>
         <MetadataItem label="ASIN">
-          <EditableField value={edition.asin ?? ""} onSave={(val) => saveField("asin", val)} placeholder="—" />
+          <EditableField value={edition.asin ?? ""} onSave={(val) => saveField("asin", val)} placeholder="\u2014" />
         </MetadataItem>
         <MetadataItem label="Language">
-          <EditableField value={edition.language ?? ""} onSave={(val) => saveField("language", val)} placeholder="—" />
+          <EditableField value={edition.language ?? ""} onSave={(val) => saveField("language", val)} placeholder="\u2014" />
         </MetadataItem>
       </div>
 
@@ -101,6 +130,30 @@ export function EditionTabPanel({
                   >
                     {ef.fileAsset.availabilityStatus}
                   </Badge>
+                  {canSendToKindle &&
+                    ef.fileAsset.availabilityStatus === "PRESENT" &&
+                    KINDLE_COMPATIBLE_MEDIA_KINDS.has(ef.fileAsset.mediaKind) && (
+                      <Button
+                        variant="outline"
+                        size="sm"
+                        aria-label={`Send to Kindle: ${ef.fileAsset.basename}`}
+                        disabled={sendingFileId === ef.id}
+                        onClick={() => { void handleSendToKindle(ef.id); }}
+                        className="h-auto px-2 py-0.5 text-xs"
+                      >
+                        {sendingFileId === ef.id ? (
+                          <>
+                            <Loader2 className="size-3.5 animate-spin mr-1" />
+                            Sending…
+                          </>
+                        ) : (
+                          <>
+                            <TabletSmartphone className="size-3.5 mr-1" />
+                            Send to Kindle
+                          </>
+                        )}
+                      </Button>
+                    )}
                 </div>
               )).concat(
                 multiplePresent ? [

--- a/apps/web/src/components/settings/kindle-config-card.test.tsx
+++ b/apps/web/src/components/settings/kindle-config-card.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment happy-dom
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockToast = vi.hoisted(() => ({ success: vi.fn(), error: vi.fn() }));
+vi.mock("sonner", () => ({ toast: mockToast }));
+
+const mockInvalidate = vi.fn();
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual("@tanstack/react-router");
+  return {
+    ...actual,
+    useRouter: () => ({ invalidate: mockInvalidate }),
+  };
+});
+
+const {
+  getKindleConfigServerFnMock,
+  saveKindleConfigServerFnMock,
+  removeKindleConfigServerFnMock,
+} = vi.hoisted(() => ({
+  getKindleConfigServerFnMock: vi.fn(),
+  saveKindleConfigServerFnMock: vi.fn(),
+  removeKindleConfigServerFnMock: vi.fn(),
+}));
+
+vi.mock("~/lib/server-fns/kindle", () => ({
+  getKindleConfigServerFn: getKindleConfigServerFnMock,
+  saveKindleConfigServerFn: saveKindleConfigServerFnMock,
+  removeKindleConfigServerFn: removeKindleConfigServerFnMock,
+}));
+
+import { KindleConfigCard } from "./kindle-config-card";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("KindleConfigCard", () => {
+  describe("unconfigured state", () => {
+    it("renders the setup form when not configured", () => {
+      render(<KindleConfigCard configured={false} />);
+
+      expect(screen.getByText("Kindle")).toBeTruthy();
+      expect(screen.getByText("Not configured")).toBeTruthy();
+      expect(screen.getByPlaceholderText("you@kindle.com")).toBeTruthy();
+      expect(screen.getByText("Save")).toBeTruthy();
+    });
+
+    it("shows info note about approved senders", () => {
+      render(<KindleConfigCard configured={false} />);
+
+      expect(screen.getByText(/Approved Personal Document E-mail List/)).toBeTruthy();
+    });
+
+    it("submits the form with correct data", async () => {
+      const user = userEvent.setup();
+      saveKindleConfigServerFnMock.mockResolvedValue({ saved: true });
+
+      render(<KindleConfigCard configured={false} />);
+
+      await user.type(screen.getByPlaceholderText("you@kindle.com"), "me@kindle.com");
+      await user.click(screen.getByText("Save"));
+
+      await waitFor(() => {
+        expect(saveKindleConfigServerFnMock).toHaveBeenCalledWith({
+          data: { email: "me@kindle.com" },
+        });
+      });
+
+      expect(mockToast.success).toHaveBeenCalledWith("Kindle email saved");
+      expect(mockInvalidate).toHaveBeenCalled();
+    });
+
+    it("shows error toast when save fails", async () => {
+      const user = userEvent.setup();
+      saveKindleConfigServerFnMock.mockRejectedValue(new Error("Network error"));
+
+      render(<KindleConfigCard configured={false} />);
+
+      await user.type(screen.getByPlaceholderText("you@kindle.com"), "me@kindle.com");
+      await user.click(screen.getByText("Save"));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith("Network error");
+      });
+    });
+
+    it("shows generic error when save throws non-Error", async () => {
+      const user = userEvent.setup();
+      saveKindleConfigServerFnMock.mockRejectedValue("string-error");
+
+      render(<KindleConfigCard configured={false} />);
+
+      await user.type(screen.getByPlaceholderText("you@kindle.com"), "me@kindle.com");
+      await user.click(screen.getByText("Save"));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith("Failed to save Kindle email");
+      });
+    });
+
+    it("shows saving state while submitting", async () => {
+      let resolveSubmit!: () => void;
+      saveKindleConfigServerFnMock.mockReturnValue(
+        new Promise<void>((resolve) => { resolveSubmit = resolve; }),
+      );
+
+      const user = userEvent.setup();
+      render(<KindleConfigCard configured={false} />);
+
+      await user.type(screen.getByPlaceholderText("you@kindle.com"), "me@kindle.com");
+      await user.click(screen.getByText("Save"));
+
+      await waitFor(() => {
+        expect(screen.getByText("Saving...")).toBeTruthy();
+      });
+
+      resolveSubmit();
+
+      await waitFor(() => {
+        expect(screen.queryByText("Saving...")).toBeNull();
+      });
+    });
+
+    it("disables save button when email is empty", () => {
+      render(<KindleConfigCard configured={false} />);
+
+      const saveButton = screen.getByText("Save");
+      expect(saveButton.closest("button")?.disabled).toBe(true);
+    });
+  });
+
+  describe("configured state", () => {
+    beforeEach(() => {
+      getKindleConfigServerFnMock.mockResolvedValue({
+        configured: true,
+        email: "me@kindle.com",
+      });
+    });
+
+    it("loads and displays the email", async () => {
+      render(<KindleConfigCard configured={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Connected")).toBeTruthy();
+      });
+
+      expect(screen.getByText("me@kindle.com")).toBeTruthy();
+    });
+
+    it("shows edit form when Edit is clicked", async () => {
+      const user = userEvent.setup();
+      render(<KindleConfigCard configured={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Edit")).toBeTruthy();
+      });
+
+      await user.click(screen.getByText("Edit"));
+
+      expect(screen.getByPlaceholderText("you@kindle.com")).toBeTruthy();
+    });
+
+    it("removes Kindle config when Remove is clicked", async () => {
+      const user = userEvent.setup();
+      removeKindleConfigServerFnMock.mockResolvedValue({ removed: true });
+
+      render(<KindleConfigCard configured={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Remove")).toBeTruthy();
+      });
+
+      await user.click(screen.getByText("Remove"));
+
+      await waitFor(() => {
+        expect(removeKindleConfigServerFnMock).toHaveBeenCalled();
+      });
+
+      expect(mockToast.success).toHaveBeenCalledWith("Kindle email removed");
+      expect(mockInvalidate).toHaveBeenCalled();
+    });
+
+    it("shows error toast when remove fails", async () => {
+      const user = userEvent.setup();
+      removeKindleConfigServerFnMock.mockRejectedValue(new Error("DB error"));
+
+      render(<KindleConfigCard configured={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Remove")).toBeTruthy();
+      });
+
+      await user.click(screen.getByText("Remove"));
+
+      await waitFor(() => {
+        expect(mockToast.error).toHaveBeenCalledWith("Failed to remove Kindle email");
+      });
+    });
+  });
+
+  describe("unmount during load", () => {
+    it("does not update state after unmount", () => {
+      let resolveConfig!: () => void;
+      getKindleConfigServerFnMock.mockReturnValue(
+        new Promise<object>((resolve) => {
+          resolveConfig = () => {
+            resolve({ configured: true, email: "me@kindle.com" });
+          };
+        }),
+      );
+
+      const { unmount } = render(<KindleConfigCard configured={true} />);
+
+      unmount();
+      resolveConfig();
+
+      expect(true).toBe(true);
+    });
+
+    it("does not set error state after unmount on failure", () => {
+      let rejectConfig!: () => void;
+      getKindleConfigServerFnMock.mockReturnValue(
+        new Promise<never>((_resolve, reject) => {
+          rejectConfig = () => { reject(new Error("fail")); };
+        }),
+      );
+
+      const { unmount } = render(<KindleConfigCard configured={true} />);
+
+      unmount();
+      rejectConfig();
+
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("loading state", () => {
+    it("shows loading state while fetching config", async () => {
+      let resolveConfig!: () => void;
+      getKindleConfigServerFnMock.mockReturnValue(
+        new Promise<object>((resolve) => {
+          resolveConfig = () => {
+            resolve({ configured: true, email: "me@kindle.com" });
+          };
+        }),
+      );
+
+      render(<KindleConfigCard configured={true} />);
+
+      expect(screen.getByText("Loading...")).toBeTruthy();
+
+      resolveConfig();
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading...")).toBeNull();
+      });
+    });
+
+    it("handles config returning not configured", async () => {
+      getKindleConfigServerFnMock.mockResolvedValue({ configured: false });
+
+      render(<KindleConfigCard configured={true} />);
+
+      await waitFor(() => {
+        expect(screen.queryByText("Loading...")).toBeNull();
+      });
+
+      expect(screen.queryByText("me@kindle.com")).toBeNull();
+    });
+
+    it("shows error when config fetch fails", async () => {
+      getKindleConfigServerFnMock.mockRejectedValue(new Error("DB error"));
+
+      render(<KindleConfigCard configured={true} />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Failed to load configuration")).toBeTruthy();
+      });
+    });
+  });
+});

--- a/apps/web/src/components/settings/kindle-config-card.tsx
+++ b/apps/web/src/components/settings/kindle-config-card.tsx
@@ -1,0 +1,159 @@
+import { useState, useEffect } from "react";
+import { useRouter } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { Loader2 } from "lucide-react";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from "~/components/ui/card";
+import { Input } from "~/components/ui/input";
+import {
+  getKindleConfigServerFn,
+  saveKindleConfigServerFn,
+  removeKindleConfigServerFn,
+} from "~/lib/server-fns/kindle";
+
+export function KindleConfigCard({ configured }: { configured: boolean }) {
+  const router = useRouter();
+  const [editing, setEditing] = useState(!configured);
+  const [loading, setLoading] = useState(configured);
+  const [loadError, setLoadError] = useState(false);
+  const [email, setEmail] = useState("");
+  const [storedEmail, setStoredEmail] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [removing, setRemoving] = useState(false);
+
+  useEffect(() => {
+    if (!configured) return;
+    let cancelled = false;
+
+    async function loadConfig() {
+      try {
+        const result = await getKindleConfigServerFn();
+        if (cancelled) return;
+        if (result.configured) {
+          setStoredEmail(result.email);
+          setEmail(result.email);
+        }
+      } catch {
+        if (!cancelled) setLoadError(true);
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    }
+
+    void loadConfig();
+    return () => { cancelled = true; };
+  }, [configured]);
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await saveKindleConfigServerFn({ data: { email } });
+      toast.success("Kindle email saved");
+      setEditing(false);
+      void router.invalidate();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to save Kindle email");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handleRemove() {
+    setRemoving(true);
+    try {
+      await removeKindleConfigServerFn();
+      toast.success("Kindle email removed");
+      void router.invalidate();
+    } catch {
+      toast.error("Failed to remove Kindle email");
+    } finally {
+      setRemoving(false);
+    }
+  }
+
+  return (
+    <Card>
+      <CardHeader className="pb-2">
+        <CardTitle className="flex items-center gap-2 text-base">
+          Kindle
+          <Badge variant={configured && !editing ? "default" : "secondary"}>
+            {configured && !editing ? "Connected" : "Not configured"}
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {loading && (
+          <p className="text-sm text-muted-foreground flex items-center gap-2">
+            <Loader2 className="size-4 animate-spin" />
+            Loading...
+          </p>
+        )}
+
+        {loadError && (
+          <p className="text-sm text-destructive">Failed to load configuration</p>
+        )}
+
+        {!loading && !loadError && editing && (
+          <div className="space-y-3">
+            <div className="space-y-1">
+              <label className="text-sm text-muted-foreground">Kindle Email</label>
+              <Input
+                type="email"
+                value={email}
+                onChange={(e) => { setEmail(e.target.value); }}
+                placeholder="you@kindle.com"
+              />
+            </div>
+            <p className="text-xs text-muted-foreground">
+              Add your sender email address to your Kindle&apos;s Approved Personal Document E-mail List in your Amazon account settings.
+            </p>
+            <Button
+              onClick={() => { void handleSave(); }}
+              disabled={saving || !email.trim()}
+            >
+              {saving ? (
+                <>
+                  <Loader2 className="size-4 animate-spin mr-1" />
+                  Saving...
+                </>
+              ) : (
+                "Save"
+              )}
+            </Button>
+          </div>
+        )}
+
+        {!loading && !loadError && !editing && storedEmail && (
+          <>
+            <div className="space-y-1 text-sm">
+              <div className="flex gap-4">
+                <span className="text-muted-foreground">Kindle email:</span>
+                <span>{storedEmail}</span>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Button variant="outline" size="sm" onClick={() => { setEditing(true); }}>
+                Edit
+              </Button>
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => { void handleRemove(); }}
+                disabled={removing}
+              >
+                {removing ? "Removing..." : "Remove"}
+              </Button>
+            </div>
+          </>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/lib/server-fns/kindle.test.ts
+++ b/apps/web/src/lib/server-fns/kindle.test.ts
@@ -1,0 +1,363 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tanstack/react-start", () => ({
+  createServerFn: () => {
+    type Builder = {
+      inputValidator: (schema: object) => Builder;
+      handler: <T extends Record<string, string | number | boolean | null | string[] | Date | undefined>>(fn: (a: T) => T | Promise<T>) => (a: T) => T | Promise<T>;
+    };
+    const b: Builder = {
+      inputValidator: () => b,
+      handler: (fn) => (a) => fn(a),
+    };
+    return b;
+  },
+}));
+
+const mockFindUnique = vi.fn();
+const mockFindMany = vi.fn();
+const mockUpsert = vi.fn();
+const mockDeleteMany = vi.fn();
+
+vi.mock("@bookhouse/db", () => ({
+  db: {
+    appSetting: {
+      findUnique: mockFindUnique,
+      findMany: mockFindMany,
+      upsert: mockUpsert,
+      deleteMany: mockDeleteMany,
+    },
+    editionFile: {
+      findUnique: mockFindUnique,
+    },
+  },
+}));
+
+vi.mock("@bookhouse/auth", () => ({
+  loadAuthConfig: () => ({ secret: "a]1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d" }),
+}));
+
+const mockSendMail = vi.fn();
+const mockCreateTransport = vi.fn(() => ({
+  sendMail: mockSendMail,
+}));
+
+vi.mock("nodemailer", () => ({
+  createTransport: mockCreateTransport,
+}));
+
+const mockGetDecryptedSmtpConfig = vi.fn();
+vi.mock("./smtp", () => ({
+  getDecryptedSmtpConfig: mockGetDecryptedSmtpConfig,
+}));
+
+import {
+  KINDLE_COMPATIBLE_MEDIA_KINDS,
+  KINDLE_MAX_FILE_SIZE,
+  getKindleStatusServerFn,
+  getKindleConfigServerFn,
+  saveKindleConfigServerFn,
+  removeKindleConfigServerFn,
+  sendToKindleServerFn,
+} from "./kindle";
+
+describe("kindle server functions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("constants", () => {
+    it("exports Kindle-compatible media kinds", () => {
+      expect(KINDLE_COMPATIBLE_MEDIA_KINDS).toEqual(new Set(["EPUB", "PDF"]));
+    });
+
+    it("exports 50 MB max file size", () => {
+      expect(KINDLE_MAX_FILE_SIZE).toBe(50 * 1024 * 1024);
+    });
+  });
+
+  describe("getKindleStatusServerFn", () => {
+    it("returns configured false when no kindle:email exists", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const result = await getKindleStatusServerFn({} as never);
+
+      expect(result).toEqual({ configured: false });
+      expect(mockFindUnique).toHaveBeenCalledWith({ where: { key: "kindle:email" } });
+    });
+
+    it("returns configured true when kindle:email exists", async () => {
+      mockFindUnique.mockResolvedValue({ key: "kindle:email", value: "me@kindle.com" });
+
+      const result = await getKindleStatusServerFn({} as never);
+
+      expect(result).toEqual({ configured: true });
+    });
+  });
+
+  describe("getKindleConfigServerFn", () => {
+    it("returns configured false when no setting exists", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      const result = await getKindleConfigServerFn({} as never);
+
+      expect(result).toEqual({ configured: false });
+    });
+
+    it("returns configured true with email when setting exists", async () => {
+      mockFindUnique.mockResolvedValue({ key: "kindle:email", value: "me@kindle.com" });
+
+      const result = await getKindleConfigServerFn({} as never);
+
+      expect(result).toEqual({ configured: true, email: "me@kindle.com" });
+    });
+  });
+
+  describe("saveKindleConfigServerFn", () => {
+    it("upserts the kindle:email setting", async () => {
+      await saveKindleConfigServerFn({
+        data: { email: "me@kindle.com" },
+      });
+
+      expect(mockUpsert).toHaveBeenCalledWith({
+        where: { key: "kindle:email" },
+        create: { key: "kindle:email", value: "me@kindle.com" },
+        update: { value: "me@kindle.com" },
+      });
+    });
+
+    it("returns saved true", async () => {
+      const result = await saveKindleConfigServerFn({
+        data: { email: "me@kindle.com" },
+      });
+
+      expect(result).toEqual({ saved: true });
+    });
+  });
+
+  describe("removeKindleConfigServerFn", () => {
+    it("deletes the kindle:email setting", async () => {
+      mockDeleteMany.mockResolvedValue({ count: 1 });
+
+      const result = await removeKindleConfigServerFn({} as never);
+
+      expect(result).toEqual({ removed: true });
+      expect(mockDeleteMany).toHaveBeenCalledWith({
+        where: { key: { in: ["kindle:email"] } },
+      });
+    });
+  });
+
+  describe("sendToKindleServerFn", () => {
+    const smtpConfig = {
+      host: "mail.smtp2go.com",
+      port: 587,
+      username: "user@example.com",
+      password: "secret123",
+      fromAddress: "books@example.com",
+      security: "starttls" as const,
+    };
+
+    function mockEditionFile(overrides: Record<string, string | bigint> = {}) {
+      return {
+        id: "ef1",
+        fileAsset: {
+          absolutePath: "/books/wind.epub",
+          basename: "wind.epub",
+          mediaKind: "EPUB",
+          availabilityStatus: "PRESENT",
+          sizeBytes: BigInt(2400000),
+          ...overrides,
+        },
+      };
+    }
+
+    it("sends an EPUB file with empty subject using path attachment", async () => {
+      mockFindUnique
+        .mockResolvedValueOnce(mockEditionFile())
+        .mockResolvedValueOnce({ key: "kindle:email", value: "me@kindle.com" });
+      mockGetDecryptedSmtpConfig.mockResolvedValue(smtpConfig);
+      mockSendMail.mockResolvedValue({ messageId: "abc" });
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockSendMail).toHaveBeenCalledWith({
+        from: "books@example.com",
+        to: "me@kindle.com",
+        subject: "",
+        text: "Sent via Bookhouse",
+        attachments: [{ filename: "wind.epub", path: "/books/wind.epub", contentType: "application/epub+zip" }],
+      });
+    });
+
+    it("sends a PDF file with CONVERT subject using path attachment", async () => {
+      mockFindUnique
+        .mockResolvedValueOnce(mockEditionFile({ mediaKind: "PDF", basename: "wind.pdf", absolutePath: "/books/wind.pdf" }))
+        .mockResolvedValueOnce({ key: "kindle:email", value: "me@kindle.com" });
+      mockGetDecryptedSmtpConfig.mockResolvedValue(smtpConfig);
+      mockSendMail.mockResolvedValue({ messageId: "abc" });
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({ success: true });
+      expect(mockSendMail).toHaveBeenCalledWith(
+        expect.objectContaining({
+          subject: "CONVERT",
+          text: "Sent via Bookhouse",
+          attachments: [{ filename: "wind.pdf", path: "/books/wind.pdf", contentType: "application/pdf" }],
+        }),
+      );
+    });
+
+    it("returns error when edition file not found", async () => {
+      mockFindUnique.mockResolvedValueOnce(null);
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef-missing" },
+      });
+
+      expect(result).toEqual({ success: false, error: "File not found" });
+    });
+
+    it("returns error when file is not PRESENT", async () => {
+      mockFindUnique.mockResolvedValueOnce(mockEditionFile({ availabilityStatus: "MISSING" }));
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({ success: false, error: "File is not available on disk" });
+    });
+
+    it("returns error when mediaKind is CBZ", async () => {
+      mockFindUnique.mockResolvedValueOnce(mockEditionFile({ mediaKind: "CBZ" }));
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({ success: false, error: "This file format is not supported by Kindle" });
+    });
+
+    it("returns error when mediaKind is AUDIO", async () => {
+      mockFindUnique.mockResolvedValueOnce(mockEditionFile({ mediaKind: "AUDIO" }));
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({ success: false, error: "This file format is not supported by Kindle" });
+    });
+
+    it("returns error when file exceeds 50 MB", async () => {
+      mockFindUnique.mockResolvedValueOnce(
+        mockEditionFile({ sizeBytes: BigInt(51 * 1024 * 1024) }),
+      );
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({ success: false, error: "File exceeds Kindle's 50 MB limit" });
+    });
+
+    it("returns error when Kindle is not configured", async () => {
+      mockFindUnique
+        .mockResolvedValueOnce(mockEditionFile())
+        .mockResolvedValueOnce(null);
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: "Kindle email is not configured. Set it up in Settings > Integrations.",
+      });
+    });
+
+    it("returns error when SMTP is not configured", async () => {
+      mockFindUnique
+        .mockResolvedValueOnce(mockEditionFile())
+        .mockResolvedValueOnce({ key: "kindle:email", value: "me@kindle.com" });
+      mockGetDecryptedSmtpConfig.mockResolvedValue(null);
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({
+        success: false,
+        error: "SMTP is not configured. Set it up in Settings > Integrations.",
+      });
+    });
+
+    it("returns error when sendMail fails", async () => {
+      mockFindUnique
+        .mockResolvedValueOnce(mockEditionFile())
+        .mockResolvedValueOnce({ key: "kindle:email", value: "me@kindle.com" });
+      mockGetDecryptedSmtpConfig.mockResolvedValue(smtpConfig);
+      mockSendMail.mockRejectedValue(new Error("Rejected by server"));
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({ success: false, error: "Rejected by server" });
+    });
+
+    it("returns Unknown error for non-Error exceptions", async () => {
+      mockFindUnique
+        .mockResolvedValueOnce(mockEditionFile())
+        .mockResolvedValueOnce({ key: "kindle:email", value: "me@kindle.com" });
+      mockGetDecryptedSmtpConfig.mockResolvedValue(smtpConfig);
+      mockSendMail.mockRejectedValue("string-error");
+
+      const result = await sendToKindleServerFn({
+        data: { editionFileId: "ef1" },
+      });
+
+      expect(result).toEqual({ success: false, error: "Unknown error" });
+    });
+
+    it("creates transport with correct options for starttls", async () => {
+      mockFindUnique
+        .mockResolvedValueOnce(mockEditionFile())
+        .mockResolvedValueOnce({ key: "kindle:email", value: "me@kindle.com" });
+      mockGetDecryptedSmtpConfig.mockResolvedValue(smtpConfig);
+      mockSendMail.mockResolvedValue({ messageId: "abc" });
+
+      await sendToKindleServerFn({ data: { editionFileId: "ef1" } });
+
+      expect(mockCreateTransport).toHaveBeenCalledWith({
+        host: "mail.smtp2go.com",
+        port: 587,
+        secure: false,
+        auth: { user: "user@example.com", pass: "secret123" },
+        requireTLS: true,
+      });
+    });
+
+    it("creates transport with secure:true for tls", async () => {
+      mockFindUnique
+        .mockResolvedValueOnce(mockEditionFile())
+        .mockResolvedValueOnce({ key: "kindle:email", value: "me@kindle.com" });
+      mockGetDecryptedSmtpConfig.mockResolvedValue({ ...smtpConfig, security: "tls", port: 465 });
+      mockSendMail.mockResolvedValue({ messageId: "abc" });
+
+      await sendToKindleServerFn({ data: { editionFileId: "ef1" } });
+
+      expect(mockCreateTransport).toHaveBeenCalledWith({
+        host: "mail.smtp2go.com",
+        port: 465,
+        secure: true,
+        auth: { user: "user@example.com", pass: "secret123" },
+      });
+    });
+  });
+});

--- a/apps/web/src/lib/server-fns/kindle.ts
+++ b/apps/web/src/lib/server-fns/kindle.ts
@@ -1,0 +1,140 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+export const KINDLE_COMPATIBLE_MEDIA_KINDS = new Set(["EPUB", "PDF"]);
+export const KINDLE_MAX_FILE_SIZE = 50 * 1024 * 1024; // 50 MB
+
+export const getKindleStatusServerFn = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  const { db } = await import("@bookhouse/db");
+  const setting = await db.appSetting.findUnique({ where: { key: "kindle:email" } });
+  return { configured: setting !== null };
+});
+
+export const getKindleConfigServerFn = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  const { db } = await import("@bookhouse/db");
+  const setting = await db.appSetting.findUnique({ where: { key: "kindle:email" } });
+  if (!setting) return { configured: false as const };
+
+  return {
+    configured: true as const,
+    email: setting.value,
+  };
+});
+
+const saveKindleConfigSchema = z.object({
+  email: z.string().email().regex(/@kindle\.com$/i, "Must be a @kindle.com address"),
+});
+
+export const saveKindleConfigServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(saveKindleConfigSchema)
+  .handler(async ({ data }) => {
+    const { db } = await import("@bookhouse/db");
+
+    await db.appSetting.upsert({
+      where: { key: "kindle:email" },
+      create: { key: "kindle:email", value: data.email },
+      update: { value: data.email },
+    });
+
+    return { saved: true };
+  });
+
+export const removeKindleConfigServerFn = createServerFn({
+  method: "POST",
+}).handler(async () => {
+  const { db } = await import("@bookhouse/db");
+  await db.appSetting.deleteMany({
+    where: { key: { in: ["kindle:email"] } },
+  });
+  return { removed: true };
+});
+
+const sendToKindleSchema = z.object({
+  editionFileId: z.string(),
+});
+
+export const sendToKindleServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(sendToKindleSchema)
+  .handler(async ({ data }) => {
+    const { db } = await import("@bookhouse/db");
+
+    const editionFile = await db.editionFile.findUnique({
+      where: { id: data.editionFileId },
+      include: { fileAsset: true },
+    });
+
+    if (!editionFile) {
+      return { success: false, error: "File not found" };
+    }
+
+    const { fileAsset } = editionFile;
+
+    if (!KINDLE_COMPATIBLE_MEDIA_KINDS.has(fileAsset.mediaKind)) {
+      return { success: false, error: "This file format is not supported by Kindle" };
+    }
+
+    if (fileAsset.availabilityStatus !== "PRESENT") {
+      return { success: false, error: "File is not available on disk" };
+    }
+
+    if (fileAsset.sizeBytes !== null && Number(fileAsset.sizeBytes) > KINDLE_MAX_FILE_SIZE) {
+      return { success: false, error: "File exceeds Kindle's 50 MB limit" };
+    }
+
+    const kindleSetting = await db.appSetting.findUnique({ where: { key: "kindle:email" } });
+    if (!kindleSetting) {
+      return { success: false, error: "Kindle email is not configured. Set it up in Settings > Integrations." };
+    }
+
+    const { getDecryptedSmtpConfig } = await import("./smtp");
+    const smtpConfig = await getDecryptedSmtpConfig();
+    if (!smtpConfig) {
+      return { success: false, error: "SMTP is not configured. Set it up in Settings > Integrations." };
+    }
+
+    const subject = fileAsset.mediaKind === "PDF" ? "CONVERT" : "";
+    const contentType = fileAsset.mediaKind === "PDF" ? "application/pdf" : "application/epub+zip";
+
+    try {
+      const nodemailer = await import("nodemailer");
+
+      const transportOptions: {
+        host: string;
+        port: number;
+        secure: boolean;
+        auth: { user: string; pass: string };
+        requireTLS?: boolean;
+      } = {
+        host: smtpConfig.host,
+        port: smtpConfig.port,
+        secure: smtpConfig.security === "tls",
+        auth: { user: smtpConfig.username, pass: smtpConfig.password },
+      };
+
+      if (smtpConfig.security === "starttls") {
+        transportOptions.requireTLS = true;
+      }
+
+      const transport = nodemailer.createTransport(transportOptions);
+      await transport.sendMail({
+        from: smtpConfig.fromAddress,
+        to: kindleSetting.value,
+        subject,
+        text: "Sent via Bookhouse",
+        attachments: [{ filename: fileAsset.basename, path: fileAsset.absolutePath, contentType }],
+      });
+
+      return { success: true };
+    } catch (error) {
+      const message = error instanceof Error ? error.message : "Unknown error";
+      return { success: false, error: message };
+    }
+  });

--- a/apps/web/src/routes/_authenticated/-library.$workId.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.$workId.test.tsx
@@ -47,7 +47,7 @@ interface MockProgress {
   percent: number | null;
 }
 
-let mockLoaderData: { work: MockWork; progress: MockProgress[]; trackingMode: string; contributorNames: string[] } = {
+let mockLoaderData: { work: MockWork; progress: MockProgress[]; trackingMode: string; contributorNames: string[]; smtpConfigured: boolean; kindleConfigured: boolean } = {
   work: {
     id: "work-1",
     titleDisplay: "The Name of the Wind",
@@ -92,6 +92,8 @@ let mockLoaderData: { work: MockWork; progress: MockProgress[]; trackingMode: st
   progress: [],
   trackingMode: "BY_EDITION",
   contributorNames: ["Patrick Rothfuss", "Brandon Sanderson"],
+  smtpConfigured: false,
+  kindleConfigured: false,
 };
 
 const mockNavigate = vi.fn();
@@ -184,6 +186,15 @@ vi.mock("~/lib/server-fns/tags", () => ({
   updateWorkTagsServerFn: vi.fn(),
 }));
 
+vi.mock("~/lib/server-fns/smtp", () => ({
+  getSmtpStatusServerFn: vi.fn().mockResolvedValue({ configured: false }),
+}));
+
+vi.mock("~/lib/server-fns/kindle", () => ({
+  getKindleStatusServerFn: vi.fn().mockResolvedValue({ configured: false }),
+  sendToKindleServerFn: vi.fn(),
+}));
+
 const mockFetch = vi.fn();
 globalThis.fetch = mockFetch;
 
@@ -238,7 +249,7 @@ vi.mock("~/components/ui/tabs", () => ({
 let capturedEditionFieldSavedCallbacks: Record<string, () => void> = {};
 
 vi.mock("~/components/edition-tab-panel", () => ({
-  EditionTabPanel: ({ edition, onDeleteEdition, onEditionFieldSaved }: { edition: { id: string; formatFamily: string }; onDeleteEdition: () => void; onEditionFieldSaved: () => void }) => {
+  EditionTabPanel: ({ edition, onDeleteEdition, onEditionFieldSaved }: { edition: { id: string; formatFamily: string }; onDeleteEdition: () => void; onEditionFieldSaved: () => void; smtpConfigured: boolean; kindleConfigured: boolean }) => {
     capturedEditionFieldSavedCallbacks[edition.id] = onEditionFieldSaved;
     return (
       <div data-testid={`edition-panel-${edition.id}`} data-format={edition.formatFamily}>
@@ -304,6 +315,8 @@ describe("WorkDetailPage", () => {
       progress: [],
       trackingMode: "BY_EDITION",
       contributorNames: ["Patrick Rothfuss", "Brandon Sanderson"],
+      smtpConfigured: false,
+      kindleConfigured: false,
     };
     capturedDialogProps.length = 0;
     forceRenderClosed = false;
@@ -332,6 +345,8 @@ describe("WorkDetailPage", () => {
       progress: [],
       trackingMode: "BY_EDITION",
       contributorNames: [],
+      smtpConfigured: false,
+      kindleConfigured: false,
     });
   });
 

--- a/apps/web/src/routes/_authenticated/library.$workId.tsx
+++ b/apps/web/src/routes/_authenticated/library.$workId.tsx
@@ -34,17 +34,21 @@ import { deleteWorkServerFn, deleteEditionServerFn } from "~/lib/server-fns/dele
 import { EditableField } from "~/components/editable-field";
 import { EditableTagField } from "~/components/editable-tag-field";
 import { updateWorkServerFn, updateWorkAuthorsServerFn, getContributorNamesServerFn } from "~/lib/server-fns/editing";
+import { getSmtpStatusServerFn } from "~/lib/server-fns/smtp";
+import { getKindleStatusServerFn } from "~/lib/server-fns/kindle";
 import { updateWorkTagsServerFn } from "~/lib/server-fns/tags";
 import { useAppColor } from "~/hooks/use-app-color";
 
 export const Route = createFileRoute("/_authenticated/library/$workId")({
   loader: async ({ params }) => {
-    const [work, { progress, trackingMode }, contributorNames] = await Promise.all([
+    const [work, { progress, trackingMode }, contributorNames, smtpStatus, kindleStatus] = await Promise.all([
       getWorkDetailServerFn({ data: { workId: params.workId } }),
       getReadingProgressServerFn({ data: { workId: params.workId } }),
       getContributorNamesServerFn(),
+      getSmtpStatusServerFn(),
+      getKindleStatusServerFn(),
     ]);
-    return { work, progress, trackingMode, contributorNames };
+    return { work, progress, trackingMode, contributorNames, smtpConfigured: smtpStatus.configured, kindleConfigured: kindleStatus.configured };
   },
   pendingComponent: WorkDetailSkeleton,
   component: WorkDetailPage,
@@ -82,7 +86,7 @@ function getAuthors(work: WorkDetail): { id: string; name: string }[] {
 
 
 function WorkDetailPage() {
-  const { work, progress, trackingMode, contributorNames } = Route.useLoaderData();
+  const { work, progress, trackingMode, contributorNames, smtpConfigured, kindleConfigured } = Route.useLoaderData();
   const router = useRouter();
   const [imgFailed, setImgFailed] = useState(false);
   const [deleteWorkOpen, setDeleteWorkOpen] = useState(false);
@@ -374,6 +378,8 @@ function WorkDetailPage() {
                   isLastEdition={work.editions.length === 1}
                   onEditionFieldSaved={() => { void router.invalidate(); }}
                   onDeleteEdition={() => { setDeleteEditionOpen(edition.id); }}
+                  smtpConfigured={smtpConfigured}
+                  kindleConfigured={kindleConfigured}
                 />
               </TabsContent>
             ))}

--- a/apps/web/src/routes/_authenticated/settings/-index.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-index.test.tsx
@@ -31,7 +31,8 @@ let mockLoaderData: {
   integrations: Record<string, { configured: boolean; label: string }>;
   backupHistory: { version: number; timestamp: string; databaseSize: number; coverCount: number; coverSize: number }[];
   smtpStatus: { configured: boolean };
-} = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false } };
+  kindleStatus: { configured: boolean };
+} = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false } };
 
 const getLibraryRootsServerFnMock = vi.fn();
 const scanLibraryRootServerFnMock = vi.fn();
@@ -90,6 +91,13 @@ vi.mock("~/lib/server-fns/smtp", () => ({
   saveSmtpConfigServerFn: vi.fn().mockResolvedValue({ saved: true }),
   removeSmtpConfigServerFn: vi.fn().mockResolvedValue({ removed: true }),
   testSmtpConnectionServerFn: vi.fn().mockResolvedValue({ success: true }),
+}));
+
+vi.mock("~/lib/server-fns/kindle", () => ({
+  getKindleStatusServerFn: vi.fn().mockResolvedValue({ configured: false }),
+  getKindleConfigServerFn: vi.fn().mockResolvedValue({ configured: false }),
+  saveKindleConfigServerFn: vi.fn().mockResolvedValue({ saved: true }),
+  removeKindleConfigServerFn: vi.fn().mockResolvedValue({ removed: true }),
 }));
 
 vi.mock("~/lib/mutation", () => ({
@@ -213,7 +221,7 @@ const makeJob = (overrides: Partial<{
 describe("SettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false } };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false } };
     mockTheme = "system";
     mockColorMode = "book";
     mockAccentColor = null;
@@ -529,6 +537,7 @@ describe("SettingsPage", () => {
       },
       backupHistory: [],
       smtpStatus: { configured: false },
+      kindleStatus: { configured: false },
     });
   });
 
@@ -782,7 +791,7 @@ describe("SettingsPage", () => {
 describe("AppearanceCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false } };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false } };
     mockTheme = "system";
     mockColorMode = "book";
     mockAccentColor = null;
@@ -851,7 +860,7 @@ describe("AppearanceCard", () => {
 describe("ColorCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false } };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false } };
     mockTheme = "system";
     mockColorMode = "book";
     mockAccentColor = null;
@@ -1028,7 +1037,7 @@ describe("ColorCard", () => {
 describe("JobsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false } };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false } };
     mockTheme = "system";
     mockColorMode = "book";
     mockAccentColor = null;
@@ -1126,7 +1135,7 @@ describe("JobsTab", () => {
 
     const input = screen.getByDisplayValue("8");
     fireEvent.change(input, { target: { value: "12" } });
-    expect(screen.getByText("Save")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Save concurrency" })).toBeTruthy();
   });
 
   it("calls setScanConcurrencyServerFn for each changed value when Save is clicked", async () => {
@@ -1136,7 +1145,7 @@ describe("JobsTab", () => {
 
     const fullInput = screen.getByDisplayValue("8");
     fireEvent.change(fullInput, { target: { value: "12" } });
-    const saveBtn = screen.getByText("Save");
+    const saveBtn = screen.getByRole("button", { name: "Save concurrency" });
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
@@ -1323,7 +1332,7 @@ describe("Integrations Tab", () => {
     fireEvent.click(screen.getByRole("tab", { name: "Integrations" }));
 
     expect(screen.getByText("Connected")).toBeTruthy();
-    expect(screen.getAllByText("Not configured")).toHaveLength(3);
+    expect(screen.getAllByText("Not configured")).toHaveLength(4);
   });
 
   it("shows no API key required for Open Library", async () => {

--- a/apps/web/src/routes/_authenticated/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/settings/index.tsx
@@ -70,6 +70,7 @@ import {
   recordBackupServerFn,
 } from "~/lib/server-fns/backup";
 import { getSmtpStatusServerFn } from "~/lib/server-fns/smtp";
+import { getKindleStatusServerFn } from "~/lib/server-fns/kindle";
 import {
   getImportJobsServerFn,
   stopAllJobsServerFn,
@@ -78,6 +79,7 @@ import {
 import { runMutation } from "~/lib/mutation";
 import { BackupTab } from "~/components/settings/backup-tab";
 import { SmtpConfigCard } from "~/components/settings/smtp-config-card";
+import { KindleConfigCard } from "~/components/settings/kindle-config-card";
 import type { BackupManifest } from "~/lib/backup/manifest";
 
 export interface LibraryRootWithExtras extends LibraryRootRow {
@@ -87,7 +89,7 @@ export interface LibraryRootWithExtras extends LibraryRootRow {
 
 export const Route = createFileRoute("/_authenticated/settings/")({
   loader: async () => {
-    const [roots, missingFileBehavior, jobsResult, concurrencies, integrations, backupHistory, smtpStatus] = await Promise.all([
+    const [roots, missingFileBehavior, jobsResult, concurrencies, integrations, backupHistory, smtpStatus, kindleStatus] = await Promise.all([
       getLibraryRootsServerFn(),
       getMissingFileBehaviorServerFn(),
       getImportJobsServerFn({ data: { page: 1, pageSize: 100 } }),
@@ -95,6 +97,7 @@ export const Route = createFileRoute("/_authenticated/settings/")({
       getIntegrationStatusServerFn(),
       getBackupHistoryServerFn(),
       getSmtpStatusServerFn(),
+      getKindleStatusServerFn(),
     ]);
     const rootsWithExtras: LibraryRootWithExtras[] = await Promise.all(
       roots.map(async (root) => {
@@ -114,6 +117,7 @@ export const Route = createFileRoute("/_authenticated/settings/")({
       integrations,
       backupHistory,
       smtpStatus,
+      kindleStatus,
     };
   },
   pendingComponent: SettingsSkeleton,
@@ -133,7 +137,7 @@ function SettingsSkeleton() {
 }
 
 function SettingsPage() {
-  const { roots, missingFileBehavior, jobs, totalCount, concurrencies, integrations, backupHistory: initialBackupHistory, smtpStatus } = Route.useLoaderData();
+  const { roots, missingFileBehavior, jobs, totalCount, concurrencies, integrations, backupHistory: initialBackupHistory, smtpStatus, kindleStatus } = Route.useLoaderData();
   const [backupHistory, setBackupHistory] = useState(initialBackupHistory);
 
   const handleBackupComplete = async (manifest: BackupManifest) => {
@@ -178,7 +182,7 @@ function SettingsPage() {
         </TabsContent>
 
         <TabsContent value="integrations" forceMount className="space-y-6 data-[state=inactive]:hidden">
-          <IntegrationsTab integrations={integrations} smtpConfigured={smtpStatus.configured} />
+          <IntegrationsTab integrations={integrations} smtpConfigured={smtpStatus.configured} kindleConfigured={kindleStatus.configured} />
         </TabsContent>
 
         <TabsContent value="backup" forceMount className="space-y-6 data-[state=inactive]:hidden">
@@ -528,6 +532,7 @@ function JobsTab({
               <Button
                 size="sm"
                 variant="outline"
+                aria-label="Save concurrency"
                 onClick={() => void handleSaveConcurrency()}
                 disabled={savingConcurrency}
               >
@@ -872,9 +877,11 @@ type IntegrationStatus = { configured: boolean; label: string };
 function IntegrationsTab({
   integrations,
   smtpConfigured,
+  kindleConfigured,
 }: {
   integrations: Record<string, IntegrationStatus>;
   smtpConfigured: boolean;
+  kindleConfigured: boolean;
 }) {
   return (
     <>
@@ -887,6 +894,7 @@ function IntegrationsTab({
         ))}
       </div>
       <SmtpConfigCard configured={smtpConfigured} />
+      <KindleConfigCard configured={kindleConfigured} />
     </>
   );
 }


### PR DESCRIPTION
## Summary

- Adds a **Send to Kindle** button on each compatible edition file (EPUB and PDF only — audiobooks and CBZ unsupported)
- Kindle email address configured in Settings > Integrations > Kindle, validated to `@kindle.com`
- PDFs use `CONVERT` as the subject to enable Kindle font resizing/annotations
- Uses existing SMTP infrastructure; email sent as `multipart/mixed` with a non-empty text body so Amazon's parser finds the attachment

## Root cause note

Amazon's Kindle service requires attachments inside a `multipart/mixed` envelope. Without a non-empty `text` body, nodemailer sends the file as the raw email body (`Content-Type: application/epub+zip`) with no multipart wrapper — Amazon receives the email but reports E009 "No Attachment". Adding `text: "Sent via Bookhouse"` forces the correct structure.

Closes #137