### PR TITLE
Exclude test files from GitGuardian secret scanning

### DIFF
--- a/.gitguardian.yaml
+++ b/.gitguardian.yaml
@@ -1,0 +1,3 @@
+ignore-paths:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"


### PR DESCRIPTION
Test fixtures use obvious placeholder values like `secret123` which trigger false positives. Test files are not a source of real credentials.