### PR TITLE
Move global search to center header and debounce library filter

### DIFF
--- a/apps/web/src/components/app-header.tsx
+++ b/apps/web/src/components/app-header.tsx
@@ -22,10 +22,10 @@ export function AppHeader() {
     <header className="flex h-16 shrink-0 items-center gap-2 border-b px-4">
       <SidebarTrigger className="-ml-1" />
       <Separator orientation="vertical" className="mr-2 h-4" />
-      <div className="ml-auto flex items-center gap-2">
-        <ThemeToggle />
+      <div className="flex flex-1 justify-center">
         <GlobalSearch />
       </div>
+      <ThemeToggle />
     </header>
   );
 }

--- a/apps/web/src/components/global-search.tsx
+++ b/apps/web/src/components/global-search.tsx
@@ -68,7 +68,7 @@ export function GlobalSearch() {
         size="sm"
         onClick={() => { setOpen(true); }}
         aria-label="Search library"
-        className="gap-2"
+        className="w-full max-w-md justify-start gap-2"
       >
         <Search className="size-4" />
         <span className="hidden text-muted-foreground sm:inline">Search...</span>

--- a/apps/web/src/components/library-toolbar.test.tsx
+++ b/apps/web/src/components/library-toolbar.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment happy-dom
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { describe, it, expect, vi } from "vitest";
 import { LibraryToolbar, type SortValue } from "./library-toolbar";
@@ -23,15 +23,17 @@ const defaultProps = {
 describe("LibraryToolbar", () => {
   it("renders search input with placeholder", () => {
     render(<LibraryToolbar {...defaultProps} />);
-    expect(screen.getByPlaceholderText("Search title or author...")).toBeTruthy();
+    expect(screen.getByPlaceholderText("Filter by title or author...")).toBeTruthy();
   });
 
-  it("calls onSearchChange when typing in search input", async () => {
+  it("calls onSearchChange after debounce when typing in search input", async () => {
     const onSearchChange = vi.fn();
     const user = userEvent.setup();
     render(<LibraryToolbar {...defaultProps} onSearchChange={onSearchChange} />);
-    await user.type(screen.getByPlaceholderText("Search title or author..."), "hello");
-    expect(onSearchChange).toHaveBeenCalled();
+    await user.type(screen.getByPlaceholderText("Filter by title or author..."), "hello");
+    await waitFor(() => {
+      expect(onSearchChange).toHaveBeenCalledWith("hello");
+    });
   });
 
   it("shows clear button when searchValue is non-empty", () => {
@@ -49,7 +51,9 @@ describe("LibraryToolbar", () => {
     const user = userEvent.setup();
     render(<LibraryToolbar {...defaultProps} searchValue="test" onSearchChange={onSearchChange} />);
     await user.click(screen.getByLabelText("Clear search"));
-    expect(onSearchChange).toHaveBeenCalledWith("");
+    await waitFor(() => {
+      expect(onSearchChange).toHaveBeenCalledWith("");
+    });
   });
 
   it("renders sort and filter select triggers", () => {

--- a/apps/web/src/components/library-toolbar.tsx
+++ b/apps/web/src/components/library-toolbar.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from "react";
 import { Grid2x2, Grid3x3, LayoutGrid, Table2, X } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import { Input } from "~/components/ui/input";
+import { useDebounce } from "~/hooks/use-debounce";
 import {
   Select,
   SelectContent,
@@ -58,19 +60,30 @@ export function LibraryToolbar({
   tileSize,
   onTileSizeChange,
 }: LibraryToolbarProps) {
+  const [localSearch, setLocalSearch] = useState(searchValue);
+  const debouncedSearch = useDebounce(localSearch, 300);
+
+  useEffect(() => {
+    onSearchChange(debouncedSearch);
+  }, [debouncedSearch, onSearchChange]);
+
+  useEffect(() => {
+    setLocalSearch(searchValue);
+  }, [searchValue]);
+
   return (
     <div className="flex items-center justify-between gap-2">
       <div className="flex flex-1 items-center gap-2">
         <Input
-          placeholder="Search title or author..."
-          value={searchValue}
-          onChange={(e) => { onSearchChange(e.target.value); }}
+          placeholder="Filter by title or author..."
+          value={localSearch}
+          onChange={(e) => { setLocalSearch(e.target.value); }}
           className="h-8 w-[150px] lg:w-[250px]"
         />
-        {searchValue && (
+        {localSearch && (
           <Button
             variant="ghost"
-            onClick={() => { onSearchChange(""); }}
+            onClick={() => { setLocalSearch(""); }}
             className="h-8 px-2"
             aria-label="Clear search"
           >


### PR DESCRIPTION
## Summary
- Repositions the global search from top-right to top-center of the app header and widens the trigger button for better discoverability
- Adds local state + 300ms debounce to the library toolbar filter input, preventing dropped keystrokes when the backend can't keep up with per-character URL navigations
- Updates filter placeholder text from "Search title or author..." to "Filter by title or author..." to better reflect its purpose

## Test plan
- Verified all 2430 tests pass with 100% coverage
- Lint and typecheck clean