### PR TITLE
Add Kobo two-way reading progress sync

### DIFF
--- a/apps/web/server/routes/kobo/[token]/v1/library/[bookId]/state.test.ts
+++ b/apps/web/server/routes/kobo/[token]/v1/library/[bookId]/state.test.ts
@@ -1,0 +1,308 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createStateHandler } from "./state";
+import type { StateHandlerDeps } from "./state";
+import type { H3Event } from "h3";
+import type { ReadingProgressRecord, KoboLocation, KoboReadingState, KoboRequestResult } from "@bookhouse/kobo";
+
+const validToken = "a".repeat(64);
+
+const mockDevice = {
+  id: "d1",
+  userId: "u1",
+  deviceId: "My Kobo",
+  userKey: "key",
+  authToken: validToken,
+  status: "ACTIVE",
+  lastSyncAt: null,
+  createdAt: new Date("2024-01-01"),
+};
+
+const NOW = new Date("2024-07-01T12:00:00.000Z");
+
+const mockLocation: KoboLocation = {
+  Source: "OEBPS/xhtml/chapter01.xhtml",
+  Type: "KoboSpan",
+  Value: "kobo.1.1",
+};
+
+const mockProgress: ReadingProgressRecord = {
+  id: "rp-1",
+  userId: "u1",
+  editionId: "ed-1",
+  progressKind: "EBOOK",
+  locator: { koboLocation: mockLocation },
+  percent: 42,
+  source: "kobo",
+  updatedAt: NOW,
+};
+
+// Actual payload format sent by Kobo devices
+const validPayload = {
+  ReadingStates: [{
+    EntitlementId: "ed-1",
+    LastModified: "2024-07-01T13:00:00.000Z",
+    StatusInfo: {
+      Status: "Reading",
+      LastModified: "2024-07-01T13:00:00.000Z",
+    },
+    CurrentBookmark: {
+      ProgressPercent: 55,
+      LastModified: "2024-07-01T13:00:00.000Z",
+      Location: {
+        Source: "OEBPS/xhtml/chapter02.xhtml",
+        Type: "KoboSpan",
+        Value: "kobo.2.1",
+      },
+    },
+    Statistics: {
+      LastModified: "2024-07-01T13:00:00.000Z",
+      SpentReadingMinutes: 16,
+      RemainingTimeMinutes: 555,
+    },
+  }],
+};
+
+function makeEvent(bookId = "ed-1"): H3Event {
+  return {
+    context: { params: { token: validToken, bookId } },
+  } as unknown as H3Event;
+}
+
+function makeDeps(overrides: Partial<StateHandlerDeps> = {}): StateHandlerDeps {
+  return {
+    auth: {
+      findDeviceByToken: vi.fn().mockResolvedValue(mockDevice),
+    },
+    findProgress: vi.fn().mockResolvedValue(null),
+    upsertProgress: vi.fn().mockResolvedValue(mockProgress),
+    getMethod: vi.fn().mockReturnValue("GET"),
+    readBody: vi.fn().mockResolvedValue({}),
+    ...overrides,
+  };
+}
+
+describe("createStateHandler", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("GET", () => {
+    it("returns array with default ReadyToRead when no progress exists", async () => {
+      const deps = makeDeps();
+      const handler = createStateHandler(deps);
+      const result = await handler(makeEvent()) as KoboReadingState[];
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(expect.objectContaining({
+        EntitlementId: "ed-1",
+        StatusInfo: expect.objectContaining({
+          Status: "ReadyToRead",
+          TimesStartedReading: 0,
+        }),
+      }));
+    });
+
+    it("returns array with formatted reading state when progress exists", async () => {
+      const deps = makeDeps({
+        findProgress: vi.fn().mockResolvedValue(mockProgress),
+      });
+      const handler = createStateHandler(deps);
+      const result = await handler(makeEvent()) as KoboReadingState[];
+
+      expect(Array.isArray(result)).toBe(true);
+      expect(result).toHaveLength(1);
+      expect(result[0]).toEqual(expect.objectContaining({
+        EntitlementId: "ed-1",
+        StatusInfo: expect.objectContaining({
+          Status: "Reading",
+          TimesStartedReading: 1,
+        }),
+        CurrentBookmark: expect.objectContaining({
+          ProgressPercent: 42,
+          Location: mockLocation,
+        }),
+      }));
+    });
+
+    it("throws 400 for invalid bookId", async () => {
+      const deps = makeDeps();
+      const handler = createStateHandler(deps);
+
+      try {
+        await handler(makeEvent("../../../etc"));
+        expect.fail("Should have thrown");
+      } catch (e) {
+        const err = e as Error & { statusCode: number };
+        expect(err.statusCode).toBe(400);
+      }
+    });
+
+    it("throws when auth fails", async () => {
+      const deps = makeDeps({
+        auth: { findDeviceByToken: vi.fn().mockResolvedValue(null) },
+      });
+      const handler = createStateHandler(deps);
+
+      await expect(handler(makeEvent())).rejects.toThrow();
+    });
+  });
+
+  describe("PUT", () => {
+    it("creates new progress and returns RequestResult", async () => {
+      const upsertProgress = vi.fn().mockResolvedValue(mockProgress);
+      const deps = makeDeps({
+        getMethod: vi.fn().mockReturnValue("PUT"),
+        readBody: vi.fn().mockResolvedValue(validPayload),
+        upsertProgress,
+      });
+      const handler = createStateHandler(deps);
+      const result = await handler(makeEvent()) as KoboRequestResult;
+
+      expect(upsertProgress).toHaveBeenCalledWith({
+        userId: "u1",
+        editionId: "ed-1",
+        percent: 55,
+        locator: { koboLocation: { Source: "OEBPS/xhtml/chapter02.xhtml", Type: "KoboSpan", Value: "kobo.2.1" } },
+        source: "kobo",
+      });
+      expect(result).toEqual({
+        RequestResult: "Success",
+        UpdateResults: [{
+          EntitlementId: "ed-1",
+          CurrentBookmarkResult: { Result: "Success" },
+          StatisticsResult: { Result: "Ignored" },
+          StatusInfoResult: { Result: "Success" },
+        }],
+      });
+    });
+
+    it("updates progress when device timestamp is newer", async () => {
+      const existingProgress: ReadingProgressRecord = {
+        ...mockProgress,
+        updatedAt: new Date("2024-07-01T10:00:00.000Z"),
+      };
+      const deps = makeDeps({
+        getMethod: vi.fn().mockReturnValue("PUT"),
+        readBody: vi.fn().mockResolvedValue(validPayload),
+        findProgress: vi.fn().mockResolvedValue(existingProgress),
+        upsertProgress: vi.fn().mockResolvedValue({ ...mockProgress, percent: 55 }),
+      });
+      const handler = createStateHandler(deps);
+      const result = await handler(makeEvent()) as KoboRequestResult;
+
+      expect(deps.upsertProgress).toHaveBeenCalled();
+      expect(result.RequestResult).toBe("Success");
+    });
+
+    it("skips save when server timestamp is newer", async () => {
+      const existingProgress: ReadingProgressRecord = {
+        ...mockProgress,
+        percent: 80,
+        updatedAt: new Date("2024-07-01T14:00:00.000Z"),
+      };
+      const deps = makeDeps({
+        getMethod: vi.fn().mockReturnValue("PUT"),
+        readBody: vi.fn().mockResolvedValue(validPayload),
+        findProgress: vi.fn().mockResolvedValue(existingProgress),
+      });
+      const handler = createStateHandler(deps);
+      const result = await handler(makeEvent()) as KoboRequestResult;
+
+      expect(deps.upsertProgress).not.toHaveBeenCalled();
+      expect(result.RequestResult).toBe("Success");
+    });
+
+    it("returns 400 for invalid PUT payload", async () => {
+      const deps = makeDeps({
+        getMethod: vi.fn().mockReturnValue("PUT"),
+        readBody: vi.fn().mockResolvedValue({ invalid: true }),
+      });
+      const handler = createStateHandler(deps);
+
+      try {
+        await handler(makeEvent());
+        expect.fail("Should have thrown");
+      } catch (e) {
+        const err = e as Error & { statusCode: number };
+        expect(err.statusCode).toBe(400);
+      }
+    });
+
+    it("sets source to kobo on upserted progress", async () => {
+      const upsertProgress = vi.fn().mockResolvedValue(mockProgress);
+      const deps = makeDeps({
+        getMethod: vi.fn().mockReturnValue("PUT"),
+        readBody: vi.fn().mockResolvedValue(validPayload),
+        upsertProgress,
+      });
+      const handler = createStateHandler(deps);
+      await handler(makeEvent());
+
+      expect(upsertProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ source: "kobo" }),
+      );
+    });
+
+    it("stores kobo location from device update in locator", async () => {
+      const upsertProgress = vi.fn().mockResolvedValue(mockProgress);
+      const deps = makeDeps({
+        getMethod: vi.fn().mockReturnValue("PUT"),
+        readBody: vi.fn().mockResolvedValue(validPayload),
+        upsertProgress,
+      });
+      const handler = createStateHandler(deps);
+      await handler(makeEvent());
+
+      expect(upsertProgress).toHaveBeenCalledWith(
+        expect.objectContaining({
+          locator: { koboLocation: { Source: "OEBPS/xhtml/chapter02.xhtml", Type: "KoboSpan", Value: "kobo.2.1" } },
+        }),
+      );
+    });
+
+    it("stores empty locator when device update has no location", async () => {
+      const payloadNoLocation = {
+        ReadingStates: [{
+          LastModified: "2024-07-01T13:00:00.000Z",
+          StatusInfo: { Status: "Reading", LastModified: "2024-07-01T13:00:00.000Z" },
+          CurrentBookmark: { ProgressPercent: 30 },
+        }],
+      };
+      const upsertProgress = vi.fn().mockResolvedValue(mockProgress);
+      const deps = makeDeps({
+        getMethod: vi.fn().mockReturnValue("PUT"),
+        readBody: vi.fn().mockResolvedValue(payloadNoLocation),
+        upsertProgress,
+      });
+      const handler = createStateHandler(deps);
+      await handler(makeEvent());
+
+      expect(upsertProgress).toHaveBeenCalledWith(
+        expect.objectContaining({ locator: {} }),
+      );
+    });
+  });
+
+  describe("unsupported methods", () => {
+    it("throws 405 for DELETE method", async () => {
+      const deps = makeDeps({
+        getMethod: vi.fn().mockReturnValue("DELETE"),
+      });
+      const handler = createStateHandler(deps);
+
+      try {
+        await handler(makeEvent());
+        expect.fail("Should have thrown");
+      } catch (e) {
+        const err = e as Error & { statusCode: number };
+        expect(err.statusCode).toBe(405);
+      }
+    });
+  });
+});

--- a/apps/web/server/routes/kobo/[token]/v1/library/[bookId]/state.ts
+++ b/apps/web/server/routes/kobo/[token]/v1/library/[bookId]/state.ts
@@ -1,0 +1,194 @@
+import { defineEventHandler, getMethod, readBody } from "h3";
+import type { H3Event } from "h3";
+import type { Prisma } from "@bookhouse/db";
+import type { KoboAuthDeps } from "../../../../auth-helper";
+import type { ReadingProgressRecord, KoboReadingState, KoboRequestResult, LocatorData, KoboLocation } from "@bookhouse/kobo";
+
+export interface StateHandlerDeps {
+  auth: KoboAuthDeps;
+  findProgress: (userId: string, editionId: string) => Promise<ReadingProgressRecord | null>;
+  upsertProgress: (params: {
+    userId: string;
+    editionId: string;
+    percent: number;
+    locator: LocatorData;
+    source: string;
+  }) => Promise<ReadingProgressRecord>;
+  getMethod: (event: H3Event) => string;
+  readBody: (event: H3Event) => Promise<{
+    ReadingStates?: Array<{
+      EntitlementId?: string;
+      LastModified?: string;
+      StatusInfo?: { Status?: string; LastModified?: string };
+      CurrentBookmark?: { ProgressPercent?: number; Location?: KoboLocation; LastModified?: string };
+      Statistics?: { LastModified?: string; SpentReadingMinutes?: number; RemainingTimeMinutes?: number };
+    }>;
+  } | null | undefined>;
+}
+
+const VALID_ID = /^[a-zA-Z0-9_-]+$/;
+
+function defaultReadingState(editionId: string): KoboReadingState {
+  const now = new Date().toISOString();
+  return {
+    EntitlementId: editionId,
+    Created: now,
+    LastModified: now,
+    PriorityTimestamp: now,
+    StatusInfo: {
+      LastModified: now,
+      Status: "ReadyToRead",
+      TimesStartedReading: 0,
+    },
+    Statistics: {
+      LastModified: now,
+    },
+    CurrentBookmark: {
+      LastModified: now,
+    },
+  };
+}
+
+function successResult(bookId: string): KoboRequestResult {
+  return {
+    RequestResult: "Success",
+    UpdateResults: [{
+      EntitlementId: bookId,
+      CurrentBookmarkResult: { Result: "Success" },
+      StatisticsResult: { Result: "Ignored" },
+      StatusInfoResult: { Result: "Success" },
+    }],
+  };
+}
+
+export function createStateHandler(deps: StateHandlerDeps) {
+  return async (event: H3Event): Promise<KoboReadingState[] | KoboRequestResult> => {
+    const { createKoboAuth } = await import("../../../../auth-helper");
+    const auth = createKoboAuth(deps.auth);
+    const device = await auth(event);
+
+    const params = event.context.params as Record<string, string>;
+    const bookId = params.bookId as string;
+
+    if (!VALID_ID.test(bookId)) {
+      throw Object.assign(new Error("Invalid bookId"), {
+        statusCode: 400,
+        statusMessage: "Invalid bookId",
+      });
+    }
+
+    const method = deps.getMethod(event);
+
+    if (method === "GET") {
+      const progress = await deps.findProgress(device.userId, bookId);
+      if (!progress) {
+        return [defaultReadingState(bookId)];
+      }
+      const { formatReadingState } = await import("@bookhouse/kobo");
+      return [formatReadingState(progress, bookId)];
+    }
+
+    if (method === "PUT") {
+      const body = await deps.readBody(event);
+      const { parseStateUpdate, resolveConflict } = await import("@bookhouse/kobo");
+
+      const parsed = parseStateUpdate(body);
+      if ("error" in parsed) {
+        throw Object.assign(new Error(parsed.error), {
+          statusCode: 400,
+          statusMessage: parsed.error,
+        });
+      }
+
+      const existing = await deps.findProgress(device.userId, bookId);
+
+      if (existing) {
+        const { winner } = resolveConflict(existing.updatedAt, parsed.lastModified);
+        if (winner === "server") {
+          return successResult(bookId);
+        }
+      }
+
+      await deps.upsertProgress({
+        userId: device.userId,
+        editionId: bookId,
+        percent: parsed.progress,
+        locator: parsed.location ? { koboLocation: parsed.location } : {},
+        source: "kobo",
+      });
+
+      return successResult(bookId);
+    }
+
+    throw Object.assign(new Error("Method not allowed"), {
+      statusCode: 405,
+      statusMessage: "Method not allowed",
+    });
+  };
+}
+
+/* c8 ignore start — runtime wiring */
+export default defineEventHandler(async (event) => {
+  const { db } = await import("@bookhouse/db");
+
+  const handler = createStateHandler({
+    auth: {
+      findDeviceByToken: (token) =>
+        db.koboDevice.findUnique({ where: { authToken: token } }),
+    },
+    findProgress: async (userId, editionId) => {
+      const record = await db.readingProgress.findFirst({
+        where: { userId, editionId, progressKind: "EBOOK" },
+      });
+      if (!record) return null;
+      return {
+        id: record.id,
+        userId: record.userId,
+        editionId: record.editionId,
+        progressKind: record.progressKind,
+        locator: record.locator as LocatorData,
+        percent: record.percent,
+        source: record.source,
+        updatedAt: record.updatedAt,
+      };
+    },
+    upsertProgress: async ({ userId, editionId, percent, locator, source }) => {
+      const existing = await db.readingProgress.findFirst({
+        where: { userId, editionId, progressKind: "EBOOK" },
+      });
+
+      const jsonLocator = locator as Prisma.InputJsonValue;
+      const record = existing
+        ? await db.readingProgress.update({
+            where: { id: existing.id },
+            data: { percent, locator: jsonLocator, source },
+          })
+        : await db.readingProgress.create({
+            data: {
+              userId,
+              editionId,
+              progressKind: "EBOOK",
+              percent,
+              locator: jsonLocator,
+              source,
+            },
+          });
+
+      return {
+        id: record.id,
+        userId: record.userId,
+        editionId: record.editionId,
+        progressKind: record.progressKind,
+        locator: record.locator as LocatorData,
+        percent: record.percent,
+        source: record.source,
+        updatedAt: record.updatedAt,
+      };
+    },
+    getMethod: (ev) => getMethod(ev),
+    readBody: (ev) => readBody(ev),
+  });
+
+  return handler(event);
+});
+/* c8 ignore stop */

--- a/apps/web/server/routes/kobo/[token]/v1/library/sync.test.ts
+++ b/apps/web/server/routes/kobo/[token]/v1/library/sync.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { createSyncHandler } from "./sync";
 import type { SyncHandlerDeps } from "./sync";
 import type { H3Event } from "h3";
-import type { EligibleEdition } from "@bookhouse/kobo";
+import type { EligibleEdition, ReadingProgressRecord } from "@bookhouse/kobo";
 
 const validToken = "a".repeat(64);
 
@@ -57,6 +57,7 @@ function makeDeps(overrides: Partial<SyncHandlerDeps> = {}): SyncHandlerDeps {
     getSyncedBooks: vi.fn().mockResolvedValue([]),
     markSynced: vi.fn().mockResolvedValue(undefined),
     markRemoved: vi.fn().mockResolvedValue(undefined),
+    getReadingProgress: vi.fn().mockResolvedValue([]),
     getBaseUrl: () => "http://localhost:3000",
     setResponseHeader: vi.fn(),
     ...overrides,
@@ -200,5 +201,65 @@ describe("createSyncHandler", () => {
     // Only 100 items sent in this page
     const [, editionIds] = (deps.markSynced as ReturnType<typeof vi.fn>).mock.calls[0] as [string, string[]];
     expect(editionIds).toHaveLength(100);
+  });
+
+  it("fetches reading progress for eligible editions", async () => {
+    const deps = makeDeps({
+      getDeviceCollectionEditions: vi.fn().mockResolvedValue([makeEdition("e1"), makeEdition("e2")]),
+    });
+    const handler = createSyncHandler(deps);
+    await handler(makeEvent());
+
+    expect(deps.getReadingProgress).toHaveBeenCalledWith("u1", ["e1", "e2"]);
+  });
+
+  it("includes ChangedReadingState for already-synced books with Location", async () => {
+    const progressRecords: ReadingProgressRecord[] = [{
+      id: "rp-1",
+      userId: "u1",
+      editionId: "e1",
+      progressKind: "EBOOK",
+      locator: { koboLocation: { Source: "OEBPS/ch01.xhtml", Type: "KoboSpan", Value: "kobo.1.1" } },
+      percent: 42,
+      source: "kobo",
+      updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+    }];
+    const deps = makeDeps({
+      getDeviceCollectionEditions: vi.fn().mockResolvedValue([makeEdition("e1")]),
+      getSyncedBooks: vi.fn().mockResolvedValue([{ editionId: "e1", removedAt: null }]),
+      getReadingProgress: vi.fn().mockResolvedValue(progressRecords),
+    });
+    const handler = createSyncHandler(deps);
+    const result = await handler(makeEvent()) as Record<string, unknown>[];
+
+    const changedStates = result.filter(
+      (r) => "ChangedReadingState" in r,
+    ) as { ChangedReadingState: { ReadingState: { EntitlementId: string; CurrentBookmark: { ProgressPercent: number } } } }[];
+    expect(changedStates).toHaveLength(1);
+    expect(changedStates.at(0)?.ChangedReadingState.ReadingState.EntitlementId).toBe("e1");
+    expect(changedStates.at(0)?.ChangedReadingState.ReadingState.CurrentBookmark.ProgressPercent).toBe(42);
+  });
+
+  it("includes reading state in NewEntitlement when progress exists", async () => {
+    const progressRecords: ReadingProgressRecord[] = [{
+      id: "rp-1",
+      userId: "u1",
+      editionId: "e1",
+      progressKind: "EBOOK",
+      locator: {},
+      percent: 75,
+      source: "kobo",
+      updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+    }];
+    const deps = makeDeps({
+      getDeviceCollectionEditions: vi.fn().mockResolvedValue([makeEdition("e1")]),
+      getReadingProgress: vi.fn().mockResolvedValue(progressRecords),
+    });
+    const handler = createSyncHandler(deps);
+    const result = await handler(makeEvent()) as Record<string, unknown>[];
+
+    const item = result.at(0) as { NewEntitlement: { ReadingState: { StatusInfo: { Status: string }; CurrentBookmark: { ProgressPercent: number } } } };
+    expect(item.NewEntitlement.ReadingState.StatusInfo.Status).toBe("Reading");
+    expect(item.NewEntitlement.ReadingState.CurrentBookmark.ProgressPercent).toBe(75);
   });
 });

--- a/apps/web/server/routes/kobo/[token]/v1/library/sync.ts
+++ b/apps/web/server/routes/kobo/[token]/v1/library/sync.ts
@@ -1,7 +1,7 @@
 import { defineEventHandler, getQuery, setResponseHeader } from "h3";
 import type { H3Event } from "h3";
 import type { KoboAuthDeps } from "../../../auth-helper";
-import type { EligibleEdition } from "@bookhouse/kobo";
+import type { EligibleEdition, ReadingProgressRecord, LocatorData } from "@bookhouse/kobo";
 import type { SyncedBookRecord } from "@bookhouse/kobo";
 
 const SYNC_ITEM_LIMIT = 100;
@@ -12,6 +12,7 @@ export interface SyncHandlerDeps {
   getSyncedBooks: (deviceId: string) => Promise<SyncedBookRecord[]>;
   markSynced: (deviceId: string, editionIds: string[]) => Promise<void>;
   markRemoved: (deviceId: string, editionIds: string[]) => Promise<void>;
+  getReadingProgress: (userId: string, editionIds: string[]) => Promise<ReadingProgressRecord[]>;
   getBaseUrl: () => string;
   setResponseHeader: (event: H3Event, name: string, value: string) => void;
 }
@@ -46,11 +47,18 @@ export function createSyncHandler(deps: SyncHandlerDeps) {
     const additionsRemaining = toAdd.length > SYNC_ITEM_LIMIT;
     const pageRemove = additionsRemaining ? [] : toRemove;
 
+    // Fetch reading progress for eligible editions to include in sync response
+    const eligibleIds = eligible.map((e) => e.id);
+    const progressRecords = eligibleIds.length > 0
+      ? await deps.getReadingProgress(device.userId, eligibleIds)
+      : [];
+    const progressMap = new Map(progressRecords.map((p) => [p.editionId, p]));
+
     const baseUrl = deps.getBaseUrl();
     const result = buildSyncResponse(pageAdd, pageRemove, {
       baseUrl,
       deviceToken: device.authToken,
-    });
+    }, progressMap);
 
     if (pageAdd.length > 0) {
       await deps.markSynced(
@@ -76,6 +84,10 @@ export function createSyncHandler(deps: SyncHandlerDeps) {
           BookEntitlement: { Id: id, IsRemoved: true },
         },
       });
+    }
+
+    for (const readingState of result.changedReadingStates) {
+      syncResults.push({ ChangedReadingState: { ReadingState: readingState } });
     }
 
     // One-time cleanup: remove legacy UUID-format entries from old syncs
@@ -221,6 +233,21 @@ export default defineEventHandler(async (event) => {
         where: { koboDeviceId: deviceId, editionId: { in: editionIds } },
         data: { removedAt: new Date() },
       });
+    },
+    getReadingProgress: async (userId, editionIds) => {
+      const records = await db.readingProgress.findMany({
+        where: { userId, editionId: { in: editionIds }, progressKind: "EBOOK" },
+      });
+      return records.map((r) => ({
+        id: r.id,
+        userId: r.userId,
+        editionId: r.editionId,
+        progressKind: r.progressKind,
+        locator: r.locator as LocatorData,
+        percent: r.percent,
+        source: r.source,
+        updatedAt: r.updatedAt,
+      }));
     },
     getBaseUrl: () => process.env.KOBO_API_BASE_URL ?? process.env.APP_URL ?? "http://localhost:3000",
     setResponseHeader,

--- a/apps/web/src/lib/server-fns/kobo-devices.test.ts
+++ b/apps/web/src/lib/server-fns/kobo-devices.test.ts
@@ -21,7 +21,7 @@ const mockDelete = vi.fn();
 const mockDeviceCollectionDeleteMany = vi.fn();
 const mockDeviceCollectionCreateMany = vi.fn();
 const mockDeviceCollectionFindMany = vi.fn();
-const mockUserFindFirstOrThrow = vi.fn();
+const mockGetCurrentUser = vi.fn();
 
 vi.mock("@bookhouse/db", () => ({
   db: {
@@ -36,10 +36,11 @@ vi.mock("@bookhouse/db", () => ({
       createMany: mockDeviceCollectionCreateMany,
       findMany: mockDeviceCollectionFindMany,
     },
-    user: {
-      findFirstOrThrow: mockUserFindFirstOrThrow,
-    },
   },
+}));
+
+vi.mock("~/lib/auth-server", () => ({
+  getCurrentUser: mockGetCurrentUser,
 }));
 
 const mockGenerateAuthToken = vi.fn().mockReturnValue("a".repeat(64));
@@ -61,7 +62,7 @@ import {
 describe("kobo-devices server functions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUserFindFirstOrThrow.mockResolvedValue({ id: "u1" });
+    mockGetCurrentUser.mockResolvedValue({ id: "u1" });
   });
 
   describe("getKoboDevicesServerFn", () => {
@@ -111,6 +112,16 @@ describe("kobo-devices server functions", () => {
       });
       expect(mockGenerateAuthToken).toHaveBeenCalled();
       expect(mockGenerateUserKey).toHaveBeenCalledWith("u1", "My Kobo");
+    });
+
+    it("throws when user is not authenticated", async () => {
+      mockGetCurrentUser.mockResolvedValue(null);
+
+      await expect(
+        addKoboDeviceServerFn({ data: { deviceName: "My Kobo" } }),
+      ).rejects.toThrow("Not authenticated");
+
+      expect(mockCreate).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/web/src/lib/server-fns/kobo-devices.ts
+++ b/apps/web/src/lib/server-fns/kobo-devices.ts
@@ -30,14 +30,17 @@ export const addKoboDeviceServerFn = createServerFn({
   .handler(async ({ data }) => {
     const { db } = await import("@bookhouse/db");
     const { generateAuthToken, generateUserKey } = await import("@bookhouse/kobo");
+    const { getCurrentUser } = await import("~/lib/auth-server");
 
-    const userId = await getFirstUserId();
+    const user = await getCurrentUser();
+    if (!user) throw new Error("Not authenticated");
+
     const authToken = generateAuthToken();
-    const userKey = generateUserKey(userId, data.deviceName);
+    const userKey = generateUserKey(user.id, data.deviceName);
 
     return db.koboDevice.create({
       data: {
-        userId,
+        userId: user.id,
         deviceId: data.deviceName,
         authToken,
         userKey,
@@ -107,8 +110,3 @@ export const updateDeviceCollectionsServerFn = createServerFn({
     });
   });
 
-async function getFirstUserId(): Promise<string> {
-  const { db } = await import("@bookhouse/db");
-  const user = await db.user.findFirstOrThrow();
-  return user.id;
-}

--- a/apps/web/src/lib/server-fns/reading-progress.test.ts
+++ b/apps/web/src/lib/server-fns/reading-progress.test.ts
@@ -137,7 +137,7 @@ describe("updateReadingProgressServerFn", () => {
     });
     expect(readingProgressUpdateMock).toHaveBeenCalledWith({
       where: { id: "rp1" },
-      data: { percent: 50, locator: {} },
+      data: { percent: 50, locator: {}, source: "manual" },
     });
     expect(result).toBe(updated);
   });
@@ -159,6 +159,7 @@ describe("updateReadingProgressServerFn", () => {
         progressKind: "AUDIO",
         percent: 75,
         locator: {},
+        source: "manual",
       },
     });
     expect(result).toBe(created);

--- a/apps/web/src/lib/server-fns/reading-progress.ts
+++ b/apps/web/src/lib/server-fns/reading-progress.ts
@@ -65,7 +65,7 @@ export const updateReadingProgressServerFn = createServerFn({
     if (existing) {
       return db.readingProgress.update({
         where: { id: existing.id },
-        data: { percent: data.percent, locator: {} },
+        data: { percent: data.percent, locator: {}, source: "manual" },
       });
     }
 
@@ -76,6 +76,7 @@ export const updateReadingProgressServerFn = createServerFn({
         progressKind: data.progressKind,
         percent: data.percent,
         locator: {},
+        source: "manual",
       },
     });
   });

--- a/apps/web/src/routes/_authenticated/-library.$workId.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.$workId.test.tsx
@@ -45,6 +45,7 @@ interface MockProgress {
   editionId: string;
   progressKind: string;
   percent: number | null;
+  source?: string | null;
 }
 
 let mockLoaderData: { work: MockWork; progress: MockProgress[]; trackingMode: string; contributorNames: string[]; smtpConfigured: boolean; kindleConfigured: boolean; shelves: { id: string; name: string; isMember: boolean }[] } = {
@@ -460,7 +461,7 @@ describe("WorkDetailPage", () => {
     const { Route } = await import("./library.$workId");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
-    expect(screen.getByText("EBOOK")).toBeTruthy();
+    expect(screen.getAllByText("EBOOK").length).toBeGreaterThanOrEqual(1);
   });
 
 
@@ -525,7 +526,7 @@ describe("WorkDetailPage", () => {
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
     expect(screen.getByRole("progressbar")).toBeTruthy();
-    expect(screen.getByText("42%")).toBeTruthy();
+    expect(screen.getAllByText("42%").length).toBeGreaterThanOrEqual(1);
     // EBOOK appears in both editions section and progress section
     expect(screen.getAllByText("EBOOK").length).toBeGreaterThanOrEqual(2);
   });
@@ -540,7 +541,7 @@ describe("WorkDetailPage", () => {
     render(<Page />);
     const bars = screen.getAllByRole("progressbar");
     expect(bars).toHaveLength(1);
-    expect(screen.getByText("42%")).toBeTruthy();
+    expect(screen.getAllByText("42%").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders BY_WORK with null percent treated as 0", async () => {
@@ -551,7 +552,7 @@ describe("WorkDetailPage", () => {
     const { Route } = await import("./library.$workId");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
-    expect(screen.getByText("0%")).toBeTruthy();
+    expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders BY_EDITION with null percent treated as 0", async () => {
@@ -562,15 +563,26 @@ describe("WorkDetailPage", () => {
     const { Route } = await import("./library.$workId");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
-    expect(screen.getByText("0%")).toBeTruthy();
+    expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(1);
   });
 
-  it("shows no progress message when empty", async () => {
+  it("shows no progress message in BY_WORK mode when empty", async () => {
     mockLoaderData.progress = [];
+    mockLoaderData.trackingMode = "BY_WORK";
     const { Route } = await import("./library.$workId");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
     expect(screen.getByText("No reading progress yet")).toBeTruthy();
+  });
+
+  it("shows 0% for edition in BY_EDITION mode when no progress recorded", async () => {
+    mockLoaderData.progress = [];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByRole("progressbar")).toBeTruthy();
   });
 
   it("renders BY_WORK with max percent from multiple editions", async () => {
@@ -598,7 +610,7 @@ describe("WorkDetailPage", () => {
     render(<Page />);
     const bars = screen.getAllByRole("progressbar");
     expect(bars).toHaveLength(1);
-    expect(screen.getByText("75%")).toBeTruthy();
+    expect(screen.getAllByText("75%").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders BY_EDITION with multiple edition progress entries", async () => {
@@ -626,8 +638,229 @@ describe("WorkDetailPage", () => {
     render(<Page />);
     const bars = screen.getAllByRole("progressbar");
     expect(bars).toHaveLength(2);
-    expect(screen.getByText("30%")).toBeTruthy();
-    expect(screen.getByText("75%")).toBeTruthy();
+    expect(screen.getAllByText("30%").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText("75%").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("uses AUDIO progressKind when saving for AUDIOBOOK edition with no existing record", async () => {
+    updateReadingProgressServerFnMock.mockResolvedValue({});
+    mockLoaderData.work.editions = [{
+      id: "edition-1",
+      formatFamily: "AUDIOBOOK",
+      publisher: "DAW Books",
+      publishedAt: "2007-03-27T00:00:00.000Z",
+      isbn13: "9780756404079",
+      isbn10: null,
+      asin: "B003HV0TN2",
+      language: "en",
+      pageCount: null,
+      editedFields: [],
+      contributors: [{ role: "AUTHOR", contributor: { id: "contrib-1", nameDisplay: "Patrick Rothfuss" } }],
+      editionFiles: [{ id: "ef-1", role: "PRIMARY", fileAsset: { id: "fa-1", basename: "the-name-of-the-wind.epub", sizeBytes: 1048576n, mediaKind: "EPUB", availabilityStatus: "PRESENT" } }],
+    }];
+    mockLoaderData.progress = [];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    fireEvent.change(screen.getByTestId("progress-input-edition-1"), { target: { value: "20" } });
+    fireEvent.click(screen.getByTestId("progress-save-edition-1"));
+    await waitFor(() => {
+      expect(updateReadingProgressServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "edition-1", percent: 20, progressKind: "AUDIO" },
+      });
+    });
+  });
+
+  it("uses EBOOK progressKind when saving for non-AUDIOBOOK edition with no existing record", async () => {
+    updateReadingProgressServerFnMock.mockResolvedValue({});
+    mockLoaderData.progress = [];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    fireEvent.change(screen.getByTestId("progress-input-edition-1"), { target: { value: "10" } });
+    fireEvent.click(screen.getByTestId("progress-save-edition-1"));
+    await waitFor(() => {
+      expect(updateReadingProgressServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "edition-1", percent: 10, progressKind: "EBOOK" },
+      });
+    });
+  });
+
+  it("shows cover-area progress display when progress exists", async () => {
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 55 },
+    ];
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByTestId("cover-progress")).toBeTruthy();
+    expect(screen.getByText("read")).toBeTruthy();
+  });
+
+  it("hides cover-area progress display when no progress", async () => {
+    mockLoaderData.progress = [];
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.queryByTestId("cover-progress")).toBeNull();
+  });
+
+  it("shows max percent in cover area when multiple progress records", async () => {
+    mockLoaderData.work.editions.push({
+      id: "edition-2",
+      formatFamily: "AUDIOBOOK",
+      publisher: null,
+      publishedAt: null,
+      isbn13: null,
+      isbn10: null,
+      asin: null,
+      language: null,
+      pageCount: null,
+      editedFields: [],
+      contributors: [],
+      editionFiles: [],
+    });
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 20 },
+      { id: "rp2", editionId: "edition-2", progressKind: "AUDIO", percent: 60 },
+    ];
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    const coverProgress = screen.getByTestId("cover-progress");
+    expect(coverProgress.textContent).toContain("60");
+  });
+
+  it("enters edit mode when percent button is clicked", async () => {
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 42 },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    expect(screen.getByTestId("progress-input-edition-1")).toBeTruthy();
+    expect(screen.getByTestId("progress-save-edition-1")).toBeTruthy();
+    expect(screen.getByTestId("progress-cancel-edition-1")).toBeTruthy();
+  });
+
+  it("cancels edit mode when cancel button clicked", async () => {
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 42 },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    fireEvent.click(screen.getByTestId("progress-cancel-edition-1"));
+    expect(screen.queryByTestId("progress-input-edition-1")).toBeNull();
+  });
+
+  it("cancels edit mode when Escape key pressed", async () => {
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 42 },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    fireEvent.keyDown(screen.getByTestId("progress-input-edition-1"), { key: "Escape" });
+    expect(screen.queryByTestId("progress-input-edition-1")).toBeNull();
+  });
+
+  it("saves progress when Save button clicked", async () => {
+    updateReadingProgressServerFnMock.mockResolvedValue({});
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 42 },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    fireEvent.change(screen.getByTestId("progress-input-edition-1"), { target: { value: "75" } });
+    fireEvent.click(screen.getByTestId("progress-save-edition-1"));
+    await waitFor(() => {
+      expect(updateReadingProgressServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "edition-1", percent: 75, progressKind: "EBOOK" },
+      });
+    });
+  });
+
+  it("saves progress when Enter key pressed", async () => {
+    updateReadingProgressServerFnMock.mockResolvedValue({});
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 10 },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    fireEvent.change(screen.getByTestId("progress-input-edition-1"), { target: { value: "50" } });
+    fireEvent.keyDown(screen.getByTestId("progress-input-edition-1"), { key: "Enter" });
+    await waitFor(() => {
+      expect(updateReadingProgressServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "edition-1", percent: 50, progressKind: "EBOOK" },
+      });
+    });
+  });
+
+  it("does not save when value is invalid (NaN)", async () => {
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 42 },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    fireEvent.change(screen.getByTestId("progress-input-edition-1"), { target: { value: "abc" } });
+    fireEvent.keyDown(screen.getByTestId("progress-input-edition-1"), { key: "Enter" });
+    expect(updateReadingProgressServerFnMock).not.toHaveBeenCalled();
+  });
+
+  it("does not save when value is out of range", async () => {
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 42 },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByTestId("progress-edit-edition-1"));
+    fireEvent.change(screen.getByTestId("progress-input-edition-1"), { target: { value: "150" } });
+    fireEvent.keyDown(screen.getByTestId("progress-input-edition-1"), { key: "Enter" });
+    expect(updateReadingProgressServerFnMock).not.toHaveBeenCalled();
+  });
+
+  it("renders source badge when progress has source", async () => {
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 42, source: "kobo" },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByText("via kobo")).toBeTruthy();
+  });
+
+  it("does not render source badge when source is null", async () => {
+    mockLoaderData.progress = [
+      { id: "rp1", editionId: "edition-1", progressKind: "EBOOK", percent: 42, source: null },
+    ];
+    mockLoaderData.trackingMode = "BY_EDITION";
+    const { Route } = await import("./library.$workId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.queryByText(/^via /)).toBeNull();
   });
 
   it("renders enrichment dialog component", async () => {

--- a/apps/web/src/routes/_authenticated/library.$workId.tsx
+++ b/apps/web/src/routes/_authenticated/library.$workId.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { toast } from "sonner";
-import { BookOpen, ChevronRight, ImagePlus, Loader2, Search, Sparkles, Trash2, Upload } from "lucide-react";
+import { BookOpen, ChevronRight, ImagePlus, Loader2, Pencil, Search, Sparkles, Trash2, Upload } from "lucide-react";
 import { Button } from "~/components/ui/button";
 import {
   Dialog,
@@ -34,7 +34,7 @@ import {
   getWorkDetailServerFn,
   type WorkDetail,
 } from "~/lib/server-fns/work-detail";
-import { getReadingProgressServerFn } from "~/lib/server-fns/reading-progress";
+import { getReadingProgressServerFn, updateReadingProgressServerFn } from "~/lib/server-fns/reading-progress";
 import { deleteWorkServerFn, deleteEditionServerFn } from "~/lib/server-fns/deletion";
 import { EditableField } from "~/components/editable-field";
 import { EditableTagField } from "~/components/editable-tag-field";
@@ -114,6 +114,15 @@ function WorkDetailPage() {
   useEffect(() => {
     setBookColors(coverColors);
   }, [coverColors, setBookColors]);
+
+  const maxPercent = progress.length > 0
+    ? Math.max(...progress.map((p) => p.percent ?? 0))
+    : null;
+
+  async function handleUpdateProgress(editionId: string, percent: number, progressKind: string) {
+    await updateReadingProgressServerFn({ data: { editionId, percent, progressKind: progressKind as "EBOOK" | "AUDIO" | "READALOUD" } });
+    void router.invalidate();
+  }
 
   const firstPublishYear = (() => {
     let earliest: Date | null = null;
@@ -245,6 +254,12 @@ function WorkDetailPage() {
             data-testid="cover-file-input"
             onChange={(e) => { void handleCoverUpload(e); }}
           />
+          {maxPercent !== null && (
+            <div className="mt-2 text-center" data-testid="cover-progress">
+              <span className="text-xl font-bold tabular-nums">{String(maxPercent)}%</span>
+              <p className="text-xs text-muted-foreground">read</p>
+            </div>
+          )}
         </div>
 
         <div className="flex-1 space-y-4">
@@ -364,6 +379,19 @@ function WorkDetailPage() {
         onApplied={() => { setCoverVersion((v) => v + 1); void router.invalidate(); }}
       />
 
+      <div className="space-y-4">
+        <h2 className="text-lg font-semibold">Reading Progress</h2>
+        {trackingMode === "BY_WORK" ? (
+          progress.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No reading progress yet</p>
+          ) : (
+            <WorkProgress progress={progress} />
+          )
+        ) : (
+          <EditionProgress progress={progress} editions={work.editions} onUpdate={handleUpdateProgress} />
+        )}
+      </div>
+
       {work.editions.length > 0 && (
         <div className="space-y-4">
           <h2 className="text-lg font-semibold">Editions</h2>
@@ -396,17 +424,6 @@ function WorkDetailPage() {
           </Tabs>
         </div>
       )}
-
-      <div className="space-y-4">
-        <h2 className="text-lg font-semibold">Reading Progress</h2>
-        {progress.length === 0 ? (
-          <p className="text-sm text-muted-foreground">No reading progress yet</p>
-        ) : trackingMode === "BY_WORK" ? (
-          <WorkProgress progress={progress} />
-        ) : (
-          <EditionProgress progress={progress} editions={work.editions} />
-        )}
-      </div>
 
       <Dialog open={deleteWorkOpen} onOpenChange={setDeleteWorkOpen}>
         <DialogContent>
@@ -468,29 +485,103 @@ function WorkProgress({ progress }: { progress: { percent: number | null }[] }) 
   );
 }
 
+function progressKindForEdition(formatFamily: string): "EBOOK" | "AUDIO" | "READALOUD" {
+  if (formatFamily === "AUDIOBOOK") return "AUDIO";
+  return "EBOOK";
+}
+
 function EditionProgress({
   progress,
   editions,
+  onUpdate,
 }: {
-  progress: { editionId: string; progressKind: string; percent: number | null }[];
+  progress: { editionId: string; progressKind: string; percent: number | null; source: string | null }[];
   editions: WorkDetail["editions"];
+  onUpdate: (editionId: string, percent: number, progressKind: string) => Promise<void>;
 }) {
-  const editionMap = new Map(editions.map((e) => [e.id, e]));
+  const progressMap = new Map(progress.map((p) => [p.editionId, p]));
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave(editionId: string, progressKind: string) {
+    const val = parseInt(editValue, 10);
+    if (isNaN(val) || val < 0 || val > 100) return;
+    setSaving(true);
+    try {
+      await onUpdate(editionId, val, progressKind);
+      setEditingId(null);
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <div className="space-y-3">
-      {progress.map((p) => {
-        const edition = editionMap.get(p.editionId);
+      {editions.map((edition) => {
+        const p = progressMap.get(edition.id);
+        const percent = p?.percent ?? 0;
+        const progressKind = p?.progressKind ?? progressKindForEdition(edition.formatFamily);
+        const isEditing = editingId === edition.id;
+
         return (
-          <div key={`${p.editionId}-${p.progressKind}`} className="space-y-1">
+          <div key={edition.id} className="space-y-1">
             <div className="flex items-center gap-2 text-sm">
-              {edition && <Badge variant="secondary">{edition.formatFamily}</Badge>}
-              <span className="text-muted-foreground">{p.progressKind}</span>
+              <Badge variant="secondary">{edition.formatFamily}</Badge>
+              {p?.source && <Badge variant="outline" className="text-xs">via {p.source}</Badge>}
             </div>
             <div className="flex items-center gap-2">
               <div className="flex-1">
-                <ProgressBar percent={p.percent} />
+                <ProgressBar percent={percent} />
               </div>
-              <span className="text-sm text-muted-foreground">{String(p.percent ?? 0)}%</span>
+              {isEditing ? (
+                <div className="flex items-center gap-1">
+                  <input
+                    data-testid={`progress-input-${edition.id}`}
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={editValue}
+                    onChange={(e) => { setEditValue(e.target.value); }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") { void handleSave(edition.id, progressKind); }
+                      if (e.key === "Escape") { setEditingId(null); }
+                    }}
+                    className="w-16 rounded border px-2 py-0.5 text-sm text-right"
+                    autoFocus
+                    disabled={saving}
+                  />
+                  <span className="text-sm">%</span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={saving}
+                    onClick={() => { void handleSave(edition.id, progressKind); }}
+                    data-testid={`progress-save-${edition.id}`}
+                  >
+                    {saving ? <Loader2 className="size-3 animate-spin" /> : "Save"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={saving}
+                    onClick={() => { setEditingId(null); }}
+                    data-testid={`progress-cancel-${edition.id}`}
+                  >
+                    ✕
+                  </Button>
+                </div>
+              ) : (
+                <button
+                  className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground group"
+                  onClick={() => { setEditingId(edition.id); setEditValue(String(percent)); }}
+                  data-testid={`progress-edit-${edition.id}`}
+                  aria-label={`Edit progress for ${edition.formatFamily}`}
+                >
+                  <span>{String(percent)}%</span>
+                  <Pencil className="size-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                </button>
+              )}
             </div>
           </div>
         );

--- a/packages/kobo/src/index.ts
+++ b/packages/kobo/src/index.ts
@@ -31,6 +31,12 @@ export {
 
 export type { SyncedBookRecord, FindEligibleEditionsDeps } from "./sync";
 
+export {
+  formatReadingState,
+  parseStateUpdate,
+  resolveConflict,
+} from "./reading-state";
+
 export { getKepubCachePath, convertToKepub } from "./kepub";
 
 export type { KepubConvertDeps } from "./kepub";
@@ -44,4 +50,12 @@ export type {
   SyncToken,
   SyncResult,
   EligibleEdition,
+  ReadingProgressRecord,
+  KoboStateUpdatePayload,
+  KoboReadingState,
+  LocatorData,
+  LocatorValue,
+  KoboLocation,
+  KoboRequestResult,
+  KoboUpdateResult,
 } from "./types";

--- a/packages/kobo/src/metadata.test.ts
+++ b/packages/kobo/src/metadata.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { buildEntitlement, buildBookMetadata, buildContentUrls, toKoboId } from "./metadata";
-import type { EligibleEdition } from "./types";
+import type { EligibleEdition, ReadingProgressRecord } from "./types";
 import type { MetadataOptions } from "./metadata";
 
 const mockEdition: EligibleEdition = {
@@ -114,6 +114,44 @@ describe("buildEntitlement", () => {
   it("does not include ContentUrls inside the entitlement", () => {
     const result = buildEntitlement(mockEdition, options);
     expect(result).not.toHaveProperty("ContentUrls");
+  });
+
+  it("uses real reading state when progress is provided", () => {
+    const progress: ReadingProgressRecord = {
+      id: "rp-1",
+      userId: "u1",
+      editionId: "ed-1",
+      progressKind: "EBOOK",
+      locator: { koboLocation: { Source: "OEBPS/xhtml/ch01.xhtml", Type: "KoboSpan", Value: "kobo.1.1" } },
+      percent: 50,
+      source: "kobo",
+      updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+    };
+    const result = buildEntitlement(mockEdition, options, progress);
+    expect(result.ReadingState.StatusInfo.Status).toBe("Reading");
+    expect(result.ReadingState.StatusInfo.TimesStartedReading).toBe(1);
+    expect(result.ReadingState.CurrentBookmark.ProgressPercent).toBe(50);
+  });
+
+  it("uses ReadyToRead when progress is explicitly null", () => {
+    const result = buildEntitlement(mockEdition, options, null);
+    expect(result.ReadingState.StatusInfo.Status).toBe("ReadyToRead");
+    expect(result.ReadingState.StatusInfo.TimesStartedReading).toBe(0);
+  });
+
+  it("maps 100% progress to Finished in entitlement", () => {
+    const progress: ReadingProgressRecord = {
+      id: "rp-2",
+      userId: "u1",
+      editionId: "ed-1",
+      progressKind: "EBOOK",
+      locator: {},
+      percent: 100,
+      source: "kobo",
+      updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+    };
+    const result = buildEntitlement(mockEdition, options, progress);
+    expect(result.ReadingState.StatusInfo.Status).toBe("Finished");
   });
 });
 

--- a/packages/kobo/src/metadata.ts
+++ b/packages/kobo/src/metadata.ts
@@ -1,5 +1,6 @@
 import { createHash } from "node:crypto";
-import type { EligibleEdition, KoboEntitlement, KoboBookMetadata, KoboContentUrls } from "./types";
+import type { EligibleEdition, KoboEntitlement, KoboBookMetadata, KoboContentUrls, ReadingProgressRecord } from "./types";
+import { formatReadingState } from "./reading-state";
 
 export interface MetadataOptions {
   baseUrl: string;
@@ -24,9 +25,30 @@ export function toKoboId(input: string): string {
 export function buildEntitlement(
   edition: EligibleEdition,
   options: MetadataOptions,
+  progress?: ReadingProgressRecord | null,
 ): KoboEntitlement {
   const bookMetadata = buildBookMetadata(edition, options);
   const now = new Date().toISOString();
+
+  const readingState = progress
+    ? formatReadingState(progress, edition.id)
+    : {
+        EntitlementId: edition.id,
+        Created: now,
+        LastModified: now,
+        PriorityTimestamp: now,
+        StatusInfo: {
+          LastModified: now,
+          Status: "ReadyToRead",
+          TimesStartedReading: 0,
+        },
+        Statistics: {
+          LastModified: now,
+        },
+        CurrentBookmark: {
+          LastModified: now,
+        },
+      };
 
   return {
     BookEntitlement: {
@@ -44,23 +66,7 @@ export function buildEntitlement(
       Status: "Active",
     },
     BookMetadata: bookMetadata,
-    ReadingState: {
-      EntitlementId: edition.id,
-      Created: now,
-      LastModified: now,
-      PriorityTimestamp: now,
-      StatusInfo: {
-        LastModified: now,
-        Status: "ReadyToRead",
-        TimesStartedReading: 0,
-      },
-      Statistics: {
-        LastModified: now,
-      },
-      CurrentBookmark: {
-        LastModified: now,
-      },
-    },
+    ReadingState: readingState,
   };
 }
 

--- a/packages/kobo/src/reading-state.test.ts
+++ b/packages/kobo/src/reading-state.test.ts
@@ -1,0 +1,264 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import type { ReadingProgressRecord, KoboLocation } from "./types";
+import { formatReadingState, parseStateUpdate, resolveConflict } from "./reading-state";
+
+const NOW = new Date("2024-07-01T12:00:00.000Z");
+const NOW_ISO = NOW.toISOString();
+
+const mockLocation: KoboLocation = {
+  Source: "OEBPS/xhtml/chapter01.xhtml",
+  Type: "KoboSpan",
+  Value: "kobo.1.1",
+};
+
+function makeProgress(overrides: Partial<ReadingProgressRecord> = {}): ReadingProgressRecord {
+  return {
+    id: "rp-1",
+    userId: "u1",
+    editionId: "ed-1",
+    progressKind: "EBOOK",
+    locator: {},
+    percent: 42,
+    source: "kobo",
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe("formatReadingState", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(NOW);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("formats 0% as ReadyToRead with TimesStartedReading 0", () => {
+    const progress = makeProgress({ percent: 0 });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.StatusInfo.Status).toBe("ReadyToRead");
+    expect(result.StatusInfo.TimesStartedReading).toBe(0);
+  });
+
+  it("formats null percent as ReadyToRead", () => {
+    const progress = makeProgress({ percent: null });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.StatusInfo.Status).toBe("ReadyToRead");
+    expect(result.StatusInfo.TimesStartedReading).toBe(0);
+  });
+
+  it("formats 50% as Reading with TimesStartedReading 1", () => {
+    const progress = makeProgress({ percent: 50 });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.StatusInfo.Status).toBe("Reading");
+    expect(result.StatusInfo.TimesStartedReading).toBe(1);
+  });
+
+  it("formats 100% as Finished with TimesStartedReading 1", () => {
+    const progress = makeProgress({ percent: 100 });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.StatusInfo.Status).toBe("Finished");
+    expect(result.StatusInfo.TimesStartedReading).toBe(1);
+  });
+
+  it("uses updatedAt for all timestamp fields", () => {
+    const progress = makeProgress();
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.Created).toBe(NOW_ISO);
+    expect(result.LastModified).toBe(NOW_ISO);
+    expect(result.PriorityTimestamp).toBe(NOW_ISO);
+    expect(result.StatusInfo.LastModified).toBe(NOW_ISO);
+    expect(result.Statistics.LastModified).toBe(NOW_ISO);
+    expect(result.CurrentBookmark.LastModified).toBe(NOW_ISO);
+  });
+
+  it("sets EntitlementId to the provided editionId", () => {
+    const progress = makeProgress();
+    const result = formatReadingState(progress, "ed-42");
+    expect(result.EntitlementId).toBe("ed-42");
+  });
+
+  it("includes koboLocation in CurrentBookmark.Location", () => {
+    const progress = makeProgress({ locator: { koboLocation: mockLocation } });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.CurrentBookmark.Location).toEqual(mockLocation);
+  });
+
+  it("sets CurrentBookmark.ProgressPercent from percent", () => {
+    const progress = makeProgress({ percent: 73 });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.CurrentBookmark.ProgressPercent).toBe(73);
+  });
+
+  it("omits CurrentBookmark.Location when locator has no koboLocation", () => {
+    const progress = makeProgress({ locator: {} });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.CurrentBookmark.Location).toBeUndefined();
+    expect("Location" in result.CurrentBookmark).toBe(false);
+  });
+
+  it("omits CurrentBookmark.ProgressPercent when percent is 0", () => {
+    const progress = makeProgress({ percent: 0 });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.CurrentBookmark.ProgressPercent).toBeUndefined();
+    expect("ProgressPercent" in result.CurrentBookmark).toBe(false);
+  });
+
+  it("omits CurrentBookmark.ProgressPercent when percent is null", () => {
+    const progress = makeProgress({ percent: null });
+    const result = formatReadingState(progress, "ed-1");
+    expect(result.CurrentBookmark.ProgressPercent).toBeUndefined();
+  });
+});
+
+describe("parseStateUpdate", () => {
+  // Actual payload format sent by Kobo devices
+  const validPayload = {
+    ReadingStates: [{
+      EntitlementId: "ed-1",
+      LastModified: "2024-07-01T12:00:00.000Z",
+      StatusInfo: {
+        Status: "Reading",
+        LastModified: "2024-07-01T12:00:00.000Z",
+      },
+      CurrentBookmark: {
+        ProgressPercent: 42,
+        LastModified: "2024-07-01T12:00:00.000Z",
+        Location: {
+          Source: "OEBPS/xhtml/chapter01.xhtml",
+          Type: "KoboSpan",
+          Value: "kobo.1.1",
+        },
+      },
+      Statistics: {
+        LastModified: "2024-07-01T12:00:00.000Z",
+        SpentReadingMinutes: 10,
+        RemainingTimeMinutes: 300,
+      },
+    }],
+  };
+
+  it("parses a valid Kobo payload", () => {
+    const result = parseStateUpdate(validPayload);
+    expect(result).toEqual({
+      status: "Reading",
+      progress: 42,
+      location: {
+        Source: "OEBPS/xhtml/chapter01.xhtml",
+        Type: "KoboSpan",
+        Value: "kobo.1.1",
+      },
+      lastModified: "2024-07-01T12:00:00.000Z",
+    });
+  });
+
+  it("returns error for non-object payload", () => {
+    const result = parseStateUpdate("not an object");
+    expect(result).toEqual({ error: "Payload must be an object" });
+  });
+
+  it("returns error for null payload", () => {
+    const result = parseStateUpdate(null);
+    expect(result).toEqual({ error: "Payload must be an object" });
+  });
+
+  it("returns error for missing ReadingStates", () => {
+    const result = parseStateUpdate({} as { ReadingStates: never[] });
+    expect(result).toEqual({ error: "Missing ReadingStates" });
+  });
+
+  it("returns error for empty ReadingStates array", () => {
+    const result = parseStateUpdate({ ReadingStates: [] });
+    expect(result).toEqual({ error: "Missing ReadingStates" });
+  });
+
+  it("returns error for missing StatusInfo in reading state", () => {
+    const result = parseStateUpdate({
+      ReadingStates: [{ LastModified: "2024-07-01T12:00:00.000Z" }],
+    });
+    expect(result).toEqual({ error: "Missing StatusInfo" });
+  });
+
+  it("returns error for missing LastModified", () => {
+    const result = parseStateUpdate({
+      ReadingStates: [{
+        StatusInfo: { Status: "Reading" },
+      }],
+    });
+    expect(result).toEqual({ error: "Missing LastModified" });
+  });
+
+  it("handles missing Location gracefully", () => {
+    const result = parseStateUpdate({
+      ReadingStates: [{
+        LastModified: "2024-07-01T12:00:00.000Z",
+        StatusInfo: { Status: "Reading", LastModified: "2024-07-01T12:00:00.000Z" },
+        CurrentBookmark: { ProgressPercent: 50 },
+      }],
+    });
+    expect(result).toEqual({
+      status: "Reading",
+      progress: 50,
+      location: null,
+      lastModified: "2024-07-01T12:00:00.000Z",
+    });
+  });
+
+  it("defaults progress to 0 when CurrentBookmark is missing", () => {
+    const result = parseStateUpdate({
+      ReadingStates: [{
+        LastModified: "2024-07-01T12:00:00.000Z",
+        StatusInfo: { Status: "ReadyToRead", LastModified: "2024-07-01T12:00:00.000Z" },
+      }],
+    });
+    expect(result).toEqual({
+      status: "ReadyToRead",
+      progress: 0,
+      location: null,
+      lastModified: "2024-07-01T12:00:00.000Z",
+    });
+  });
+
+  it("defaults status to ReadyToRead when Status is not a string", () => {
+    const result = parseStateUpdate({
+      ReadingStates: [{
+        LastModified: "2024-07-01T12:00:00.000Z",
+        StatusInfo: { Status: 123, LastModified: "2024-07-01T12:00:00.000Z" },
+      }],
+    });
+    expect(result).toEqual({
+      status: "ReadyToRead",
+      progress: 0,
+      location: null,
+      lastModified: "2024-07-01T12:00:00.000Z",
+    });
+  });
+});
+
+describe("resolveConflict", () => {
+  it("device wins when device timestamp is newer", () => {
+    const server = new Date("2024-07-01T10:00:00.000Z");
+    const device = "2024-07-01T12:00:00.000Z";
+    expect(resolveConflict(server, device)).toEqual({ winner: "device" });
+  });
+
+  it("server wins when server timestamp is newer", () => {
+    const server = new Date("2024-07-01T14:00:00.000Z");
+    const device = "2024-07-01T12:00:00.000Z";
+    expect(resolveConflict(server, device)).toEqual({ winner: "server" });
+  });
+
+  it("device wins on exact tie", () => {
+    const server = new Date("2024-07-01T12:00:00.000Z");
+    const device = "2024-07-01T12:00:00.000Z";
+    expect(resolveConflict(server, device)).toEqual({ winner: "device" });
+  });
+
+  it("handles ISO timestamps with different timezone offsets", () => {
+    const server = new Date("2024-07-01T12:00:00.000Z");
+    const device = "2024-07-01T14:00:00.000+02:00"; // same instant as 12:00 UTC
+    expect(resolveConflict(server, device)).toEqual({ winner: "device" });
+  });
+});

--- a/packages/kobo/src/reading-state.ts
+++ b/packages/kobo/src/reading-state.ts
@@ -1,0 +1,122 @@
+import type { ReadingProgressRecord, KoboReadingState, KoboStateUpdatePayload, KoboLocation } from "./types";
+
+interface StatusInfoPayload {
+  Status?: string | number;
+  LastModified?: string;
+}
+
+interface BookmarkPayload {
+  ProgressPercent?: number;
+  Location?: KoboLocation;
+  LastModified?: string;
+}
+
+interface StatisticsPayload {
+  LastModified?: string;
+  SpentReadingMinutes?: number;
+  RemainingTimeMinutes?: number;
+}
+
+interface ReadingStateItem {
+  EntitlementId?: string;
+  LastModified?: string;
+  StatusInfo?: StatusInfoPayload;
+  CurrentBookmark?: BookmarkPayload;
+  Statistics?: StatisticsPayload;
+}
+
+interface KoboStatePutPayload {
+  ReadingStates?: ReadingStateItem[];
+}
+
+export function formatReadingState(
+  progress: ReadingProgressRecord,
+  editionId: string,
+): KoboReadingState {
+  const timestamp = progress.updatedAt.toISOString();
+  const percent = progress.percent ?? 0;
+
+  let status: string;
+  let timesStarted: number;
+  if (percent <= 0 || progress.percent === null) {
+    status = "ReadyToRead";
+    timesStarted = 0;
+  } else if (percent >= 100) {
+    status = "Finished";
+    timesStarted = 1;
+  } else {
+    status = "Reading";
+    timesStarted = 1;
+  }
+
+  const koboLocation = progress.locator.koboLocation;
+
+  const bookmark: KoboReadingState["CurrentBookmark"] = {
+    LastModified: timestamp,
+  };
+  if (koboLocation) {
+    bookmark.Location = koboLocation;
+  }
+  if (progress.percent !== null && progress.percent > 0) {
+    bookmark.ProgressPercent = progress.percent;
+  }
+
+  return {
+    EntitlementId: editionId,
+    Created: timestamp,
+    LastModified: timestamp,
+    PriorityTimestamp: timestamp,
+    StatusInfo: {
+      LastModified: timestamp,
+      Status: status,
+      TimesStartedReading: timesStarted,
+    },
+    Statistics: {
+      LastModified: timestamp,
+    },
+    CurrentBookmark: bookmark,
+  };
+}
+
+export function parseStateUpdate(
+  payload: KoboStatePutPayload | string | null | undefined,
+): KoboStateUpdatePayload | { error: string } {
+  if (typeof payload !== "object" || payload === null) {
+    return { error: "Payload must be an object" };
+  }
+
+  const states = payload.ReadingStates;
+  if (!states || !Array.isArray(states) || states.length === 0) {
+    return { error: "Missing ReadingStates" };
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+  const state = states[0]!;
+
+  const statusInfo = state.StatusInfo;
+  if (!statusInfo || typeof statusInfo !== "object") {
+    return { error: "Missing StatusInfo" };
+  }
+
+  const lastModified = state.LastModified;
+  if (typeof lastModified !== "string") {
+    return { error: "Missing LastModified" };
+  }
+
+  const status = typeof statusInfo.Status === "string" ? statusInfo.Status : "ReadyToRead";
+
+  const bookmark = state.CurrentBookmark;
+  const progress = typeof bookmark?.ProgressPercent === "number" ? bookmark.ProgressPercent : 0;
+  const location = bookmark?.Location ?? null;
+
+  return { status, progress, location, lastModified };
+}
+
+export function resolveConflict(
+  serverUpdatedAt: Date,
+  deviceLastModified: string,
+): { winner: "server" | "device" } {
+  const deviceTime = new Date(deviceLastModified).getTime();
+  const serverTime = serverUpdatedAt.getTime();
+  return { winner: deviceTime >= serverTime ? "device" : "server" };
+}

--- a/packages/kobo/src/sync.test.ts
+++ b/packages/kobo/src/sync.test.ts
@@ -5,7 +5,7 @@ import {
   buildSyncResponse,
 } from "./sync";
 import type { FindEligibleEditionsDeps, SyncedBookRecord } from "./sync";
-import type { EligibleEdition } from "./types";
+import type { EligibleEdition, ReadingProgressRecord } from "./types";
 import type { MetadataOptions } from "./metadata";
 
 const makeEdition = (id: string): EligibleEdition => ({
@@ -136,5 +136,84 @@ describe("buildSyncResponse", () => {
     const result = buildSyncResponse([], [], options);
     expect(result.newEntitlements).toEqual([]);
     expect(result.removedIds).toEqual([]);
+  });
+
+  it("passes progress to entitlement when progressMap provided", () => {
+    const toAdd = [makeEdition("e1")];
+    const progressMap = new Map<string, ReadingProgressRecord>([
+      ["e1", {
+        id: "rp-1",
+        userId: "u1",
+        editionId: "e1",
+        progressKind: "EBOOK",
+        locator: {},
+        percent: 65,
+        source: "kobo",
+        updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+      }],
+    ]);
+    const result = buildSyncResponse(toAdd, [], options, progressMap);
+    expect(result.newEntitlements.at(0)?.ReadingState.StatusInfo.Status).toBe("Reading");
+    expect(result.newEntitlements.at(0)?.ReadingState.CurrentBookmark.ProgressPercent).toBe(65);
+  });
+
+  it("falls back to ReadyToRead when edition not in progressMap", () => {
+    const toAdd = [makeEdition("e1")];
+    const progressMap = new Map<string, ReadingProgressRecord>();
+    const result = buildSyncResponse(toAdd, [], options, progressMap);
+    expect(result.newEntitlements.at(0)?.ReadingState.StatusInfo.Status).toBe("ReadyToRead");
+  });
+
+  it("returns changedReadingStates for progress entries with Location not in toAdd", () => {
+    const koboLocation = { Source: "OEBPS/ch02.xhtml", Type: "KoboSpan", Value: "kobo.2.1" };
+    const toAdd = [makeEdition("e1")];
+    const progressMap = new Map<string, ReadingProgressRecord>([
+      ["e1", {
+        id: "rp-1", userId: "u1", editionId: "e1", progressKind: "EBOOK",
+        locator: { koboLocation }, percent: 50, source: "kobo",
+        updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+      }],
+      ["e2", {
+        id: "rp-2", userId: "u1", editionId: "e2", progressKind: "EBOOK",
+        locator: { koboLocation }, percent: 75, source: "kobo",
+        updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+      }],
+    ]);
+    const result = buildSyncResponse(toAdd, [], options, progressMap);
+    // e1 is in toAdd so it goes in newEntitlements, not changedReadingStates
+    expect(result.newEntitlements).toHaveLength(1);
+    expect(result.changedReadingStates).toHaveLength(1);
+    expect(result.changedReadingStates.at(0)?.EntitlementId).toBe("e2");
+    expect(result.changedReadingStates.at(0)?.CurrentBookmark.ProgressPercent).toBe(75);
+  });
+
+  it("excludes progress without Location from changedReadingStates", () => {
+    const progressMap = new Map<string, ReadingProgressRecord>([
+      ["e1", {
+        id: "rp-1", userId: "u1", editionId: "e1", progressKind: "EBOOK",
+        locator: {}, percent: 50, source: "manual",
+        updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+      }],
+    ]);
+    const result = buildSyncResponse([], [], options, progressMap);
+    expect(result.changedReadingStates).toHaveLength(0);
+  });
+
+  it("returns empty changedReadingStates when all progress is in toAdd", () => {
+    const toAdd = [makeEdition("e1")];
+    const progressMap = new Map<string, ReadingProgressRecord>([
+      ["e1", {
+        id: "rp-1", userId: "u1", editionId: "e1", progressKind: "EBOOK",
+        locator: {}, percent: 50, source: "kobo",
+        updatedAt: new Date("2024-07-01T00:00:00.000Z"),
+      }],
+    ]);
+    const result = buildSyncResponse(toAdd, [], options, progressMap);
+    expect(result.changedReadingStates).toHaveLength(0);
+  });
+
+  it("returns empty changedReadingStates when no progressMap provided", () => {
+    const result = buildSyncResponse([], [], options);
+    expect(result.changedReadingStates).toHaveLength(0);
   });
 });

--- a/packages/kobo/src/sync.ts
+++ b/packages/kobo/src/sync.ts
@@ -1,5 +1,6 @@
-import type { EligibleEdition, SyncResult } from "./types";
+import type { EligibleEdition, ReadingProgressRecord, SyncResult } from "./types";
 import { buildEntitlement } from "./metadata";
+import { formatReadingState } from "./reading-state";
 import type { MetadataOptions } from "./metadata";
 
 export interface SyncedBookRecord {
@@ -39,13 +40,26 @@ export function buildSyncResponse(
   toAdd: EligibleEdition[],
   toRemove: string[],
   options: MetadataOptions,
+  progressMap?: Map<string, ReadingProgressRecord>,
 ): SyncResult {
   const newEntitlements = toAdd.map((edition) =>
-    buildEntitlement(edition, options),
+    buildEntitlement(edition, options, progressMap?.get(edition.id) ?? null),
   );
+
+  // Build ChangedReadingState entries for already-synced books with progress.
+  // Only include records that have a valid Location (from Kobo device);
+  // manual-source records lack Location data and would confuse the device.
+  // Use the current time for timestamps so the Kobo treats them as newer
+  // than its local state (which uses the time of the last sync).
+  const addedIds = new Set(toAdd.map((e) => e.id));
+  const now = new Date();
+  const changedReadingStates = [...(progressMap?.entries() ?? [])]
+    .filter(([id, progress]) => !addedIds.has(id) && progress.locator.koboLocation != null)
+    .map(([id, progress]) => formatReadingState({ ...progress, updatedAt: now }, id));
 
   return {
     newEntitlements,
     removedIds: toRemove,
+    changedReadingStates,
   };
 }

--- a/packages/kobo/src/types.ts
+++ b/packages/kobo/src/types.ts
@@ -13,6 +13,8 @@ export interface KoboReadingState {
   };
   CurrentBookmark: {
     LastModified: string;
+    Location?: KoboLocation | null;
+    ProgressPercent?: number;
   };
 }
 
@@ -87,6 +89,49 @@ export interface SyncToken {
 export interface SyncResult {
   newEntitlements: KoboEntitlement[];
   removedIds: string[];
+  changedReadingStates: KoboReadingState[];
+}
+
+export interface KoboRequestResult {
+  RequestResult: string;
+  UpdateResults: KoboUpdateResult[];
+}
+
+export interface KoboUpdateResult {
+  EntitlementId: string;
+  CurrentBookmarkResult: { Result: string };
+  StatisticsResult: { Result: string };
+  StatusInfoResult: { Result: string };
+}
+
+export type LocatorValue = string | number | boolean | null | LocatorValue[] | { [key: string]: LocatorValue };
+
+export interface KoboLocation {
+  Source: string;
+  Type: string;
+  Value: string;
+}
+
+export interface LocatorData {
+  koboLocation?: KoboLocation;
+}
+
+export interface ReadingProgressRecord {
+  id: string;
+  userId: string;
+  editionId: string;
+  progressKind: string;
+  locator: LocatorData;
+  percent: number | null;
+  source: string | null;
+  updatedAt: Date;
+}
+
+export interface KoboStateUpdatePayload {
+  status: string;
+  progress: number;
+  location: KoboLocation | null;
+  lastModified: string;
 }
 
 export interface EligibleEdition {


### PR DESCRIPTION
## Summary
- Add `GET`/`PUT` `/v1/library/{bookId}/state` endpoints for Kobo reading progress sync using correct protocol formats (discovered by studying Komga and BookLore implementations)
- Include `ChangedReadingState` entries in sync response to push device-sourced progress back to Kobo
- Add manual progress editing UI on work detail page with per-edition inline editing
- Fix `addKoboDeviceServerFn` to use `getCurrentUser()` instead of `getFirstUserId()` (was causing userId mismatch)
- Add `reading-state` module with `formatReadingState`, `parseStateUpdate`, `resolveConflict`

Kobo→Bookhouse progress fully works. Bookhouse→Kobo percentage display syncs via `ChangedReadingState`, but opening to the correct position requires EPUB spine parsing (future work documented in #88).

## Key protocol findings documented in #88
- PUT `/state` must return `RequestResult`, not a reading state
- GET `/state` must return an array
- Null fields must be omitted (not sent as `null`)
- Field name is `ProgressPercent`, not `Progress`
- `ChangedReadingState` timestamps must be current, not historical

Relates to #88