### PR TITLE
Fix cover resize passing empty deps to resizeCoverImage

### DIFF
--- a/packages/ingest/src/covers.test.ts
+++ b/packages/ingest/src/covers.test.ts
@@ -351,6 +351,27 @@ describe("processCoverForWork", () => {
     );
   });
 
+  it("calls resizeCoverImage with only input, not extra deps", async () => {
+    const resizeCoverImage = vi.fn().mockResolvedValue({
+      thumbPath: "/data/covers/work-1/thumb.webp",
+      mediumPath: "/data/covers/work-1/medium.webp",
+    });
+    const deps = createMockDeps({
+      extractEpubCover: vi.fn().mockResolvedValue({
+        buffer: Buffer.from("epub-cover"),
+        mediaType: "image/jpeg",
+      }),
+      resizeCoverImage,
+    });
+
+    await processCoverForWork(createInput(), deps);
+
+    expect(resizeCoverImage).toHaveBeenCalledWith({
+      imageBuffer: Buffer.from("epub-cover"),
+      outputDir: path.join("/data/covers", "work-1"),
+    });
+  });
+
   it("proceeds without colors when extractColors fails", async () => {
     const workUpdate = vi.fn().mockResolvedValue({});
     const deps = createMockDeps({

--- a/packages/ingest/src/covers.ts
+++ b/packages/ingest/src/covers.ts
@@ -54,7 +54,7 @@ export interface CoverDependencies {
   extractEpubCover: (absolutePath: string) => Promise<EpubCoverResult | null>;
   readFile: ReadFileFn;
   detectAdjacentCover: (directory: string, listDirectory?: ListDirectoryFn) => Promise<string | null>;
-  resizeCoverImage: (input: { imageBuffer: Buffer; outputDir: string }, deps: ResizeCoverDeps) => Promise<{ thumbPath: string; mediumPath: string }>;
+  resizeCoverImage: (input: { imageBuffer: Buffer; outputDir: string }) => Promise<{ thumbPath: string; mediumPath: string }>;
   extractColors: (imageBuffer: Buffer) => Promise<string[]>;
   db: CoverDb;
   logger?: CoverLogger;
@@ -182,7 +182,7 @@ export async function processCoverForWork(
   }
 
   const outputDir = path.join(input.coverCacheDir, input.workId);
-  await deps.resizeCoverImage({ imageBuffer, outputDir }, {} as ResizeCoverDeps);
+  await deps.resizeCoverImage({ imageBuffer, outputDir });
 
   let coverColors: string[] | undefined;
   try {


### PR DESCRIPTION
## Summary

- Removes the `{} as ResizeCoverDeps` type lie passed as the second argument to `resizeCoverImage` in `processCoverForWork` (line 185)
- Simplifies `CoverDependencies.resizeCoverImage` to a single-argument signature — callers bake their own deps in via closure, as `processCoverForWorkDefault` already does
- Adds a regression test verifying `resizeCoverImage` is called with only the input object

Closes #152