### PR TITLE
Add logging to all silent catch blocks (#154)

### DIFF
--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -37,6 +37,7 @@ export type {
   HashFileAssetResult,
   IngestDb,
   IngestDependencies,
+  IngestLogger,
   MatchFileAssetToEditionInput,
   MatchFileAssetToEditionResult,
   NormalizedBookMetadata,

--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -711,6 +711,22 @@ describe("ingest services", () => {
   });
 
   it("continues when a directory cannot be listed", async () => {
+    const warnMock = vi.fn();
+    const files = await walkRegularFiles(
+      "/tmp/unreadable-root",
+      (() => Promise.reject(new Error("permission denied"))) as ReaddirFn,
+      (() => Promise.reject(new Error("should not be called"))) as LstatFn,
+      { info: vi.fn(), warn: warnMock },
+    );
+
+    expect(files).toEqual([]);
+    expect(warnMock).toHaveBeenCalledWith(
+      { err: "permission denied", path: "/tmp/unreadable-root" },
+      "Failed to list directory",
+    );
+  });
+
+  it("continues silently when a directory cannot be listed and no logger is provided", async () => {
     const files = await walkRegularFiles(
       "/tmp/unreadable-root",
       (() => Promise.reject(new Error("permission denied"))) as ReaddirFn,
@@ -718,6 +734,23 @@ describe("ingest services", () => {
     );
 
     expect(files).toEqual([]);
+  });
+
+  it("logs non-Error throw as string when listing directory fails", async () => {
+    const warnMock = vi.fn();
+    const listDir = vi.fn().mockRejectedValue("EPERM");
+    const files = await walkRegularFiles(
+      "/tmp/unreadable-root",
+      listDir as ReaddirFn,
+      (() => Promise.reject(new Error("should not be called"))) as LstatFn,
+      { info: vi.fn(), warn: warnMock },
+    );
+
+    expect(files).toEqual([]);
+    expect(warnMock).toHaveBeenCalledWith(
+      { err: "EPERM", path: "/tmp/unreadable-root" },
+      "Failed to list directory",
+    );
   });
 
   it("falls back to lstat for ambiguous directory entries", async () => {
@@ -1330,6 +1363,52 @@ describe("ingest services", () => {
     );
     expect(batchCall).toBeDefined();
     expect(batchCall?.[0].errorCount).toBe(count);
+  });
+
+  it("logs warning when stat collection fails for a path", async () => {
+    const state = createEmptyState("/tmp/root");
+    const entries = [{ isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false, name: "broken.epub" }];
+    const listDirectory = (() => Promise.resolve(entries as never)) as ReaddirFn;
+    const readStats = vi.fn(() => Promise.reject(new Error("gone"))) as object as LstatFn;
+    const warnMock = vi.fn();
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      listDirectory,
+      readStats,
+      logger: { info: vi.fn(), warn: warnMock },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(warnMock).toHaveBeenCalledWith(
+      { err: "gone", path: "/tmp/root/broken.epub" },
+      "Failed to stat path",
+    );
+  });
+
+  it("logs non-Error throw as string when stat collection fails", async () => {
+    const state = createEmptyState("/tmp/root");
+    const entries = [{ isDirectory: () => false, isFile: () => true, isSymbolicLink: () => false, name: "broken.epub" }];
+    const listDirectory = (() => Promise.resolve(entries as never)) as ReaddirFn;
+    const readStats = vi.fn().mockRejectedValue("ENOENT") as object as LstatFn;
+    const warnMock = vi.fn();
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      listDirectory,
+      readStats,
+      logger: { info: vi.fn(), warn: warnMock },
+    });
+
+    await services.scanLibraryRoot({ libraryRootId: "root-1" });
+
+    expect(warnMock).toHaveBeenCalledWith(
+      { err: "ENOENT", path: "/tmp/root/broken.epub" },
+      "Failed to stat path",
+    );
   });
 
   it("calls reportProgress at batch intervals for non-file entries", async () => {
@@ -5510,6 +5589,147 @@ describe("ingest services", () => {
     expect(enqueueLibraryJob).toHaveBeenCalledWith(
       LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
       { fileAssetId: "file-1" },
+    );
+  });
+
+  it("logs warning when ID3 parsing fails for audio sibling during sidecar flow", async () => {
+    const state = createEmptyState("/tmp/root");
+    const sidecarAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.json",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.json",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "json",
+      fullHash: "hash",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.json",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(sidecarAsset.absolutePath, sidecarAsset);
+    state.fileAssetsById.set(sidecarAsset.id, sidecarAsset);
+
+    const audioSibling: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/chapter01.mp3",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "chapter01.mp3",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "mp3",
+      fullHash: "audio-hash",
+      id: "file-audio",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.AUDIO,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "audio-phash",
+      relativePath: "Author/Book/chapter01.mp3",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(audioSibling.absolutePath, audioSibling);
+    state.fileAssetsById.set(audioSibling.id, audioSibling);
+
+    const warnMock = vi.fn();
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      parseAudiobookJson: vi.fn().mockResolvedValue({
+        title: "Project Hail Mary",
+        authors: ["Andy Weir"],
+        narrators: [],
+        series: [],
+        genres: [],
+      }),
+      parseAudioId3: vi.fn().mockRejectedValue(new Error("corrupt ID3 header")),
+      logger: { info: vi.fn(), warn: warnMock },
+    });
+
+    await services.parseFileAssetMetadata({
+      fileAssetId: "file-1",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    expect(warnMock).toHaveBeenCalledWith(
+      {
+        err: "corrupt ID3 header",
+        audioPath: "/tmp/root/Author/Book/chapter01.mp3",
+        sidecarPath: "/tmp/root/Author/Book/metadata.json",
+        fileAssetId: "file-1",
+      },
+      "ID3 parsing failed for audio sibling during sidecar flow",
+    );
+  });
+
+  it("logs non-Error throw as string when ID3 parsing fails during sidecar flow", async () => {
+    const state = createEmptyState("/tmp/root");
+    const sidecarAsset: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/metadata.json",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "metadata.json",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "json",
+      fullHash: "hash",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.SIDECAR,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "phash",
+      relativePath: "Author/Book/metadata.json",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(sidecarAsset.absolutePath, sidecarAsset);
+    state.fileAssetsById.set(sidecarAsset.id, sidecarAsset);
+
+    const audioSibling: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Book/chapter01.mp3",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "chapter01.mp3",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "mp3",
+      fullHash: "audio-hash",
+      id: "file-audio",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.AUDIO,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "audio-phash",
+      relativePath: "Author/Book/chapter01.mp3",
+      sizeBytes: 100n,
+    };
+    state.fileAssets.set(audioSibling.absolutePath, audioSibling);
+    state.fileAssetsById.set(audioSibling.id, audioSibling);
+
+    const warnMock = vi.fn();
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      parseAudiobookJson: vi.fn().mockResolvedValue({
+        title: "Project Hail Mary",
+        authors: ["Andy Weir"],
+        narrators: [],
+        series: [],
+        genres: [],
+      }),
+      parseAudioId3: vi.fn().mockRejectedValue("ID3_CORRUPT"),
+      logger: { info: vi.fn(), warn: warnMock },
+    });
+
+    await services.parseFileAssetMetadata({
+      fileAssetId: "file-1",
+      now: new Date("2025-01-01T00:00:00.000Z"),
+    });
+
+    expect(warnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ err: "ID3_CORRUPT" }),
+      "ID3 parsing failed for audio sibling during sidecar flow",
     );
   });
 

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -480,6 +480,7 @@ interface ScanPathStatsResult {
 async function collectScanPathStats(
   discoveredPaths: string[],
   readStats: ReadStatsFn,
+  logger?: IngestLogger,
 ): Promise<ScanPathStatsResult[]> {
   const results = new Array<ScanPathStatsResult>(discoveredPaths.length);
   let nextIndex = 0;
@@ -496,7 +497,11 @@ async function collectScanPathStats(
           fileStats: await readStats(absolutePath),
           statFailed: false,
         };
-      } catch {
+      } catch (error) {
+        logger?.warn(
+          { err: error instanceof Error ? error.message : String(error), path: absolutePath },
+          "Failed to stat path",
+        );
         results[currentIndex] = {
           absolutePath,
           statFailed: true,
@@ -718,6 +723,7 @@ async function walkRegularFiles(
   rootPath: string,
   listDirectory: ListDirectoryFn,
   readStats: ReadStatsFn,
+  logger?: IngestLogger,
 ): Promise<string[]> {
   const pendingDirectories = [normalizeRootPath(rootPath)];
   const files: string[] = [];
@@ -729,7 +735,11 @@ async function walkRegularFiles(
 
     try {
       entries = await listDirectory(currentDirectory, { withFileTypes: true });
-    } catch {
+    } catch (error) {
+      logger?.warn(
+        { err: error instanceof Error ? error.message : String(error), path: currentDirectory },
+        "Failed to list directory",
+      );
       continue;
     }
 
@@ -1447,8 +1457,8 @@ export function createIngestServices(
     const workById = new Map(
       existingWorks.map((work) => [work.id, work]),
     );
-    const discoveredPaths = await walkRegularFiles(normalizedRootPath, listDirectory, readStats);
-    const scanPathStats = await collectScanPathStats(discoveredPaths, readStats);
+    const discoveredPaths = await walkRegularFiles(normalizedRootPath, listDirectory, readStats, logger);
+    const scanPathStats = await collectScanPathStats(discoveredPaths, readStats, logger);
     const seenPaths = new Set<string>();
     const scannedFileAssetIds: string[] = [];
     const enqueuedHashJobs: string[] = [];
@@ -2038,8 +2048,16 @@ export function createIngestServices(
           try {
             const { tags } = await parseAudioId3(firstAudioSibling.absolutePath);
             id3Raw = tags;
-          } catch {
-            // ID3 parsing failure is non-fatal for sidecar flow
+          } catch (error) {
+            logger.warn(
+              {
+                err: error instanceof Error ? error.message : String(error),
+                audioPath: firstAudioSibling.absolutePath,
+                sidecarPath: fileAsset.absolutePath,
+                fileAssetId: fileAsset.id,
+              },
+              "ID3 parsing failed for audio sibling during sidecar flow",
+            );
           }
         }
 

--- a/workers/library-worker/src/index.test.ts
+++ b/workers/library-worker/src/index.test.ts
@@ -13,6 +13,11 @@ type EnrichDeps = {
   acquireOLToken: () => Promise<void>;
 };
 
+const loggerInfoMock = vi.fn();
+const loggerWarnMock = vi.fn();
+const loggerErrorMock = vi.fn();
+const mockLogger = { info: loggerInfoMock, warn: loggerWarnMock, error: loggerErrorMock };
+
 const addMock = vi.fn();
 const onMock = vi.fn();
 const workerCloseMock = vi.fn(() => Promise.resolve(undefined));
@@ -132,6 +137,7 @@ vi.mock("@bookhouse/shared", async () => {
 
   return {
     ...actual,
+    createLogger: () => mockLogger,
     getQueueConnectionConfig: queueConnectionConfigMock,
     enqueueLibraryJob: enqueueLibraryJobMock,
   };
@@ -154,6 +160,9 @@ function createMockJob(overrides: Record<string, string | number | boolean | obj
 }
 
 beforeEach(() => {
+  loggerInfoMock.mockReset();
+  loggerWarnMock.mockReset();
+  loggerErrorMock.mockReset();
   addMock.mockReset();
   createIngestServicesMock.mockReset();
   detectDuplicatesMock.mockReset();
@@ -1399,6 +1408,34 @@ describe("library worker", () => {
 
     _setActiveScanType(null);
     expect(_getActiveScanType()).toBe("onDemand");
+  });
+
+  it("logs warning when DB is unavailable during concurrency poll", async () => {
+    appSettingFindUniqueMock.mockRejectedValue(new Error("DB down"));
+    const { _pollConcurrency } = await import("./index");
+
+    const fakeWorker = { concurrency: 5 };
+    await _pollConcurrency(fakeWorker);
+
+    expect(fakeWorker.concurrency).toBe(5);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      { err: "DB down" },
+      "Failed to poll concurrency settings",
+    );
+  });
+
+  it("logs non-Error throw as string when DB poll fails", async () => {
+    appSettingFindUniqueMock.mockRejectedValue("CONNECTION_RESET");
+    const { _pollConcurrency } = await import("./index");
+
+    const fakeWorker = { concurrency: 5 };
+    await _pollConcurrency(fakeWorker);
+
+    expect(fakeWorker.concurrency).toBe(5);
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      { err: "CONNECTION_RESET" },
+      "Failed to poll concurrency settings",
+    );
   });
 
   it("polls DB using concurrencyIncremental key when an incremental scan is active", async () => {

--- a/workers/library-worker/src/index.ts
+++ b/workers/library-worker/src/index.ts
@@ -396,8 +396,8 @@ async function pollConcurrency(worker: Pick<Worker, "concurrency">): Promise<voi
       worker.concurrency = desired;
       logger.info({ concurrency: desired }, "Worker concurrency updated");
     }
-  } catch {
-    // DB unavailable — keep current concurrency
+  } catch (error) {
+    logger.warn({ err: error instanceof Error ? error.message : String(error) }, "Failed to poll concurrency settings");
   }
 }
 


### PR DESCRIPTION
## Summary

- Added `logger.warn(...)` calls to 4 bare `catch { }` blocks that silently swallowed errors
- Threaded `logger` parameter into `walkRegularFiles` and `collectScanPathStats` standalone functions
- Mocked `createLogger` in library-worker tests to enable asserting on log output
- Verified the 2 `enrichment-worker.ts` locations from the issue already had logging (false positives)

### Locations fixed
| File | Operation | Context logged |
|------|-----------|----------------|
| `services.ts` | `collectScanPathStats` stat failure | `err`, `path` |
| `services.ts` | `walkRegularFiles` directory listing failure | `err`, `path` |
| `services.ts` | Audiobook sidecar ID3 parsing failure | `err`, `audioPath`, `sidecarPath`, `fileAssetId` |
| `index.ts` (library-worker) | `pollConcurrency` DB unavailability | `err` |

## Test plan
- 9 new tests covering all 4 catch blocks (Error and non-Error branches, plus no-logger path)
- All CI gates pass: lint, typecheck, test (100% coverage), build

Closes #154