### PR TITLE
Add compound indexes on ImportJob and FileAsset

### DIFF
--- a/packages/db/prisma/migrations/20260401120000_add_compound_indexes_import_job_file_asset/migration.sql
+++ b/packages/db/prisma/migrations/20260401120000_add_compound_indexes_import_job_file_asset/migration.sql
@@ -1,0 +1,5 @@
+-- CreateIndex
+CREATE INDEX "FileAsset_libraryRootId_availabilityStatus_idx" ON "FileAsset"("libraryRootId", "availabilityStatus");
+
+-- CreateIndex
+CREATE INDEX "ImportJob_libraryRootId_status_idx" ON "ImportJob"("libraryRootId", "status");

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -210,6 +210,7 @@ model FileAsset {
   duplicateRight DuplicateCandidate[] @relation("DuplicateRightFile")
 
   @@index([libraryRootId])
+  @@index([libraryRootId, availabilityStatus])
   @@index([partialHash])
   @@index([fullHash])
 }
@@ -451,6 +452,7 @@ model ImportJob {
   libraryRoot LibraryRoot? @relation(fields: [libraryRootId], references: [id])
 
   @@index([status])
+  @@index([libraryRootId, status])
   @@index([kind])
   @@index([createdAt])
 }


### PR DESCRIPTION
## Summary

- Adds `@@index([libraryRootId, status])` on `ImportJob` to support the scan restart cleanup query that filters by both fields
- Adds `@@index([libraryRootId, availabilityStatus])` on `FileAsset` for scan queries filtering missing files within a library root

Closes #159