### PR TITLE
Refactor: break up large frontend route components

### DIFF
--- a/apps/web/src/components/edition-progress.test.tsx
+++ b/apps/web/src/components/edition-progress.test.tsx
@@ -1,0 +1,171 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/components/progress-bar", () => ({
+  ProgressBar: ({ percent }: { percent: number }) => (
+    <div data-testid="progress-bar" data-percent={percent} />
+  ),
+}));
+
+import { EditionProgress, progressKindForEdition } from "./edition-progress";
+
+type Editions = Parameters<typeof EditionProgress>[0]["editions"];
+
+/** Cast test data to the Editions type without going through `unknown` */
+function asEditions(data: object[]): Editions {
+  return data as Editions & object[];
+}
+
+describe("progressKindForEdition", () => {
+  it("returns AUDIO for AUDIOBOOK", () => {
+    expect(progressKindForEdition("AUDIOBOOK")).toBe("AUDIO");
+  });
+
+  it("returns EBOOK for other formats", () => {
+    expect(progressKindForEdition("EBOOK")).toBe("EBOOK");
+    expect(progressKindForEdition("PDF")).toBe("EBOOK");
+  });
+});
+
+describe("EditionProgress", () => {
+  const mockOnUpdate = vi.fn();
+
+  const editions = asEditions([
+    {
+      id: "e1",
+      formatFamily: "EBOOK",
+      publisher: null,
+      publishedAt: null,
+      isbn13: null,
+      isbn10: null,
+      asin: null,
+      language: null,
+      pageCount: null,
+      editedFields: [],
+      contributors: [],
+      editionFiles: [],
+    },
+  ]);
+
+  const progress = [
+    { editionId: "e1", progressKind: "EBOOK", percent: 42, source: "Kobo" as string | null },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockOnUpdate.mockResolvedValue(undefined);
+  });
+
+  it("renders progress bar for each edition", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    expect(screen.getByTestId("progress-bar")).toBeTruthy();
+  });
+
+  it("renders format badge", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    expect(screen.getByText("EBOOK")).toBeTruthy();
+  });
+
+  it("renders source badge", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    expect(screen.getByText("via Kobo")).toBeTruthy();
+  });
+
+  it("does not render source badge when source is null", () => {
+    const noSourceProgress = [{ editionId: "e1", progressKind: "EBOOK", percent: 42, source: null }];
+    render(<EditionProgress progress={noSourceProgress} editions={editions} onUpdate={mockOnUpdate} />);
+    expect(screen.queryByText(/via/)).toBeNull();
+  });
+
+  it("shows edit input when clicking percentage", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    fireEvent.click(screen.getByTestId("progress-edit-e1"));
+    expect(screen.getByTestId("progress-input-e1")).toBeTruthy();
+  });
+
+  it("calls onUpdate when saving valid value", async () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    fireEvent.click(screen.getByTestId("progress-edit-e1"));
+    const input = screen.getByTestId("progress-input-e1");
+    fireEvent.change(input, { target: { value: "75" } });
+    fireEvent.click(screen.getByTestId("progress-save-e1"));
+
+    await waitFor(() => {
+      expect(mockOnUpdate).toHaveBeenCalledWith("e1", 75, "EBOOK");
+    });
+  });
+
+  it("calls onUpdate on Enter key", async () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    fireEvent.click(screen.getByTestId("progress-edit-e1"));
+    const input = screen.getByTestId("progress-input-e1");
+    fireEvent.change(input, { target: { value: "50" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockOnUpdate).toHaveBeenCalledWith("e1", 50, "EBOOK");
+    });
+  });
+
+  it("cancels editing on Escape", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    fireEvent.click(screen.getByTestId("progress-edit-e1"));
+    const input = screen.getByTestId("progress-input-e1");
+    fireEvent.keyDown(input, { key: "Escape" });
+    expect(screen.queryByTestId("progress-input-e1")).toBeNull();
+  });
+
+  it("cancels editing when cancel button is clicked", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    fireEvent.click(screen.getByTestId("progress-edit-e1"));
+    fireEvent.click(screen.getByTestId("progress-cancel-e1"));
+    expect(screen.queryByTestId("progress-input-e1")).toBeNull();
+  });
+
+  it("does not call onUpdate for invalid values", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    fireEvent.click(screen.getByTestId("progress-edit-e1"));
+    const input = screen.getByTestId("progress-input-e1");
+    fireEvent.change(input, { target: { value: "abc" } });
+    fireEvent.click(screen.getByTestId("progress-save-e1"));
+    expect(mockOnUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not call onUpdate for values > 100", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    fireEvent.click(screen.getByTestId("progress-edit-e1"));
+    const input = screen.getByTestId("progress-input-e1");
+    fireEvent.change(input, { target: { value: "150" } });
+    fireEvent.click(screen.getByTestId("progress-save-e1"));
+    expect(mockOnUpdate).not.toHaveBeenCalled();
+  });
+
+  it("does not call onUpdate for negative values", () => {
+    render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
+    fireEvent.click(screen.getByTestId("progress-edit-e1"));
+    const input = screen.getByTestId("progress-input-e1");
+    fireEvent.change(input, { target: { value: "-5" } });
+    fireEvent.click(screen.getByTestId("progress-save-e1"));
+    expect(mockOnUpdate).not.toHaveBeenCalled();
+  });
+
+  it("uses progressKindForEdition when no progress exists for edition", () => {
+    const audioEditions = asEditions([{
+      id: "e-audio",
+      formatFamily: "AUDIOBOOK",
+      publisher: null,
+      publishedAt: null,
+      isbn13: null,
+      isbn10: null,
+      asin: null,
+      language: null,
+      pageCount: null,
+      editedFields: [],
+      contributors: [],
+      editionFiles: [],
+    }]);
+    render(<EditionProgress progress={[]} editions={audioEditions} onUpdate={mockOnUpdate} />);
+    expect(screen.getByText("AUDIOBOOK")).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/edition-progress.tsx
+++ b/apps/web/src/components/edition-progress.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import { Loader2, Pencil } from "lucide-react";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { ProgressBar } from "~/components/progress-bar";
+import type { WorkDetail } from "~/lib/server-fns/work-detail";
+
+export function progressKindForEdition(formatFamily: string): "EBOOK" | "AUDIO" | "READALOUD" {
+  if (formatFamily === "AUDIOBOOK") return "AUDIO";
+  return "EBOOK";
+}
+
+interface EditionProgressProps {
+  progress: { editionId: string; progressKind: string; percent: number | null; source: string | null }[];
+  editions: WorkDetail["editions"];
+  onUpdate: (editionId: string, percent: number, progressKind: string) => Promise<void>;
+}
+
+export function EditionProgress({ progress, editions, onUpdate }: EditionProgressProps) {
+  const progressMap = new Map(progress.map((p) => [p.editionId, p]));
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave(editionId: string, progressKind: string) {
+    const val = parseInt(editValue, 10);
+    if (isNaN(val) || val < 0 || val > 100) return;
+    setSaving(true);
+    try {
+      await onUpdate(editionId, val, progressKind);
+      setEditingId(null);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="space-y-3">
+      {editions.map((edition) => {
+        const p = progressMap.get(edition.id);
+        const percent = p?.percent ?? 0;
+        const progressKind = p?.progressKind ?? progressKindForEdition(edition.formatFamily);
+        const isEditing = editingId === edition.id;
+
+        return (
+          <div key={edition.id} className="space-y-1">
+            <div className="flex items-center gap-2 text-sm">
+              <Badge variant="secondary">{edition.formatFamily}</Badge>
+              {p?.source && <Badge variant="outline" className="text-xs">via {p.source}</Badge>}
+            </div>
+            <div className="flex items-center gap-2">
+              <div className="flex-1">
+                <ProgressBar percent={percent} />
+              </div>
+              {isEditing ? (
+                <div className="flex items-center gap-1">
+                  <input
+                    data-testid={`progress-input-${edition.id}`}
+                    type="number"
+                    min={0}
+                    max={100}
+                    value={editValue}
+                    onChange={(e) => { setEditValue(e.target.value); }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") { void handleSave(edition.id, progressKind); }
+                      if (e.key === "Escape") { setEditingId(null); }
+                    }}
+                    className="w-16 rounded border px-2 py-0.5 text-sm text-right"
+                    autoFocus
+                    disabled={saving}
+                  />
+                  <span className="text-sm">%</span>
+                  <Button
+                    size="sm"
+                    variant="outline"
+                    disabled={saving}
+                    onClick={() => { void handleSave(edition.id, progressKind); }}
+                    data-testid={`progress-save-${edition.id}`}
+                  >
+                    {saving ? <Loader2 className="size-3 animate-spin" /> : "Save"}
+                  </Button>
+                  <Button
+                    size="sm"
+                    variant="ghost"
+                    disabled={saving}
+                    onClick={() => { setEditingId(null); }}
+                    data-testid={`progress-cancel-${edition.id}`}
+                  >
+                    ✕
+                  </Button>
+                </div>
+              ) : (
+                <button
+                  className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground group"
+                  onClick={() => { setEditingId(edition.id); setEditValue(String(percent)); }}
+                  data-testid={`progress-edit-${edition.id}`}
+                  aria-label={`Edit progress for ${edition.formatFamily}`}
+                >
+                  <span>{String(percent)}%</span>
+                  <Pencil className="size-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                </button>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/components/library-selection-toolbar.test.tsx
+++ b/apps/web/src/components/library-selection-toolbar.test.tsx
@@ -1,0 +1,148 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/lib/server-fns/deletion", () => ({
+  bulkDeleteWorksServerFn: vi.fn(),
+}));
+
+vi.mock("~/lib/server-fns/shelves", () => ({
+  bulkAddToShelfServerFn: vi.fn(),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+import { toast } from "sonner";
+import { bulkDeleteWorksServerFn } from "~/lib/server-fns/deletion";
+import { bulkAddToShelfServerFn } from "~/lib/server-fns/shelves";
+import { LibrarySelectionToolbar } from "./library-selection-toolbar";
+
+const bulkDeleteWorksServerFnMock = vi.mocked(bulkDeleteWorksServerFn);
+const bulkAddToShelfServerFnMock = vi.mocked(bulkAddToShelfServerFn);
+const mockToast = vi.mocked(toast);
+
+const defaultProps = {
+  selectedCount: 1,
+  selectedWorkIds: ["w1"],
+  shelves: [] as { id: string; name: string; _count: { items: number } }[],
+  onDeleted: vi.fn(),
+  onAddedToShelf: vi.fn(),
+  onClearSelection: vi.fn(),
+};
+
+describe("LibrarySelectionToolbar", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns null when selectedCount is 0", () => {
+    const { container } = render(<LibrarySelectionToolbar {...defaultProps} selectedCount={0} selectedWorkIds={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("shows selection count text", () => {
+    render(<LibrarySelectionToolbar {...defaultProps} />);
+    expect(screen.getByText(/1 work selected/)).toBeTruthy();
+  });
+
+  it("shows plural text for multiple selections", () => {
+    render(<LibrarySelectionToolbar {...defaultProps} selectedCount={3} selectedWorkIds={["w1", "w2", "w3"]} />);
+    expect(screen.getByText(/3 works selected/)).toBeTruthy();
+  });
+
+  it("calls onClearSelection when Clear is clicked", () => {
+    const onClearSelection = vi.fn();
+    render(<LibrarySelectionToolbar {...defaultProps} onClearSelection={onClearSelection} />);
+    fireEvent.click(screen.getByText("Clear"));
+    expect(onClearSelection).toHaveBeenCalled();
+  });
+
+  it("opens delete dialog and calls bulkDeleteWorksServerFn on confirm", async () => {
+    bulkDeleteWorksServerFnMock.mockResolvedValue({ deletedWorkIds: ["w1"] });
+    const onDeleted = vi.fn();
+    render(<LibrarySelectionToolbar {...defaultProps} onDeleted={onDeleted} />);
+
+    fireEvent.click(screen.getByText("Delete Selected"));
+    expect(screen.getByText(/will remove 1 work/)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(bulkDeleteWorksServerFnMock).toHaveBeenCalledWith({ data: { workIds: ["w1"] } });
+    });
+    await waitFor(() => {
+      expect(onDeleted).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error toast when delete fails", async () => {
+    bulkDeleteWorksServerFnMock.mockRejectedValue(new Error("fail"));
+    render(<LibrarySelectionToolbar {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Delete Selected"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("fail");
+    });
+  });
+
+  it("shows generic error toast when delete fails with non-Error", async () => {
+    bulkDeleteWorksServerFnMock.mockRejectedValue("oops");
+    render(<LibrarySelectionToolbar {...defaultProps} />);
+
+    fireEvent.click(screen.getByText("Delete Selected"));
+    fireEvent.click(screen.getByRole("button", { name: "Delete" }));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Failed to delete works");
+    });
+  });
+
+  it("closes delete dialog on cancel", () => {
+    render(<LibrarySelectionToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByText("Delete Selected"));
+    expect(screen.getByText(/will remove 1 work/)).toBeTruthy();
+    fireEvent.click(screen.getByText("Cancel"));
+  });
+
+  it("opens shelf picker and calls bulkAddToShelfServerFn", async () => {
+    bulkAddToShelfServerFnMock.mockResolvedValue({ added: 1 });
+    const onAddedToShelf = vi.fn();
+    const shelves = [{ id: "s1", name: "Fiction", _count: { items: 3 } }];
+    render(<LibrarySelectionToolbar {...defaultProps} shelves={shelves} onAddedToShelf={onAddedToShelf} />);
+
+    fireEvent.click(screen.getByTestId("bulk-add-to-shelf-btn"));
+    expect(screen.getByTestId("shelf-picker")).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId("shelf-pick-s1"));
+
+    await waitFor(() => {
+      expect(bulkAddToShelfServerFnMock).toHaveBeenCalledWith({ data: { shelfId: "s1", workIds: ["w1"] } });
+    });
+    await waitFor(() => {
+      expect(onAddedToShelf).toHaveBeenCalled();
+    });
+  });
+
+  it("shows error toast when shelf add fails", async () => {
+    bulkAddToShelfServerFnMock.mockRejectedValue(new Error("DB error"));
+    const shelves = [{ id: "s1", name: "Fiction", _count: { items: 3 } }];
+    render(<LibrarySelectionToolbar {...defaultProps} shelves={shelves} />);
+
+    fireEvent.click(screen.getByTestId("bulk-add-to-shelf-btn"));
+    fireEvent.click(screen.getByTestId("shelf-pick-s1"));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Failed to add to shelf");
+    });
+  });
+
+  it("shows empty shelf message when no shelves exist", () => {
+    render(<LibrarySelectionToolbar {...defaultProps} />);
+    fireEvent.click(screen.getByTestId("bulk-add-to-shelf-btn"));
+    expect(screen.getByText(/No shelves created yet/)).toBeTruthy();
+  });
+});

--- a/apps/web/src/components/library-selection-toolbar.tsx
+++ b/apps/web/src/components/library-selection-toolbar.tsx
@@ -1,0 +1,135 @@
+import { useState } from "react";
+import { toast } from "sonner";
+import { FolderOpen, Trash2, X } from "lucide-react";
+import { Button } from "~/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "~/components/ui/dialog";
+import { bulkDeleteWorksServerFn } from "~/lib/server-fns/deletion";
+import { bulkAddToShelfServerFn } from "~/lib/server-fns/shelves";
+
+interface LibrarySelectionToolbarProps {
+  selectedCount: number;
+  selectedWorkIds: string[];
+  shelves: { id: string; name: string; _count: { items: number } }[];
+  onDeleted: () => void;
+  onAddedToShelf: () => void;
+  onClearSelection: () => void;
+}
+
+export function LibrarySelectionToolbar({
+  selectedCount,
+  selectedWorkIds,
+  shelves,
+  onDeleted,
+  onAddedToShelf,
+  onClearSelection,
+}: LibrarySelectionToolbarProps) {
+  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
+  const [bulkDeleting, setBulkDeleting] = useState(false);
+  const [addToShelfOpen, setAddToShelfOpen] = useState(false);
+  const [addingToShelf, setAddingToShelf] = useState(false);
+
+  if (selectedCount === 0) return null;
+
+  async function handleBulkDelete() {
+    setBulkDeleting(true);
+    try {
+      await bulkDeleteWorksServerFn({ data: { workIds: selectedWorkIds } });
+      toast.success(`${String(selectedWorkIds.length)} work${selectedWorkIds.length === 1 ? "" : "s"} deleted`);
+      setBulkDeleteOpen(false);
+      onDeleted();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to delete works");
+    } finally {
+      setBulkDeleting(false);
+    }
+  }
+
+  async function handleAddToShelf(shelfId: string) {
+    setAddingToShelf(true);
+    try {
+      const result = await bulkAddToShelfServerFn({ data: { shelfId, workIds: selectedWorkIds } });
+      toast.success(`Added ${String(result.added)} to shelf`);
+      setAddToShelfOpen(false);
+      onAddedToShelf();
+    } catch {
+      toast.error("Failed to add to shelf");
+    } finally {
+      setAddingToShelf(false);
+    }
+  }
+
+  return (
+    <>
+      <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-lg border bg-background p-3 shadow-lg">
+        <span className="text-sm font-medium">{selectedCount} work{selectedCount === 1 ? "" : "s"} selected</span>
+        <Button variant="outline" size="sm" onClick={() => { setAddToShelfOpen(true); }} data-testid="bulk-add-to-shelf-btn">
+          <FolderOpen className="mr-1.5 size-3.5" />
+          Add to Shelf
+        </Button>
+        <Button variant="destructive" size="sm" onClick={() => { setBulkDeleteOpen(true); }}>
+          <Trash2 className="mr-1.5 size-3.5" />
+          Delete Selected
+        </Button>
+        <Button variant="outline" size="sm" onClick={onClearSelection}>
+          <X className="mr-1.5 size-3.5" />
+          Clear
+        </Button>
+      </div>
+
+      <Dialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete {selectedCount} Work{selectedCount === 1 ? "" : "s"}</DialogTitle>
+            <DialogDescription>
+              This will remove {selectedCount} work{selectedCount === 1 ? "" : "s"} and all {selectedCount === 1 ? "its" : "their"} editions from the library.
+              The actual files on disk will not be affected.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => { setBulkDeleteOpen(false); }} disabled={bulkDeleting}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={() => { void handleBulkDelete(); }} disabled={bulkDeleting}>
+              {bulkDeleting ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog open={addToShelfOpen} onOpenChange={setAddToShelfOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Add {selectedCount} Work{selectedCount === 1 ? "" : "s"} to Shelf</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-2" data-testid="shelf-picker">
+            {shelves.length === 0 ? (
+              <p className="text-sm text-muted-foreground">No shelves created yet. Create one from the Shelves page.</p>
+            ) : (
+              shelves.map((shelf) => (
+                <Button
+                  key={shelf.id}
+                  variant="outline"
+                  className="w-full justify-start"
+                  onClick={() => { void handleAddToShelf(shelf.id); }}
+                  disabled={addingToShelf}
+                  data-testid={`shelf-pick-${shelf.id}`}
+                >
+                  <FolderOpen className="mr-2 size-4" />
+                  {shelf.name}
+                  <span className="ml-auto text-muted-foreground">{shelf._count.items} works</span>
+                </Button>
+              ))
+            )}
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/library-table-view.test.tsx
+++ b/apps/web/src/components/library-table-view.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/components/data-table", () => ({
+  VirtualizedDataTable: (props: { columnVisibility?: Record<string, boolean>; textOverflow?: string; [k: string]: string | boolean | Record<string, boolean> | undefined }) => (
+    <div data-testid="virtualized-data-table" data-column-visibility={JSON.stringify(props.columnVisibility)} data-text-overflow={String(props.textOverflow)} />
+  ),
+}));
+
+vi.mock("~/components/data-table/data-table-column-picker", () => ({
+  DataTableColumnPicker: (props: { columnVisibility?: Record<string, boolean>; [k: string]: string | boolean | Record<string, boolean> | undefined }) => (
+    <div data-testid="column-picker" data-column-visibility={JSON.stringify(props.columnVisibility)} />
+  ),
+}));
+
+import { LibraryTableView } from "./library-table-view";
+
+const defaultProps = {
+  works: [],
+  columns: [],
+  editMode: false,
+  onEditModeToggle: vi.fn(),
+  tablePrefs: { columnVisibility: {} as Record<string, boolean>, textOverflow: "truncate" as const },
+  onColumnToggle: vi.fn(),
+  onTextOverflowToggle: vi.fn(),
+  rowSelection: {},
+  onRowSelectionChange: vi.fn(),
+  sorting: [],
+  onSortingChange: vi.fn(),
+};
+
+describe("LibraryTableView", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders edit mode toggle button with 'Edit' label", () => {
+    render(<LibraryTableView {...defaultProps} />);
+    expect(screen.getByTestId("edit-mode-toggle")).toBeTruthy();
+    expect(screen.getByText("Edit")).toBeTruthy();
+  });
+
+  it("shows 'Done' label when editMode is true", () => {
+    render(<LibraryTableView {...defaultProps} editMode={true} />);
+    expect(screen.getByText("Done")).toBeTruthy();
+  });
+
+  it("calls onEditModeToggle when edit button is clicked", () => {
+    const onEditModeToggle = vi.fn();
+    render(<LibraryTableView {...defaultProps} onEditModeToggle={onEditModeToggle} />);
+    fireEvent.click(screen.getByTestId("edit-mode-toggle"));
+    expect(onEditModeToggle).toHaveBeenCalled();
+  });
+
+  it("renders Wrap button when textOverflow is truncate", () => {
+    render(<LibraryTableView {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /wrap text/i })).toBeTruthy();
+  });
+
+  it("renders Truncate button when textOverflow is wrap", () => {
+    render(<LibraryTableView {...defaultProps} tablePrefs={{ ...defaultProps.tablePrefs, textOverflow: "wrap" }} />);
+    expect(screen.getByRole("button", { name: /truncate text/i })).toBeTruthy();
+  });
+
+  it("calls onTextOverflowToggle when text overflow button is clicked", () => {
+    const onTextOverflowToggle = vi.fn();
+    render(<LibraryTableView {...defaultProps} onTextOverflowToggle={onTextOverflowToggle} />);
+    fireEvent.click(screen.getByRole("button", { name: /wrap text/i }));
+    expect(onTextOverflowToggle).toHaveBeenCalled();
+  });
+
+  it("renders column picker", () => {
+    render(<LibraryTableView {...defaultProps} />);
+    expect(screen.getByTestId("column-picker")).toBeTruthy();
+  });
+
+  it("renders VirtualizedDataTable", () => {
+    render(<LibraryTableView {...defaultProps} />);
+    expect(screen.getByTestId("virtualized-data-table")).toBeTruthy();
+  });
+
+  it("passes columnVisibility and textOverflow to VirtualizedDataTable", () => {
+    const prefs = { columnVisibility: { isbn: false }, textOverflow: "wrap" as const };
+    render(<LibraryTableView {...defaultProps} tablePrefs={prefs} />);
+    const table = screen.getByTestId("virtualized-data-table");
+    expect(table.getAttribute("data-column-visibility")).toBe(JSON.stringify({ isbn: false }));
+    expect(table.getAttribute("data-text-overflow")).toBe("wrap");
+  });
+});

--- a/apps/web/src/components/library-table-view.tsx
+++ b/apps/web/src/components/library-table-view.tsx
@@ -1,0 +1,80 @@
+import type { ColumnDef, OnChangeFn, RowSelectionState, SortingState, Updater } from "@tanstack/react-table";
+import { AlignJustify, Pencil, WrapText } from "lucide-react";
+import { VirtualizedDataTable } from "~/components/data-table";
+import { DataTableColumnPicker } from "~/components/data-table/data-table-column-picker";
+import { Button } from "~/components/ui/button";
+import { COLUMN_PICKER_ITEMS } from "~/lib/library-columns";
+
+interface LibraryTableViewProps<T> {
+  works: T[];
+  columns: ColumnDef<T>[];
+  editMode: boolean;
+  onEditModeToggle: () => void;
+  tablePrefs: { columnVisibility: Record<string, boolean>; textOverflow: "wrap" | "truncate" };
+  onColumnToggle: (columnId: string) => void;
+  onTextOverflowToggle: () => void;
+  rowSelection: RowSelectionState;
+  onRowSelectionChange: OnChangeFn<RowSelectionState>;
+  sorting: SortingState;
+  onSortingChange: (updater: Updater<SortingState>) => void;
+}
+
+export function LibraryTableView<T>({
+  works,
+  columns,
+  editMode,
+  onEditModeToggle,
+  tablePrefs,
+  onColumnToggle,
+  onTextOverflowToggle,
+  rowSelection,
+  onRowSelectionChange,
+  sorting,
+  onSortingChange,
+}: LibraryTableViewProps<T>) {
+  return (
+    <>
+      <div className="flex items-center gap-2 justify-end">
+        <Button
+          data-testid="edit-mode-toggle"
+          variant={editMode ? "default" : "outline"}
+          size="sm"
+          onClick={onEditModeToggle}
+          aria-label={editMode ? "Exit edit mode" : "Enter edit mode"}
+        >
+          <Pencil className="mr-2 h-4 w-4" />
+          {editMode ? "Done" : "Edit"}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onTextOverflowToggle}
+          aria-label={tablePrefs.textOverflow === "truncate" ? "Wrap text" : "Truncate text"}
+        >
+          {tablePrefs.textOverflow === "truncate" ? (
+            <WrapText className="mr-2 h-4 w-4" />
+          ) : (
+            <AlignJustify className="mr-2 h-4 w-4" />
+          )}
+          {tablePrefs.textOverflow === "truncate" ? "Wrap" : "Truncate"}
+        </Button>
+        <DataTableColumnPicker
+          columns={COLUMN_PICKER_ITEMS}
+          columnVisibility={tablePrefs.columnVisibility}
+          onToggle={onColumnToggle}
+        />
+      </div>
+      <VirtualizedDataTable
+        columns={columns}
+        data={works}
+        showPagination={false}
+        columnVisibility={tablePrefs.columnVisibility}
+        textOverflow={tablePrefs.textOverflow}
+        rowSelection={rowSelection}
+        onRowSelectionChange={onRowSelectionChange}
+        sorting={sorting}
+        onSortingChange={onSortingChange}
+      />
+    </>
+  );
+}

--- a/apps/web/src/components/shelf-membership.test.tsx
+++ b/apps/web/src/components/shelf-membership.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("~/lib/server-fns/shelves", () => ({
+  addEditionsForWorkToShelfServerFn: vi.fn(),
+  removeWorkEditionsFromShelfServerFn: vi.fn(),
+}));
+
+import { addEditionsForWorkToShelfServerFn, removeWorkEditionsFromShelfServerFn } from "~/lib/server-fns/shelves";
+import { ShelfMembership } from "./shelf-membership";
+
+describe("ShelfMembership", () => {
+  const mockOnToggle = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(addEditionsForWorkToShelfServerFn).mockResolvedValue(undefined as never);
+    vi.mocked(removeWorkEditionsFromShelfServerFn).mockResolvedValue(undefined as never);
+  });
+
+  it("shows 'No shelves created yet' when shelves is empty", () => {
+    render(<ShelfMembership workId="w1" shelves={[]} onToggled={mockOnToggle} />);
+    expect(screen.getByText("No shelves created yet")).toBeTruthy();
+  });
+
+  it("renders badges for each shelf", () => {
+    const shelves = [
+      { id: "s1", name: "Fiction", isMember: true },
+      { id: "s2", name: "Non-Fiction", isMember: false },
+    ];
+    render(<ShelfMembership workId="w1" shelves={shelves} onToggled={mockOnToggle} />);
+    expect(screen.getByText("Fiction")).toBeTruthy();
+    expect(screen.getByText("Non-Fiction")).toBeTruthy();
+  });
+
+  it("calls removeWorkEditionsFromShelfServerFn when clicking a member shelf", async () => {
+    const shelves = [{ id: "s1", name: "Fiction", isMember: true }];
+    render(<ShelfMembership workId="w1" shelves={shelves} onToggled={mockOnToggle} />);
+    fireEvent.click(screen.getByTestId("shelf-toggle-s1"));
+
+    await waitFor(() => {
+      expect(vi.mocked(removeWorkEditionsFromShelfServerFn)).toHaveBeenCalledWith({
+        data: { shelfId: "s1", workId: "w1" },
+      });
+    });
+    await waitFor(() => {
+      expect(mockOnToggle).toHaveBeenCalled();
+    });
+  });
+
+  it("calls addEditionsForWorkToShelfServerFn when clicking a non-member shelf", async () => {
+    const shelves = [{ id: "s2", name: "Non-Fiction", isMember: false }];
+    render(<ShelfMembership workId="w1" shelves={shelves} onToggled={mockOnToggle} />);
+    fireEvent.click(screen.getByTestId("shelf-toggle-s2"));
+
+    await waitFor(() => {
+      expect(vi.mocked(addEditionsForWorkToShelfServerFn)).toHaveBeenCalledWith({
+        data: { shelfId: "s2", workId: "w1" },
+      });
+    });
+    await waitFor(() => {
+      expect(mockOnToggle).toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/components/shelf-membership.tsx
+++ b/apps/web/src/components/shelf-membership.tsx
@@ -1,0 +1,42 @@
+import { Badge } from "~/components/ui/badge";
+import {
+  addEditionsForWorkToShelfServerFn,
+  removeWorkEditionsFromShelfServerFn,
+} from "~/lib/server-fns/shelves";
+
+interface ShelfMembershipProps {
+  workId: string;
+  shelves: { id: string; name: string; isMember: boolean }[];
+  onToggled: () => void;
+}
+
+export function ShelfMembership({ workId, shelves, onToggled }: ShelfMembershipProps) {
+  const handleToggle = async (shelfId: string, isMember: boolean) => {
+    if (isMember) {
+      await removeWorkEditionsFromShelfServerFn({ data: { shelfId, workId } });
+    } else {
+      await addEditionsForWorkToShelfServerFn({ data: { shelfId, workId } });
+    }
+    onToggled();
+  };
+
+  if (shelves.length === 0) {
+    return <span className="text-muted-foreground">No shelves created yet</span>;
+  }
+
+  return (
+    <div className="flex flex-wrap gap-1.5" data-testid="shelf-membership">
+      {shelves.map((shelf) => (
+        <Badge
+          key={shelf.id}
+          variant={shelf.isMember ? "default" : "outline"}
+          className="cursor-pointer select-none"
+          onClick={() => { void handleToggle(shelf.id, shelf.isMember); }}
+          data-testid={`shelf-toggle-${shelf.id}`}
+        >
+          {shelf.name}
+        </Badge>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/work-cover.test.tsx
+++ b/apps/web/src/components/work-cover.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment happy-dom
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("~/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({ children, onClick, ...props }: { children: React.ReactNode; onClick?: () => void; [k: string]: string | React.ReactNode | (() => void) | undefined }) => (
+    <button onClick={onClick} {...props}>{children}</button>
+  ),
+}));
+
+import { toast } from "sonner";
+import { WorkCover } from "./work-cover";
+
+const defaultProps = {
+  workId: "w1",
+  coverPath: "/covers/w1" as string | null,
+  titleDisplay: "Test Book",
+  maxPercent: null as number | null,
+  coverVersion: 0,
+  onCoverUpdated: vi.fn(),
+  onCoverSearchOpen: vi.fn(),
+};
+
+describe("WorkCover", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  it("renders image when coverPath exists", () => {
+    render(<WorkCover {...defaultProps} />);
+    const img = screen.getByAltText("Test Book");
+    expect(img).toBeTruthy();
+    expect(img.getAttribute("src")).toBe("/api/covers/w1/medium?v=0");
+  });
+
+  it("renders placeholder when coverPath is null", () => {
+    render(<WorkCover {...defaultProps} coverPath={null} />);
+    expect(screen.getByTestId("cover-placeholder")).toBeTruthy();
+  });
+
+  it("falls back to placeholder on image error", () => {
+    render(<WorkCover {...defaultProps} />);
+    const img = screen.getByAltText("Test Book");
+    fireEvent.error(img);
+    expect(screen.getByTestId("cover-placeholder")).toBeTruthy();
+  });
+
+  it("shows maxPercent when not null", () => {
+    render(<WorkCover {...defaultProps} maxPercent={75} />);
+    expect(screen.getByTestId("cover-progress")).toBeTruthy();
+    expect(screen.getByText("75%")).toBeTruthy();
+  });
+
+  it("does not show progress when maxPercent is null", () => {
+    render(<WorkCover {...defaultProps} maxPercent={null} />);
+    expect(screen.queryByTestId("cover-progress")).toBeNull();
+  });
+
+  it("calls onCoverUpdated after successful upload", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    global.fetch = mockFetch;
+    const onCoverUpdated = vi.fn();
+    render(<WorkCover {...defaultProps} onCoverUpdated={onCoverUpdated} />);
+
+    const fileInput = screen.getByTestId("cover-file-input");
+    const file = new File(["data"], "cover.jpg", { type: "image/jpeg" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(mockFetch).toHaveBeenCalledWith(
+        "/api/upload-cover/w1",
+        expect.objectContaining({ method: "POST" }),
+      );
+    });
+    await waitFor(() => {
+      expect(onCoverUpdated).toHaveBeenCalled();
+    });
+    expect(vi.mocked(toast).success).toHaveBeenCalledWith("Cover updated");
+  });
+
+  it("shows error toast on failed upload", async () => {
+    global.fetch = vi.fn().mockResolvedValue({ ok: false, text: () => Promise.resolve("Bad file") });
+    render(<WorkCover {...defaultProps} />);
+
+    const fileInput = screen.getByTestId("cover-file-input");
+    const file = new File(["data"], "cover.jpg", { type: "image/jpeg" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(vi.mocked(toast).error).toHaveBeenCalledWith("Bad file");
+    });
+  });
+
+  it("shows generic error toast on upload exception", async () => {
+    global.fetch = vi.fn().mockRejectedValue(new Error("Network error"));
+    render(<WorkCover {...defaultProps} />);
+
+    const fileInput = screen.getByTestId("cover-file-input");
+    const file = new File(["data"], "cover.jpg", { type: "image/jpeg" });
+    fireEvent.change(fileInput, { target: { files: [file] } });
+
+    await waitFor(() => {
+      expect(vi.mocked(toast).error).toHaveBeenCalledWith("Network error");
+    });
+  });
+
+  it("does nothing when no file selected", () => {
+    render(<WorkCover {...defaultProps} />);
+    const fileInput = screen.getByTestId("cover-file-input");
+    fireEvent.change(fileInput, { target: { files: [] } });
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("calls onCoverSearchOpen when search option is used", () => {
+    const onCoverSearchOpen = vi.fn();
+    render(<WorkCover {...defaultProps} onCoverSearchOpen={onCoverSearchOpen} />);
+    fireEvent.click(screen.getByTestId("cover-search-option"));
+    expect(onCoverSearchOpen).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/work-cover.tsx
+++ b/apps/web/src/components/work-cover.tsx
@@ -1,0 +1,118 @@
+import { useRef, useState } from "react";
+import { toast } from "sonner";
+import { BookOpen, ImagePlus, Loader2, Search, Upload } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "~/components/ui/dropdown-menu";
+
+interface WorkCoverProps {
+  workId: string;
+  coverPath: string | null;
+  titleDisplay: string;
+  maxPercent: number | null;
+  coverVersion: number;
+  onCoverUpdated: () => void;
+  onCoverSearchOpen: () => void;
+}
+
+export function WorkCover({
+  workId,
+  coverPath,
+  titleDisplay,
+  maxPercent,
+  coverVersion,
+  onCoverUpdated,
+  onCoverSearchOpen,
+}: WorkCoverProps) {
+  const [imgFailed, setImgFailed] = useState(false);
+  const [uploadingCover, setUploadingCover] = useState(false);
+  const coverInputRef = useRef<HTMLInputElement>(null);
+  const showPlaceholder = !coverPath || imgFailed;
+
+  async function handleCoverUpload(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setUploadingCover(true);
+    try {
+      const formData = new FormData();
+      formData.append("file", file);
+      const res = await fetch(`/api/upload-cover/${workId}`, {
+        method: "POST",
+        body: formData,
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(text || "Upload failed");
+      }
+      toast.success("Cover updated");
+      setImgFailed(false);
+      onCoverUpdated();
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : "Failed to upload cover");
+    } finally {
+      setUploadingCover(false);
+      e.target.value = "";
+    }
+  }
+
+  return (
+    <div className="w-48 shrink-0">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <div
+            className="group relative aspect-[2/3] cursor-pointer overflow-hidden rounded-lg bg-muted"
+            role="button"
+            tabIndex={0}
+          >
+            {showPlaceholder ? (
+              <div data-testid="cover-placeholder" className="flex size-full items-center justify-center text-muted-foreground">
+                <BookOpen className="size-12" />
+              </div>
+            ) : (
+              <img
+                src={`/api/covers/${workId}/medium?v=${String(coverVersion)}`}
+                alt={titleDisplay}
+                onError={() => { setImgFailed(true); }}
+                className="size-full object-cover"
+              />
+            )}
+            <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
+              {uploadingCover ? (
+                <Loader2 className="size-8 animate-spin text-white" />
+              ) : (
+                <ImagePlus className="size-8 text-white" />
+              )}
+            </div>
+          </div>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start">
+          <DropdownMenuItem data-testid="cover-upload-option" onClick={() => { coverInputRef.current?.click(); }}>
+            <Upload className="size-4 mr-2" />
+            Upload from file
+          </DropdownMenuItem>
+          <DropdownMenuItem data-testid="cover-search-option" onClick={onCoverSearchOpen}>
+            <Search className="size-4 mr-2" />
+            Search for cover
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+      <input
+        ref={coverInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        data-testid="cover-file-input"
+        onChange={(e) => { void handleCoverUpload(e); }}
+      />
+      {maxPercent !== null && (
+        <div className="mt-2 text-center" data-testid="cover-progress">
+          <span className="text-xl font-bold tabular-nums">{String(maxPercent)}%</span>
+          <p className="text-xs text-muted-foreground">read</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/work-progress.test.tsx
+++ b/apps/web/src/components/work-progress.test.tsx
@@ -1,0 +1,30 @@
+// @vitest-environment happy-dom
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+
+vi.mock("~/components/progress-bar", () => ({
+  ProgressBar: ({ percent }: { percent: number }) => (
+    <div data-testid="progress-bar" data-percent={percent} />
+  ),
+}));
+
+import { WorkProgress } from "./work-progress";
+
+describe("WorkProgress", () => {
+  it("renders progress bar with max percent", () => {
+    render(<WorkProgress progress={[{ percent: 50 }, { percent: 75 }]} />);
+    const bar = screen.getByTestId("progress-bar");
+    expect(bar.getAttribute("data-percent")).toBe("75");
+  });
+
+  it("renders percentage text", () => {
+    render(<WorkProgress progress={[{ percent: 42 }]} />);
+    expect(screen.getByText("42%")).toBeTruthy();
+  });
+
+  it("treats null percent as 0", () => {
+    render(<WorkProgress progress={[{ percent: null }, { percent: 30 }]} />);
+    const bar = screen.getByTestId("progress-bar");
+    expect(bar.getAttribute("data-percent")).toBe("30");
+  });
+});

--- a/apps/web/src/components/work-progress.tsx
+++ b/apps/web/src/components/work-progress.tsx
@@ -1,0 +1,19 @@
+import { ProgressBar } from "~/components/progress-bar";
+
+interface WorkProgressProps {
+  progress: { percent: number | null }[];
+}
+
+export function WorkProgress({ progress }: WorkProgressProps) {
+  const maxPercent = Math.max(...progress.map((p) => p.percent ?? 0));
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <div className="flex-1">
+          <ProgressBar percent={maxPercent} />
+        </div>
+        <span className="text-sm text-muted-foreground">{String(maxPercent)}%</span>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/hooks/use-library-filters.test.ts
+++ b/apps/web/src/hooks/use-library-filters.test.ts
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useLibraryFilters } from "./use-library-filters";
+
+type SearchParams = Record<string, string | number | boolean | string[] | undefined>;
+type NavigateOpts = { search: (prev: SearchParams) => SearchParams };
+
+function extractSearch(mockFn: ReturnType<typeof vi.fn>): (prev: SearchParams) => SearchParams {
+  const call = mockFn.mock.calls[0] as [NavigateOpts] | undefined;
+  if (!call) throw new Error("Expected navigate to have been called");
+  return call[0].search;
+}
+
+describe("useLibraryFilters", () => {
+  const mockNavigate = vi.fn().mockImplementation((opts: { search?: (prev: SearchParams) => object }) => {
+    if (typeof opts.search === "function") {
+      opts.search({});
+    }
+  });
+
+  const defaultSearch = { page: 1, pageSize: 50, sort: "title-asc" as const };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("updateSearch calls navigate with merged params and page reset to 1", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: defaultSearch, navigate: mockNavigate }),
+    );
+    act(() => {
+      result.current.updateSearch({ q: "test" });
+    });
+    expect(mockNavigate).toHaveBeenCalledWith(expect.objectContaining({
+      to: ".",
+      replace: true,
+    }));
+  });
+
+  it("updateSearch preserves explicit page", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: defaultSearch, navigate: mockNavigate }),
+    );
+    act(() => {
+      result.current.updateSearch({ page: 3 });
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+    // The search function inside navigate should set page to 3
+    const merged = extractSearch(mockNavigate)({});
+    expect(merged.page).toBe(3);
+  });
+
+  it("handleFiltersChange maps filter values to search params", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: defaultSearch, navigate: mockNavigate }),
+    );
+    act(() => {
+      result.current.handleFiltersChange({
+        format: ["EBOOK"],
+        authorId: undefined,
+        seriesId: undefined,
+        publisher: undefined,
+        hasCover: true,
+        enriched: undefined,
+        hasDescription: undefined,
+        inSeries: undefined,
+        hasIsbn: undefined,
+      });
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it("handleSearchChange passes q, sets undefined when empty", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: defaultSearch, navigate: mockNavigate }),
+    );
+    act(() => {
+      result.current.handleSearchChange("foo");
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+
+    mockNavigate.mockClear();
+    act(() => {
+      result.current.handleSearchChange("");
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+    const merged = extractSearch(mockNavigate)({});
+    expect(merged.q).toBeUndefined();
+  });
+
+  it("handleSortChange passes sort as typed param", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: defaultSearch, navigate: mockNavigate }),
+    );
+    act(() => {
+      result.current.handleSortChange("title-desc");
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it("handleColumnSort converts updater to sort param", () => {
+    const search = { ...defaultSearch, sort: "title-asc" as const };
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search, navigate: mockNavigate }),
+    );
+    act(() => {
+      // Simulate TanStack Table passing a function updater that toggles title sort
+      result.current.handleColumnSort(() => [{ id: "titleDisplay", desc: true }]);
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+    const merged = extractSearch(mockNavigate)({});
+    expect(merged.sort).toBe("title-desc");
+  });
+
+  it("handlePageChange navigates with explicit page", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: defaultSearch, navigate: mockNavigate }),
+    );
+    act(() => {
+      result.current.handlePageChange(5);
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+    const merged = extractSearch(mockNavigate)({});
+    expect(merged.page).toBe(5);
+  });
+
+  it("handlePageSizeChange navigates with pageSize and resets to page 1", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: defaultSearch, navigate: mockNavigate }),
+    );
+    act(() => {
+      result.current.handlePageSizeChange(20);
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+    const merged = extractSearch(mockNavigate)({});
+    expect(merged.pageSize).toBe(20);
+    expect(merged.page).toBe(1);
+  });
+
+  it("tableSorting derives correct state from search.sort", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: { ...defaultSearch, sort: "author-desc" as const }, navigate: mockNavigate }),
+    );
+    expect(result.current.tableSorting).toEqual([{ id: "authors", desc: true }]);
+  });
+
+  it("tableSorting returns empty array for unknown sort", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: { ...defaultSearch, sort: "recent" as const }, navigate: mockNavigate }),
+    );
+    expect(result.current.tableSorting).toEqual([]);
+  });
+
+  it("currentFilters extracts filter fields from search", () => {
+    const search = {
+      ...defaultSearch,
+      format: ["EBOOK" as const],
+      hasCover: true,
+      authorId: ["a1"],
+      seriesId: undefined,
+      publisher: undefined,
+      enriched: undefined,
+      hasDescription: undefined,
+      inSeries: undefined,
+      hasIsbn: undefined,
+    };
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search, navigate: mockNavigate }),
+    );
+    expect(result.current.currentFilters.format).toEqual(["EBOOK"]);
+    expect(result.current.currentFilters.hasCover).toBe(true);
+    expect(result.current.currentFilters.authorId).toEqual(["a1"]);
+  });
+});

--- a/apps/web/src/hooks/use-library-filters.ts
+++ b/apps/web/src/hooks/use-library-filters.ts
@@ -1,0 +1,115 @@
+import { useCallback, useMemo } from "react";
+import type { SortingState, Updater } from "@tanstack/react-table";
+import type { LibrarySearchParams } from "~/lib/library-search-schema";
+import type { LibraryFilterValues } from "~/components/library-filters";
+import { columnSortToParam, COLUMN_SORT_MAP, SORT_TO_COLUMN } from "~/lib/library-filter-helpers";
+
+type NavigateFn = (opts: {
+  to: string;
+  search: (prev: Partial<LibrarySearchParams>) => LibrarySearchParams;
+  replace: boolean;
+}) => void | Promise<void>;
+
+interface UseLibraryFiltersOptions {
+  search: LibrarySearchParams;
+  navigate: NavigateFn;
+}
+
+export function useLibraryFilters({ search, navigate }: UseLibraryFiltersOptions) {
+  const updateSearch = useCallback(
+    (updates: Partial<LibrarySearchParams>) => {
+      void navigate({
+        to: ".",
+        search: (prev) => ({
+          ...(prev as LibrarySearchParams),
+          ...updates,
+          page: updates.page ?? 1,
+        }),
+        replace: true,
+      });
+    },
+    [navigate],
+  );
+
+  const handleFiltersChange = useCallback(
+    (filters: LibraryFilterValues) => {
+      updateSearch({
+        format: filters.format as LibrarySearchParams["format"],
+        authorId: filters.authorId,
+        seriesId: filters.seriesId,
+        publisher: filters.publisher,
+        hasCover: filters.hasCover,
+        enriched: filters.enriched,
+        hasDescription: filters.hasDescription,
+        inSeries: filters.inSeries,
+        hasIsbn: filters.hasIsbn,
+      });
+    },
+    [updateSearch],
+  );
+
+  const handleSearchChange = useCallback(
+    (q: string) => {
+      updateSearch({ q: q || undefined });
+    },
+    [updateSearch],
+  );
+
+  const handleSortChange = useCallback(
+    (sort: string) => {
+      updateSearch({ sort: sort as LibrarySearchParams["sort"] });
+    },
+    [updateSearch],
+  );
+
+  const tableSorting: SortingState = useMemo(() => {
+    const mapped = SORT_TO_COLUMN[search.sort];
+    return mapped ? [mapped] : [];
+  }, [search.sort]);
+
+  const handleColumnSort = useCallback(
+    (updater: Updater<SortingState>) => {
+      const newState = (updater as (prev: SortingState) => SortingState)(tableSorting);
+      updateSearch({ sort: columnSortToParam(newState, COLUMN_SORT_MAP) });
+    },
+    [tableSorting, updateSearch],
+  );
+
+  const handlePageChange = useCallback(
+    (page: number) => {
+      updateSearch({ page });
+    },
+    [updateSearch],
+  );
+
+  const handlePageSizeChange = useCallback(
+    (pageSize: number) => {
+      updateSearch({ pageSize, page: 1 });
+    },
+    [updateSearch],
+  );
+
+  const currentFilters: LibraryFilterValues = {
+    format: search.format,
+    authorId: search.authorId,
+    seriesId: search.seriesId,
+    publisher: search.publisher,
+    hasCover: search.hasCover,
+    enriched: search.enriched,
+    hasDescription: search.hasDescription,
+    inSeries: search.inSeries,
+    hasIsbn: search.hasIsbn,
+  };
+
+  return {
+    updateSearch,
+    handleFiltersChange,
+    handleSearchChange,
+    handleSortChange,
+    handleColumnSort,
+    handlePageChange,
+    handlePageSizeChange,
+    tableSorting,
+    currentFilters,
+  };
+}

--- a/apps/web/src/lib/library-columns.test.tsx
+++ b/apps/web/src/lib/library-columns.test.tsx
@@ -1,0 +1,173 @@
+// @vitest-environment happy-dom
+import type * as TanstackRouter from "@tanstack/react-router";
+import type { ColumnDef } from "@tanstack/react-table";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof TanstackRouter>("@tanstack/react-router");
+  return {
+    ...actual,
+    Link: ({ children, to, params, ...props }: { children?: React.ReactNode; to: string; params?: Record<string, string>; [key: string]: string | undefined | React.ReactNode | Record<string, string> | (() => void) }) => {
+      let href = to;
+      if (params) {
+        for (const [key, value] of Object.entries(params)) {
+          href = href.replace(`$${key}`, value);
+        }
+      }
+      return <a href={href} {...props}>{children}</a>;
+    },
+  };
+});
+
+vi.mock("~/lib/server-fns/editing", () => ({
+  updateWorkServerFn: vi.fn(),
+  updateEditionServerFn: vi.fn(),
+  updateWorkAuthorsServerFn: vi.fn(),
+}));
+
+vi.mock("~/components/editable-table-cell", async () => {
+  const actual = await vi.importActual("~/components/editable-table-cell");
+  return actual as Record<string, object>;
+});
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+import { getFormats, COLUMN_PICKER_ITEMS, getColumns } from "./library-columns";
+
+type LibraryWork = Parameters<typeof getFormats>[0];
+type Edition = LibraryWork["editions"][number];
+
+/** Cast partial test data to LibraryWork without using `unknown` */
+function forceCast<T>(value: T | string | number | boolean | object | null): T {
+  return value as T & typeof value;
+}
+
+function makeWork(
+  title: string,
+  authors: string[] = [],
+  formats: string[] = [],
+  enrichmentStatus: LibraryWork["enrichmentStatus"] = "ENRICHED",
+): LibraryWork {
+  return forceCast<LibraryWork>({
+    id: `work-${title.toLowerCase().replace(/\s/g, "-")}`,
+    titleDisplay: title,
+    titleCanonical: title.toLowerCase(),
+    sortTitle: title.toLowerCase(),
+    coverPath: null,
+    createdAt: new Date("2025-01-01"),
+    enrichmentStatus,
+    series: null,
+    seriesPosition: null,
+    editions: [
+      {
+        id: `edition-${title.toLowerCase().replace(/\s/g, "-")}`,
+        formatFamily: formats[0] ?? "EBOOK",
+        publisher: "Test Publisher" as string | null,
+        isbn13: "1234567890123" as string | null,
+        isbn10: null as string | null,
+        contributors: authors.map((name) => ({
+          role: "AUTHOR",
+          contributor: { nameDisplay: name },
+        })),
+      },
+    ],
+  });
+}
+
+function makeEdition(overrides: Partial<Edition> & { id: string; formatFamily: string }): Edition {
+  return forceCast<Edition>({
+    publisher: null,
+    isbn13: null,
+    isbn10: null,
+    contributors: [],
+    ...overrides,
+  });
+}
+
+describe("getFormats", () => {
+  it("returns unique format families from editions", () => {
+    const work = makeWork("Test", [], ["EBOOK"]);
+    work.editions.push(makeEdition({ id: "e2", formatFamily: "AUDIOBOOK" }));
+    expect(getFormats(work)).toEqual(["EBOOK", "AUDIOBOOK"]);
+  });
+
+  it("deduplicates format families", () => {
+    const work = makeWork("Test", [], ["EBOOK"]);
+    work.editions.push(makeEdition({ id: "e2", formatFamily: "EBOOK" }));
+    expect(getFormats(work)).toEqual(["EBOOK"]);
+  });
+
+  it("returns empty array for work with no editions", () => {
+    const work = makeWork("Test");
+    work.editions = [];
+    expect(getFormats(work)).toEqual([]);
+  });
+});
+
+describe("COLUMN_PICKER_ITEMS", () => {
+  it("has expected shape", () => {
+    expect(COLUMN_PICKER_ITEMS).toEqual([
+      { id: "authors", label: "Author(s)" },
+      { id: "formats", label: "Format" },
+      { id: "publisher", label: "Publisher" },
+      { id: "isbn", label: "ISBN" },
+    ]);
+  });
+});
+
+describe("getColumns", () => {
+  const router = { invalidate: vi.fn() };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  function col(cols: ColumnDef<LibraryWork>[], index: number): ColumnDef<LibraryWork> {
+    const c = cols[index];
+    if (!c) throw new Error(`No column at index ${String(index)}`);
+    return c;
+  }
+
+  it("returns 6 columns", () => {
+    const cols = getColumns(false, false, router);
+    expect(cols).toHaveLength(6);
+  });
+
+  it("first column is select with checkboxes", () => {
+    const selectCol = col(getColumns(false, false, router), 0);
+    expect(selectCol.id).toBe("select");
+    expect(selectCol.enableSorting).toBe(false);
+    expect(selectCol.enableHiding).toBe(false);
+  });
+
+  it("title column has correct accessor and config", () => {
+    const titleCol = col(getColumns(false, false, router), 1);
+    expect((titleCol as ColumnDef<LibraryWork> & { accessorKey?: string }).accessorKey).toBe("titleDisplay");
+    expect(titleCol.enableHiding).toBe(false);
+    expect(titleCol.size).toBe(300);
+  });
+
+  it("authors column has correct id and size", () => {
+    const authorsCol = col(getColumns(false, false, router), 2);
+    expect(authorsCol.id).toBe("authors");
+    expect(authorsCol.size).toBe(200);
+  });
+
+  it("formats column has correct id and size", () => {
+    const formatsCol = col(getColumns(false, false, router), 3);
+    expect(formatsCol.id).toBe("formats");
+    expect(formatsCol.size).toBe(80);
+  });
+
+  it("publisher column has correct id and size", () => {
+    const publisherCol = col(getColumns(false, false, router), 4);
+    expect(publisherCol.id).toBe("publisher");
+    expect(publisherCol.size).toBe(150);
+  });
+
+  it("isbn column has correct id and size", () => {
+    const isbnCol = col(getColumns(false, false, router), 5);
+    expect(isbnCol.id).toBe("isbn");
+    expect(isbnCol.size).toBe(120);
+  });
+});

--- a/apps/web/src/lib/library-columns.tsx
+++ b/apps/web/src/lib/library-columns.tsx
@@ -1,0 +1,170 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { Link } from "@tanstack/react-router";
+import { Badge } from "~/components/ui/badge";
+import { DataTableColumnHeader } from "~/components/data-table";
+import { EditableTableCell } from "~/components/editable-table-cell";
+import { updateWorkServerFn, updateEditionServerFn, updateWorkAuthorsServerFn } from "~/lib/server-fns/editing";
+import { getAuthors } from "~/lib/sort-filter-works";
+import type { LibraryWork } from "~/lib/server-fns/library";
+
+export { getAuthors } from "~/lib/sort-filter-works";
+
+export function getFormats(work: LibraryWork): string[] {
+  return [...new Set(work.editions.map((e) => e.formatFamily))];
+}
+
+export const COLUMN_PICKER_ITEMS = [
+  { id: "authors", label: "Author(s)" },
+  { id: "formats", label: "Format" },
+  { id: "publisher", label: "Publisher" },
+  { id: "isbn", label: "ISBN" },
+];
+
+export function getColumns(scanActive: boolean, editMode: boolean, router: { invalidate: () => void }): ColumnDef<LibraryWork>[] {
+  return [
+  {
+    id: "select",
+    header: ({ table }) => (
+      <input
+        type="checkbox"
+        checked={table.getIsAllPageRowsSelected()}
+        onChange={(e) => { table.toggleAllPageRowsSelected(e.target.checked); }}
+        aria-label="Select all"
+      />
+    ),
+    cell: ({ row }) => (
+      <input
+        type="checkbox"
+        checked={row.getIsSelected()}
+        onChange={(e) => { row.toggleSelected(e.target.checked); }}
+        aria-label="Select row"
+      />
+    ),
+    size: 40,
+    enableSorting: false,
+    enableHiding: false,
+  },
+  {
+    accessorKey: "titleDisplay",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Title" />
+    ),
+    cell: ({ row }) => {
+      if (editMode) {
+        return (
+          <EditableTableCell
+            value={row.original.titleDisplay}
+            editing={true}
+            onSave={async (val) => {
+              await updateWorkServerFn({ data: { workId: row.original.id, fields: { titleDisplay: val } } });
+              router.invalidate();
+            }}
+          />
+        );
+      }
+      return (
+        <Link to="/library/$workId" params={{ workId: row.original.id }} search={{ page: 1, pageSize: 50, sort: "title-asc" as const }} className="flex items-center gap-2">
+          {row.original.titleDisplay}
+          {row.original.enrichmentStatus === "STUB" && scanActive && (
+            <Badge variant="outline" className="animate-pulse px-1.5 py-0 text-[10px]">
+              Processing&hellip;
+            </Badge>
+          )}
+        </Link>
+      );
+    },
+    size: 300,
+    enableHiding: false,
+  },
+  {
+    id: "authors",
+    accessorFn: (row) => getAuthors(row),
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Author(s)" />
+    ),
+    cell: ({ row }) => {
+      const authorsStr = getAuthors(row.original);
+      if (editMode) {
+        return (
+          <EditableTableCell
+            value={authorsStr === "—" ? "" : authorsStr}
+            editing={true}
+            onSave={async (val) => {
+              const authors = val.split(",").map((a) => a.trim()).filter((a) => a.length > 0);
+              if (authors.length === 0) return;
+              await updateWorkAuthorsServerFn({ data: { workId: row.original.id, authors } });
+              router.invalidate();
+            }}
+          />
+        );
+      }
+      return <span>{authorsStr}</span>;
+    },
+    size: 200,
+  },
+  {
+    id: "formats",
+    accessorFn: (row) => getFormats(row).join(", "),
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Format" />
+    ),
+    cell: ({ row }) =>
+      getFormats(row.original).map((f) => (
+        <Badge key={f} variant="secondary" className="mr-1">
+          {f}
+        </Badge>
+      )),
+    size: 80,
+  },
+  {
+    id: "publisher",
+    accessorFn: (row) => row.editions[0]?.publisher ?? "",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="Publisher" />
+    ),
+    cell: ({ row }) => {
+      const pub = row.original.editions[0]?.publisher ?? "";
+      const editionId = row.original.editions[0]?.id;
+      if (editMode && editionId) {
+        return (
+          <EditableTableCell
+            value={pub}
+            editing={true}
+            onSave={async (val) => {
+              await updateEditionServerFn({ data: { editionId, fields: { publisher: val || null } } });
+              router.invalidate();
+            }}
+          />
+        );
+      }
+      return <span>{pub || "—"}</span>;
+    },
+    size: 150,
+  },
+  {
+    id: "isbn",
+    accessorFn: (row) => row.editions[0]?.isbn13 ?? row.editions[0]?.isbn10 ?? "",
+    header: ({ column }) => (
+      <DataTableColumnHeader column={column} title="ISBN" />
+    ),
+    cell: ({ row }) => {
+      const isbn = row.original.editions[0]?.isbn13 ?? row.original.editions[0]?.isbn10 ?? "";
+      const editionId = row.original.editions[0]?.id;
+      if (editMode && editionId) {
+        return (
+          <EditableTableCell
+            value={isbn}
+            editing={true}
+            onSave={async (val) => {
+              await updateEditionServerFn({ data: { editionId, fields: { isbn13: val || null } } });
+              router.invalidate();
+            }}
+          />
+        );
+      }
+      return <span>{isbn || "—"}</span>;
+    },
+    size: 120,
+  },
+  ];
+}

--- a/apps/web/src/lib/library-filter-helpers.test.ts
+++ b/apps/web/src/lib/library-filter-helpers.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from "vitest";
+import {
+  filterByReadingStatus,
+  columnSortToParam,
+  COLUMN_SORT_MAP,
+  SORT_TO_COLUMN,
+} from "./library-filter-helpers";
+
+describe("filterByReadingStatus", () => {
+  const works = [
+    { id: "w1" },
+    { id: "w2" },
+    { id: "w3" },
+  ] as { id: string }[];
+  const progressMap = { w1: 0, w2: 50, w3: 100 };
+
+  it("returns all works when filter is 'all'", () => {
+    expect(filterByReadingStatus(works, "all", progressMap)).toEqual(works);
+  });
+
+  it("returns only reading works (0 < pct < 100)", () => {
+    const result = filterByReadingStatus(works, "reading", progressMap);
+    expect(result.map((w) => w.id)).toEqual(["w2"]);
+  });
+
+  it("returns only finished works (pct >= 100)", () => {
+    const result = filterByReadingStatus(works, "finished", progressMap);
+    expect(result.map((w) => w.id)).toEqual(["w3"]);
+  });
+
+  it("returns only unread works (pct === 0)", () => {
+    const result = filterByReadingStatus(works, "unread", progressMap);
+    expect(result.map((w) => w.id)).toEqual(["w1"]);
+  });
+
+  it("treats missing progressMap entries as 0", () => {
+    const result = filterByReadingStatus([{ id: "unknown" }] as { id: string }[], "unread", {});
+    expect(result).toHaveLength(1);
+  });
+});
+
+describe("columnSortToParam", () => {
+  it("returns title-asc for empty state", () => {
+    const map = { titleDisplay: { asc: "title-asc" as const, desc: "title-desc" as const } };
+    expect(columnSortToParam([], map)).toBe("title-asc");
+  });
+
+  it("returns title-asc for unknown column id", () => {
+    const map = { titleDisplay: { asc: "title-asc" as const, desc: "title-desc" as const } };
+    expect(columnSortToParam([{ id: "unknown", desc: false }], map)).toBe("title-asc");
+  });
+
+  it("returns asc sort param for ascending column", () => {
+    const map = { titleDisplay: { asc: "title-asc" as const, desc: "title-desc" as const } };
+    expect(columnSortToParam([{ id: "titleDisplay", desc: false }], map)).toBe("title-asc");
+  });
+
+  it("returns desc sort param for descending column", () => {
+    const map = { titleDisplay: { asc: "title-asc" as const, desc: "title-desc" as const } };
+    expect(columnSortToParam([{ id: "titleDisplay", desc: true }], map)).toBe("title-desc");
+  });
+});
+
+describe("COLUMN_SORT_MAP", () => {
+  it("maps titleDisplay to title-asc/title-desc", () => {
+    expect(COLUMN_SORT_MAP.titleDisplay).toEqual({ asc: "title-asc", desc: "title-desc" });
+  });
+
+  it("maps authors to author-asc/author-desc", () => {
+    expect(COLUMN_SORT_MAP.authors).toEqual({ asc: "author-asc", desc: "author-desc" });
+  });
+
+  it("maps publisher to publisher-asc/publisher-desc", () => {
+    expect(COLUMN_SORT_MAP.publisher).toEqual({ asc: "publisher-asc", desc: "publisher-desc" });
+  });
+
+  it("maps formats to format-asc/format-desc", () => {
+    expect(COLUMN_SORT_MAP.formats).toEqual({ asc: "format-asc", desc: "format-desc" });
+  });
+
+  it("maps isbn to isbn-asc/isbn-desc", () => {
+    expect(COLUMN_SORT_MAP.isbn).toEqual({ asc: "isbn-asc", desc: "isbn-desc" });
+  });
+});
+
+describe("SORT_TO_COLUMN", () => {
+  it("maps title-asc to titleDisplay ascending", () => {
+    expect(SORT_TO_COLUMN["title-asc"]).toEqual({ id: "titleDisplay", desc: false });
+  });
+
+  it("maps title-desc to titleDisplay descending", () => {
+    expect(SORT_TO_COLUMN["title-desc"]).toEqual({ id: "titleDisplay", desc: true });
+  });
+
+  it("maps all author sort params", () => {
+    expect(SORT_TO_COLUMN["author-asc"]).toEqual({ id: "authors", desc: false });
+    expect(SORT_TO_COLUMN["author-desc"]).toEqual({ id: "authors", desc: true });
+  });
+
+  it("maps all publisher sort params", () => {
+    expect(SORT_TO_COLUMN["publisher-asc"]).toEqual({ id: "publisher", desc: false });
+    expect(SORT_TO_COLUMN["publisher-desc"]).toEqual({ id: "publisher", desc: true });
+  });
+
+  it("maps all format sort params", () => {
+    expect(SORT_TO_COLUMN["format-asc"]).toEqual({ id: "formats", desc: false });
+    expect(SORT_TO_COLUMN["format-desc"]).toEqual({ id: "formats", desc: true });
+  });
+
+  it("maps all isbn sort params", () => {
+    expect(SORT_TO_COLUMN["isbn-asc"]).toEqual({ id: "isbn", desc: false });
+    expect(SORT_TO_COLUMN["isbn-desc"]).toEqual({ id: "isbn", desc: true });
+  });
+});

--- a/apps/web/src/lib/library-filter-helpers.ts
+++ b/apps/web/src/lib/library-filter-helpers.ts
@@ -1,0 +1,54 @@
+import type { SortingState } from "@tanstack/react-table";
+import type { LibrarySearchParams } from "~/lib/library-search-schema";
+import type { ReadingFilter } from "~/lib/sort-filter-works";
+
+export function filterByReadingStatus<T extends { id: string }>(
+  works: T[],
+  readingFilter: ReadingFilter,
+  progressMap: Record<string, number>,
+): T[] {
+  if (readingFilter === "all") return works;
+  return works.filter((w) => {
+    const pct = progressMap[w.id] ?? 0;
+    switch (readingFilter) {
+      case "reading":
+        return pct > 0 && pct < 100;
+      case "finished":
+        return pct >= 100;
+      case "unread":
+        return pct === 0;
+    }
+  });
+}
+
+export function columnSortToParam(
+  state: SortingState,
+  map: Record<string, { asc: LibrarySearchParams["sort"]; desc: LibrarySearchParams["sort"] }>,
+): LibrarySearchParams["sort"] {
+  const entry = state[0];
+  if (!entry) return "title-asc";
+  const col = map[entry.id];
+  if (!col) return "title-asc";
+  return entry.desc ? col.desc : col.asc;
+}
+
+export const COLUMN_SORT_MAP: Record<string, { asc: LibrarySearchParams["sort"]; desc: LibrarySearchParams["sort"] }> = {
+  titleDisplay: { asc: "title-asc", desc: "title-desc" },
+  authors: { asc: "author-asc", desc: "author-desc" },
+  publisher: { asc: "publisher-asc", desc: "publisher-desc" },
+  formats: { asc: "format-asc", desc: "format-desc" },
+  isbn: { asc: "isbn-asc", desc: "isbn-desc" },
+};
+
+export const SORT_TO_COLUMN: Record<string, { id: string; desc: boolean }> = {
+  "title-asc": { id: "titleDisplay", desc: false },
+  "title-desc": { id: "titleDisplay", desc: true },
+  "author-asc": { id: "authors", desc: false },
+  "author-desc": { id: "authors", desc: true },
+  "publisher-asc": { id: "publisher", desc: false },
+  "publisher-desc": { id: "publisher", desc: true },
+  "format-asc": { id: "formats", desc: false },
+  "format-desc": { id: "formats", desc: true },
+  "isbn-asc": { id: "isbn", desc: false },
+  "isbn-desc": { id: "isbn", desc: true },
+};

--- a/apps/web/src/lib/sort-filter-works.ts
+++ b/apps/web/src/lib/sort-filter-works.ts
@@ -3,7 +3,7 @@ import type { LibraryWork } from "~/lib/server-fns/library";
 export type SortOption = "title-asc" | "title-desc" | "author-asc" | "author-desc" | "publisher-asc" | "publisher-desc" | "format-asc" | "format-desc" | "isbn-asc" | "isbn-desc" | "recent";
 export type ReadingFilter = "all" | "reading" | "finished" | "unread";
 
-function getAuthors(work: LibraryWork): string {
+export function getAuthors(work: LibraryWork): string {
   const authors = work.editions
     .flatMap((e) => e.contributors)
     .filter((c) => c.role === "AUTHOR")

--- a/apps/web/src/routes/_authenticated/-library.index.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.index.test.tsx
@@ -285,25 +285,25 @@ const makeWork = (title: string, authors: string[] = [], formats: string[] = [],
 
 describe("columnSortToParam", () => {
   it("returns title-asc for empty state", async () => {
-    const { columnSortToParam } = await import("./library.index");
+    const { columnSortToParam } = await import("~/lib/library-filter-helpers");
     const map = { titleDisplay: { asc: "title-asc" as const, desc: "title-desc" as const } };
     expect(columnSortToParam([], map)).toBe("title-asc");
   });
 
   it("returns title-asc for unknown column id", async () => {
-    const { columnSortToParam } = await import("./library.index");
+    const { columnSortToParam } = await import("~/lib/library-filter-helpers");
     const map = { titleDisplay: { asc: "title-asc" as const, desc: "title-desc" as const } };
     expect(columnSortToParam([{ id: "unknown", desc: false }], map)).toBe("title-asc");
   });
 
   it("returns asc sort param for ascending column", async () => {
-    const { columnSortToParam } = await import("./library.index");
+    const { columnSortToParam } = await import("~/lib/library-filter-helpers");
     const map = { titleDisplay: { asc: "title-asc" as const, desc: "title-desc" as const } };
     expect(columnSortToParam([{ id: "titleDisplay", desc: false }], map)).toBe("title-asc");
   });
 
   it("returns desc sort param for descending column", async () => {
-    const { columnSortToParam } = await import("./library.index");
+    const { columnSortToParam } = await import("~/lib/library-filter-helpers");
     const map = { titleDisplay: { asc: "title-asc" as const, desc: "title-desc" as const } };
     expect(columnSortToParam([{ id: "titleDisplay", desc: true }], map)).toBe("title-desc");
   });

--- a/apps/web/src/routes/_authenticated/library.$workId.tsx
+++ b/apps/web/src/routes/_authenticated/library.$workId.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { createFileRoute, Link, useRouter } from "@tanstack/react-router";
 import { toast } from "sonner";
-import { BookOpen, ChevronRight, ImagePlus, Loader2, Pencil, Search, Sparkles, Trash2, Upload } from "lucide-react";
+import { ChevronRight, Sparkles, Trash2 } from "lucide-react";
+import { WorkCover } from "~/components/work-cover";
 import { Button } from "~/components/ui/button";
 import {
   Dialog,
@@ -11,25 +12,17 @@ import {
   DialogHeader,
   DialogTitle,
 } from "~/components/ui/dialog";
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from "~/components/ui/dropdown-menu";
 import { Badge } from "~/components/ui/badge";
 import { Skeleton } from "~/components/ui/skeleton";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "~/components/ui/tabs";
-import { ProgressBar } from "~/components/progress-bar";
 import { EnrichmentDialog } from "~/components/enrichment-dialog";
+import { WorkProgress } from "~/components/work-progress";
+import { EditionProgress } from "~/components/edition-progress";
+import { ShelfMembership } from "~/components/shelf-membership";
 import { CoverSearchDialog } from "~/components/cover-search-dialog";
 import { EditionTabPanel } from "~/components/edition-tab-panel";
 import { MetadataItem } from "~/components/metadata-item";
-import {
-  getShelvesForWorkServerFn,
-  addEditionsForWorkToShelfServerFn,
-  removeWorkEditionsFromShelfServerFn,
-} from "~/lib/server-fns/shelves";
+import { getShelvesForWorkServerFn } from "~/lib/server-fns/shelves";
 import {
   getWorkDetailServerFn,
   type WorkDetail,
@@ -94,18 +87,14 @@ function getAuthors(work: WorkDetail): { id: string; name: string }[] {
 function WorkDetailPage() {
   const { work, progress, trackingMode, contributorNames, smtpConfigured, kindleConfigured, shelves } = Route.useLoaderData();
   const router = useRouter();
-  const [imgFailed, setImgFailed] = useState(false);
   const [deleteWorkOpen, setDeleteWorkOpen] = useState(false);
   const [deletingWork, setDeletingWork] = useState(false);
   const [deleteEditionOpen, setDeleteEditionOpen] = useState<string | null>(null);
   const [deletingEdition, setDeletingEdition] = useState(false);
-  const [uploadingCover, setUploadingCover] = useState(false);
   const [coverVersion, setCoverVersion] = useState(0);
   const [enrichOpen, setEnrichOpen] = useState(false);
   const [coverSearchOpen, setCoverSearchOpen] = useState(false);
   const [activeEditionIdx, setActiveEditionIdx] = useState(0);
-  const coverInputRef = useRef<HTMLInputElement>(null);
-  const showPlaceholder = !work.coverPath || imgFailed;
   const authors = getAuthors(work);
   const coverColors = work.coverColors as string[] | null;
   const { setBookColors } = useAppColor();
@@ -168,32 +157,10 @@ function WorkDetailPage() {
     }
   }
 
-  async function handleCoverUpload(e: React.ChangeEvent<HTMLInputElement>) {
-    const file = e.target.files?.[0];
-    if (!file) return;
-    setUploadingCover(true);
-    try {
-      const formData = new FormData();
-      formData.append("file", file);
-      const res = await fetch(`/api/upload-cover/${work.id}`, {
-        method: "POST",
-        body: formData,
-      });
-      if (!res.ok) {
-        const text = await res.text();
-        throw new Error(text || "Upload failed");
-      }
-      toast.success("Cover updated");
-      setImgFailed(false);
-      setCoverVersion((v) => v + 1);
-      void router.invalidate();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to upload cover");
-    } finally {
-      setUploadingCover(false);
-      e.target.value = "";
-    }
-  }
+  const handleCoverUpdated = () => {
+    setCoverVersion((v) => v + 1);
+    void router.invalidate();
+  };
 
   return (
     <div className="space-y-6">
@@ -206,61 +173,15 @@ function WorkDetailPage() {
       </nav>
 
       <div className="flex gap-8">
-        <div className="w-48 shrink-0">
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <div
-                className="group relative aspect-[2/3] cursor-pointer overflow-hidden rounded-lg bg-muted"
-                role="button"
-                tabIndex={0}
-              >
-                {showPlaceholder ? (
-                  <div data-testid="cover-placeholder" className="flex size-full items-center justify-center text-muted-foreground">
-                    <BookOpen className="size-12" />
-                  </div>
-                ) : (
-                  <img
-                    src={`/api/covers/${work.id}/medium?v=${String(coverVersion)}`}
-                    alt={work.titleDisplay}
-                    onError={() => { setImgFailed(true); }}
-                    className="size-full object-cover"
-                  />
-                )}
-                <div className="absolute inset-0 flex items-center justify-center bg-black/40 opacity-0 transition-opacity group-hover:opacity-100">
-                  {uploadingCover ? (
-                    <Loader2 className="size-8 animate-spin text-white" />
-                  ) : (
-                    <ImagePlus className="size-8 text-white" />
-                  )}
-                </div>
-              </div>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start">
-              <DropdownMenuItem data-testid="cover-upload-option" onClick={() => { coverInputRef.current?.click(); }}>
-                <Upload className="size-4 mr-2" />
-                Upload from file
-              </DropdownMenuItem>
-              <DropdownMenuItem data-testid="cover-search-option" onClick={() => { setCoverSearchOpen(true); }}>
-                <Search className="size-4 mr-2" />
-                Search for cover
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <input
-            ref={coverInputRef}
-            type="file"
-            accept="image/*"
-            className="hidden"
-            data-testid="cover-file-input"
-            onChange={(e) => { void handleCoverUpload(e); }}
-          />
-          {maxPercent !== null && (
-            <div className="mt-2 text-center" data-testid="cover-progress">
-              <span className="text-xl font-bold tabular-nums">{String(maxPercent)}%</span>
-              <p className="text-xs text-muted-foreground">read</p>
-            </div>
-          )}
-        </div>
+        <WorkCover
+          workId={work.id}
+          coverPath={work.coverPath}
+          titleDisplay={work.titleDisplay}
+          maxPercent={maxPercent}
+          coverVersion={coverVersion}
+          onCoverUpdated={handleCoverUpdated}
+          onCoverSearchOpen={() => { setCoverSearchOpen(true); }}
+        />
 
         <div className="flex-1 space-y-4">
           <div>
@@ -341,7 +262,7 @@ function WorkDetailPage() {
           </MetadataItem>
 
           <MetadataItem label="Shelves">
-            <ShelfMembership workId={work.id} shelves={shelves} />
+            <ShelfMembership workId={work.id} shelves={shelves} onToggled={() => { void router.invalidate(); }} />
           </MetadataItem>
         </div>
       </div>
@@ -368,7 +289,7 @@ function WorkDetailPage() {
           pageCount: work.editions[activeEditionIdx].pageCount ?? null,
           editedFields: work.editions[activeEditionIdx].editedFields,
         } : null}
-        onApplied={() => { setCoverVersion((v) => v + 1); void router.invalidate(); }}
+        onApplied={handleCoverUpdated}
       />
 
       <CoverSearchDialog
@@ -376,7 +297,7 @@ function WorkDetailPage() {
         onOpenChange={setCoverSearchOpen}
         workId={work.id}
         workTitle={work.titleDisplay}
-        onApplied={() => { setCoverVersion((v) => v + 1); void router.invalidate(); }}
+        onApplied={handleCoverUpdated}
       />
 
       <div className="space-y-4">
@@ -470,162 +391,4 @@ function WorkDetailPage() {
   );
 }
 
-
-function WorkProgress({ progress }: { progress: { percent: number | null }[] }) {
-  const maxPercent = Math.max(...progress.map((p) => p.percent ?? 0));
-  return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-2">
-        <div className="flex-1">
-          <ProgressBar percent={maxPercent} />
-        </div>
-        <span className="text-sm text-muted-foreground">{String(maxPercent)}%</span>
-      </div>
-    </div>
-  );
-}
-
-function progressKindForEdition(formatFamily: string): "EBOOK" | "AUDIO" | "READALOUD" {
-  if (formatFamily === "AUDIOBOOK") return "AUDIO";
-  return "EBOOK";
-}
-
-function EditionProgress({
-  progress,
-  editions,
-  onUpdate,
-}: {
-  progress: { editionId: string; progressKind: string; percent: number | null; source: string | null }[];
-  editions: WorkDetail["editions"];
-  onUpdate: (editionId: string, percent: number, progressKind: string) => Promise<void>;
-}) {
-  const progressMap = new Map(progress.map((p) => [p.editionId, p]));
-  const [editingId, setEditingId] = useState<string | null>(null);
-  const [editValue, setEditValue] = useState("");
-  const [saving, setSaving] = useState(false);
-
-  async function handleSave(editionId: string, progressKind: string) {
-    const val = parseInt(editValue, 10);
-    if (isNaN(val) || val < 0 || val > 100) return;
-    setSaving(true);
-    try {
-      await onUpdate(editionId, val, progressKind);
-      setEditingId(null);
-    } finally {
-      setSaving(false);
-    }
-  }
-
-  return (
-    <div className="space-y-3">
-      {editions.map((edition) => {
-        const p = progressMap.get(edition.id);
-        const percent = p?.percent ?? 0;
-        const progressKind = p?.progressKind ?? progressKindForEdition(edition.formatFamily);
-        const isEditing = editingId === edition.id;
-
-        return (
-          <div key={edition.id} className="space-y-1">
-            <div className="flex items-center gap-2 text-sm">
-              <Badge variant="secondary">{edition.formatFamily}</Badge>
-              {p?.source && <Badge variant="outline" className="text-xs">via {p.source}</Badge>}
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="flex-1">
-                <ProgressBar percent={percent} />
-              </div>
-              {isEditing ? (
-                <div className="flex items-center gap-1">
-                  <input
-                    data-testid={`progress-input-${edition.id}`}
-                    type="number"
-                    min={0}
-                    max={100}
-                    value={editValue}
-                    onChange={(e) => { setEditValue(e.target.value); }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") { void handleSave(edition.id, progressKind); }
-                      if (e.key === "Escape") { setEditingId(null); }
-                    }}
-                    className="w-16 rounded border px-2 py-0.5 text-sm text-right"
-                    autoFocus
-                    disabled={saving}
-                  />
-                  <span className="text-sm">%</span>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={saving}
-                    onClick={() => { void handleSave(edition.id, progressKind); }}
-                    data-testid={`progress-save-${edition.id}`}
-                  >
-                    {saving ? <Loader2 className="size-3 animate-spin" /> : "Save"}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={saving}
-                    onClick={() => { setEditingId(null); }}
-                    data-testid={`progress-cancel-${edition.id}`}
-                  >
-                    ✕
-                  </Button>
-                </div>
-              ) : (
-                <button
-                  className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground group"
-                  onClick={() => { setEditingId(edition.id); setEditValue(String(percent)); }}
-                  data-testid={`progress-edit-${edition.id}`}
-                  aria-label={`Edit progress for ${edition.formatFamily}`}
-                >
-                  <span>{String(percent)}%</span>
-                  <Pencil className="size-3 opacity-0 group-hover:opacity-100 transition-opacity" />
-                </button>
-              )}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
-}
-
-function ShelfMembership({
-  workId,
-  shelves,
-}: {
-  workId: string;
-  shelves: { id: string; name: string; isMember: boolean }[];
-}) {
-  const router = useRouter();
-
-  const handleToggle = async (shelfId: string, isMember: boolean) => {
-    if (isMember) {
-      await removeWorkEditionsFromShelfServerFn({ data: { shelfId, workId } });
-    } else {
-      await addEditionsForWorkToShelfServerFn({ data: { shelfId, workId } });
-    }
-    void router.invalidate();
-  };
-
-  if (shelves.length === 0) {
-    return <span className="text-muted-foreground">No shelves created yet</span>;
-  }
-
-  return (
-    <div className="flex flex-wrap gap-1.5" data-testid="shelf-membership">
-      {shelves.map((shelf) => (
-        <Badge
-          key={shelf.id}
-          variant={shelf.isMember ? "default" : "outline"}
-          className="cursor-pointer select-none"
-          onClick={() => { void handleToggle(shelf.id, shelf.isMember); }}
-          data-testid={`shelf-toggle-${shelf.id}`}
-        >
-          {shelf.name}
-        </Badge>
-      ))}
-    </div>
-  );
-}
 

--- a/apps/web/src/routes/_authenticated/library.index.tsx
+++ b/apps/web/src/routes/_authenticated/library.index.tsx
@@ -1,42 +1,27 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { createFileRoute, Link, useNavigate, useRouter } from "@tanstack/react-router";
-import { toast } from "sonner";
 import { useSSE } from "~/hooks/use-sse";
 import { useLibraryViewPreference } from "~/hooks/use-library-view-preference";
 import { useLibraryTablePreferences } from "~/hooks/use-library-table-preferences";
 import { useGridTileSize } from "~/hooks/use-grid-tile-size";
-import type { ColumnDef, RowSelectionState, SortingState, Updater } from "@tanstack/react-table";
-import { AlignJustify, BookOpen, Loader2, Pencil, Trash2, WrapText, X } from "lucide-react";
-import { VirtualizedDataTable, DataTableColumnHeader } from "~/components/data-table";
-import { DataTableColumnPicker } from "~/components/data-table/data-table-column-picker";
-import { Badge } from "~/components/ui/badge";
-import { Button } from "~/components/ui/button";
-import {
-  Dialog,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-} from "~/components/ui/dialog";
-import { FolderOpen } from "lucide-react";
-import { bulkDeleteWorksServerFn } from "~/lib/server-fns/deletion";
-import { getShelvesServerFn, bulkAddToShelfServerFn } from "~/lib/server-fns/shelves";
-import { EditableTableCell } from "~/components/editable-table-cell";
-import { updateWorkServerFn, updateEditionServerFn, updateWorkAuthorsServerFn } from "~/lib/server-fns/editing";
+import { useLibraryFilters } from "~/hooks/use-library-filters";
+import type { RowSelectionState } from "@tanstack/react-table";
+import { BookOpen, Loader2 } from "lucide-react";
+import { LibrarySelectionToolbar } from "~/components/library-selection-toolbar";
 import { GridPageSkeleton } from "~/components/skeletons/grid-page-skeleton";
+import { getColumns } from "~/lib/library-columns";
+import { LibraryTableView } from "~/components/library-table-view";
+import { filterByReadingStatus } from "~/lib/library-filter-helpers";
 import { LibraryToolbar } from "~/components/library-toolbar";
 import { LibraryGrid } from "~/components/library-grid";
-import { LibraryFilters, type LibraryFilterValues } from "~/components/library-filters";
+import { LibraryFilters } from "~/components/library-filters";
 import { LibraryPagination } from "~/components/library-pagination";
-import { librarySearchSchema, type LibrarySearchParams } from "~/lib/library-search-schema";
+import { librarySearchSchema } from "~/lib/library-search-schema";
 import type { ReadingFilter } from "~/lib/sort-filter-works";
-import {
-  getFilteredLibraryWorksServerFn,
-  type LibraryWork,
-} from "~/lib/server-fns/library";
+import { getFilteredLibraryWorksServerFn } from "~/lib/server-fns/library";
 import { getActiveJobCountServerFn } from "~/lib/server-fns/import-jobs";
 import { getBulkReadingProgressServerFn } from "~/lib/server-fns/reading-progress";
+import { getShelvesServerFn } from "~/lib/server-fns/shelves";
 
 export const Route = createFileRoute("/_authenticated/library/")({
   validateSearch: (search) => librarySearchSchema.parse(search),
@@ -54,204 +39,6 @@ export const Route = createFileRoute("/_authenticated/library/")({
   component: LibraryPage,
 });
 
-function getAuthors(work: LibraryWork): string {
-  const authors = work.editions
-    .flatMap((e) => e.contributors)
-    .filter((c) => c.role === "AUTHOR")
-    .map((c) => c.contributor.nameDisplay);
-  return [...new Set(authors)].join(", ") || "—";
-}
-
-function getFormats(work: LibraryWork): string[] {
-  return [...new Set(work.editions.map((e) => e.formatFamily))];
-}
-
-const COLUMN_PICKER_ITEMS = [
-  { id: "authors", label: "Author(s)" },
-  { id: "formats", label: "Format" },
-  { id: "publisher", label: "Publisher" },
-  { id: "isbn", label: "ISBN" },
-];
-
-function getColumns(scanActive: boolean, editMode: boolean, router: { invalidate: () => void }): ColumnDef<LibraryWork>[] {
-  return [
-  {
-    id: "select",
-    header: ({ table }) => (
-      <input
-        type="checkbox"
-        checked={table.getIsAllPageRowsSelected()}
-        onChange={(e) => { table.toggleAllPageRowsSelected(e.target.checked); }}
-        aria-label="Select all"
-      />
-    ),
-    cell: ({ row }) => (
-      <input
-        type="checkbox"
-        checked={row.getIsSelected()}
-        onChange={(e) => { row.toggleSelected(e.target.checked); }}
-        aria-label="Select row"
-      />
-    ),
-    size: 40,
-    enableSorting: false,
-    enableHiding: false,
-  },
-  {
-    accessorKey: "titleDisplay",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Title" />
-    ),
-    cell: ({ row }) => {
-      if (editMode) {
-        return (
-          <EditableTableCell
-            value={row.original.titleDisplay}
-            editing={true}
-            onSave={async (val) => {
-              await updateWorkServerFn({ data: { workId: row.original.id, fields: { titleDisplay: val } } });
-              router.invalidate();
-            }}
-          />
-        );
-      }
-      return (
-        <Link to="/library/$workId" params={{ workId: row.original.id }} search={{ page: 1, pageSize: 50, sort: "title-asc" as const }} className="flex items-center gap-2">
-          {row.original.titleDisplay}
-          {row.original.enrichmentStatus === "STUB" && scanActive && (
-            <Badge variant="outline" className="animate-pulse px-1.5 py-0 text-[10px]">
-              Processing&hellip;
-            </Badge>
-          )}
-        </Link>
-      );
-    },
-    size: 300,
-    enableHiding: false,
-  },
-  {
-    id: "authors",
-    accessorFn: (row) => getAuthors(row),
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Author(s)" />
-    ),
-    cell: ({ row }) => {
-      const authorsStr = getAuthors(row.original);
-      if (editMode) {
-        return (
-          <EditableTableCell
-            value={authorsStr === "—" ? "" : authorsStr}
-            editing={true}
-            onSave={async (val) => {
-              const authors = val.split(",").map((a) => a.trim()).filter((a) => a.length > 0);
-              if (authors.length === 0) return;
-              await updateWorkAuthorsServerFn({ data: { workId: row.original.id, authors } });
-              router.invalidate();
-            }}
-          />
-        );
-      }
-      return <span>{authorsStr}</span>;
-    },
-    size: 200,
-  },
-  {
-    id: "formats",
-    accessorFn: (row) => getFormats(row).join(", "),
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Format" />
-    ),
-    cell: ({ row }) =>
-      getFormats(row.original).map((f) => (
-        <Badge key={f} variant="secondary" className="mr-1">
-          {f}
-        </Badge>
-      )),
-    size: 80,
-  },
-  {
-    id: "publisher",
-    accessorFn: (row) => row.editions[0]?.publisher ?? "",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="Publisher" />
-    ),
-    cell: ({ row }) => {
-      const pub = row.original.editions[0]?.publisher ?? "";
-      const editionId = row.original.editions[0]?.id;
-      if (editMode && editionId) {
-        return (
-          <EditableTableCell
-            value={pub}
-            editing={true}
-            onSave={async (val) => {
-              await updateEditionServerFn({ data: { editionId, fields: { publisher: val || null } } });
-              router.invalidate();
-            }}
-          />
-        );
-      }
-      return <span>{pub || "—"}</span>;
-    },
-    size: 150,
-  },
-  {
-    id: "isbn",
-    accessorFn: (row) => row.editions[0]?.isbn13 ?? row.editions[0]?.isbn10 ?? "",
-    header: ({ column }) => (
-      <DataTableColumnHeader column={column} title="ISBN" />
-    ),
-    cell: ({ row }) => {
-      const isbn = row.original.editions[0]?.isbn13 ?? row.original.editions[0]?.isbn10 ?? "";
-      const editionId = row.original.editions[0]?.id;
-      if (editMode && editionId) {
-        return (
-          <EditableTableCell
-            value={isbn}
-            editing={true}
-            onSave={async (val) => {
-              await updateEditionServerFn({ data: { editionId, fields: { isbn13: val || null } } });
-              router.invalidate();
-            }}
-          />
-        );
-      }
-      return <span>{isbn || "—"}</span>;
-    },
-    size: 120,
-  },
-  ];
-}
-
-function filterByReadingStatus(
-  works: LibraryWork[],
-  readingFilter: ReadingFilter,
-  progressMap: Record<string, number>,
-): LibraryWork[] {
-  if (readingFilter === "all") return works;
-  return works.filter((w) => {
-    const pct = progressMap[w.id] ?? 0;
-    switch (readingFilter) {
-      case "reading":
-        return pct > 0 && pct < 100;
-      case "finished":
-        return pct >= 100;
-      case "unread":
-        return pct === 0;
-    }
-  });
-}
-
-export function columnSortToParam(
-  state: SortingState,
-  map: Record<string, { asc: LibrarySearchParams["sort"]; desc: LibrarySearchParams["sort"] }>,
-): LibrarySearchParams["sort"] {
-  const entry = state[0];
-  if (!entry) return "title-asc";
-  const col = map[entry.id];
-  if (!col) return "title-asc";
-  return entry.desc ? col.desc : col.asc;
-}
-
 function LibraryPage() {
   const { libraryResult, activeJobCount, progressMap, shelves } = Route.useLoaderData();
   const { works, totalCount, facetCounts, totalFacetCounts } = libraryResult;
@@ -265,166 +52,11 @@ function LibraryPage() {
 
   const router = useRouter();
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
-  const [bulkDeleteOpen, setBulkDeleteOpen] = useState(false);
-  const [bulkDeleting, setBulkDeleting] = useState(false);
-  const [addToShelfOpen, setAddToShelfOpen] = useState(false);
-  const [addingToShelf, setAddingToShelf] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const isScanning = activeJobCount > 0;
   const columns = useMemo(() => getColumns(isScanning, editMode, router), [isScanning, editMode, router]);
   const newCount = totalCount - prevCount;
   const selectedCount = Object.keys(rowSelection).length;
-
-  async function handleBulkDelete() {
-    setBulkDeleting(true);
-    try {
-      await bulkDeleteWorksServerFn({ data: { workIds: selectedWorkIds } });
-      toast.success(`${String(selectedWorkIds.length)} work${selectedWorkIds.length === 1 ? "" : "s"} deleted`);
-      setRowSelection({});
-      setBulkDeleteOpen(false);
-      void router.invalidate();
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : "Failed to delete works");
-    } finally {
-      setBulkDeleting(false);
-    }
-  }
-
-  async function handleAddToShelf(shelfId: string) {
-    setAddingToShelf(true);
-    try {
-      const result = await bulkAddToShelfServerFn({ data: { shelfId, workIds: selectedWorkIds } });
-      toast.success(`Added ${String(result.added)} to shelf`);
-      setRowSelection({});
-      setAddToShelfOpen(false);
-      void router.invalidate();
-    } catch {
-      toast.error("Failed to add to shelf");
-    } finally {
-      setAddingToShelf(false);
-    }
-  }
-
-  useSSE();
-
-  useEffect(() => {
-    if (!isScanning) {
-      setPrevCount(totalCount);
-    }
-  }, [isScanning, totalCount]);
-
-  const updateSearch = useCallback(
-    (updates: Partial<LibrarySearchParams>) => {
-      void navigate({
-        to: ".",
-        search: (prev) => ({
-          ...(prev as LibrarySearchParams),
-          ...updates,
-          page: updates.page ?? 1,
-        }),
-        replace: true,
-      });
-    },
-    [navigate],
-  );
-
-  const handleFiltersChange = useCallback(
-    (filters: LibraryFilterValues) => {
-      updateSearch({
-        format: filters.format as LibrarySearchParams["format"],
-        authorId: filters.authorId,
-        seriesId: filters.seriesId,
-        publisher: filters.publisher,
-        hasCover: filters.hasCover,
-        enriched: filters.enriched,
-        hasDescription: filters.hasDescription,
-        inSeries: filters.inSeries,
-        hasIsbn: filters.hasIsbn,
-      });
-    },
-    [updateSearch],
-  );
-
-  const handleSearchChange = useCallback(
-    (q: string) => {
-      updateSearch({ q: q || undefined });
-    },
-    [updateSearch],
-  );
-
-  const handleSortChange = useCallback(
-    (sort: string) => {
-      updateSearch({ sort: sort as LibrarySearchParams["sort"] });
-    },
-    [updateSearch],
-  );
-
-  const COLUMN_SORT_MAP: Record<string, { asc: LibrarySearchParams["sort"]; desc: LibrarySearchParams["sort"] }> = useMemo(() => ({
-    titleDisplay: { asc: "title-asc", desc: "title-desc" },
-    authors: { asc: "author-asc", desc: "author-desc" },
-    publisher: { asc: "publisher-asc", desc: "publisher-desc" },
-    formats: { asc: "format-asc", desc: "format-desc" },
-    isbn: { asc: "isbn-asc", desc: "isbn-desc" },
-  }), []);
-
-  const SORT_TO_COLUMN: Record<string, { id: string; desc: boolean }> = useMemo(() => ({
-    "title-asc": { id: "titleDisplay", desc: false },
-    "title-desc": { id: "titleDisplay", desc: true },
-    "author-asc": { id: "authors", desc: false },
-    "author-desc": { id: "authors", desc: true },
-    "publisher-asc": { id: "publisher", desc: false },
-    "publisher-desc": { id: "publisher", desc: true },
-    "format-asc": { id: "formats", desc: false },
-    "format-desc": { id: "formats", desc: true },
-    "isbn-asc": { id: "isbn", desc: false },
-    "isbn-desc": { id: "isbn", desc: true },
-  }), []);
-
-  const tableSorting: SortingState = useMemo(() => {
-    const mapped = SORT_TO_COLUMN[search.sort];
-    return mapped ? [mapped] : [];
-  }, [search.sort, SORT_TO_COLUMN]);
-
-  const handleColumnSort = useCallback(
-    (updater: Updater<SortingState>) => {
-      // TanStack Table always passes a function updater; cast is safe
-      const newState = (updater as (prev: SortingState) => SortingState)(tableSorting);
-      updateSearch({ sort: columnSortToParam(newState, COLUMN_SORT_MAP) });
-    },
-    [tableSorting, updateSearch, COLUMN_SORT_MAP],
-  );
-
-  const handlePageChange = useCallback(
-    (page: number) => {
-      updateSearch({ page });
-    },
-    [updateSearch],
-  );
-
-  const handlePageSizeChange = useCallback(
-    (pageSize: number) => {
-      updateSearch({ pageSize, page: 1 });
-    },
-    [updateSearch],
-  );
-
-  const handleColumnToggle = useCallback(
-    (columnId: string) => {
-      const current = tablePrefs.columnVisibility[columnId] !== false;
-      setTablePrefs({
-        ...tablePrefs,
-        columnVisibility: { ...tablePrefs.columnVisibility, [columnId]: !current },
-      });
-    },
-    [tablePrefs, setTablePrefs],
-  );
-
-  const handleTextOverflowToggle = useCallback(() => {
-    setTablePrefs({
-      ...tablePrefs,
-      textOverflow: tablePrefs.textOverflow === "truncate" ? "wrap" : "truncate",
-    });
-  }, [tablePrefs, setTablePrefs]);
 
   const filteredByReading = useMemo(
     () => filterByReadingStatus(works, readingFilter, progressMap),
@@ -437,16 +69,43 @@ function LibraryPage() {
       .filter((id): id is string => id !== undefined);
   }, [rowSelection, filteredByReading]);
 
-  const currentFilters: LibraryFilterValues = {
-    format: search.format,
-    authorId: search.authorId,
-    seriesId: search.seriesId,
-    publisher: search.publisher,
-    hasCover: search.hasCover,
-    enriched: search.enriched,
-    hasDescription: search.hasDescription,
-    inSeries: search.inSeries,
-    hasIsbn: search.hasIsbn,
+  useSSE();
+
+  useEffect(() => {
+    if (!isScanning) {
+      setPrevCount(totalCount);
+    }
+  }, [isScanning, totalCount]);
+
+  const {
+    handleFiltersChange,
+    handleSearchChange,
+    handleSortChange,
+    handleColumnSort,
+    handlePageChange,
+    handlePageSizeChange,
+    tableSorting,
+    currentFilters,
+  } = useLibraryFilters({ search, navigate });
+
+  const handleColumnToggle = (columnId: string) => {
+    const current = tablePrefs.columnVisibility[columnId] !== false;
+    setTablePrefs({
+      ...tablePrefs,
+      columnVisibility: { ...tablePrefs.columnVisibility, [columnId]: !current },
+    });
+  };
+
+  const handleTextOverflowToggle = () => {
+    setTablePrefs({
+      ...tablePrefs,
+      textOverflow: tablePrefs.textOverflow === "truncate" ? "wrap" : "truncate",
+    });
+  };
+
+  const handleSelectionDone = () => {
+    setRowSelection({});
+    void router.invalidate();
   };
 
   if (totalCount === 0 && !isScanning && !search.q && !search.format && !search.authorId && !search.seriesId && !search.publisher && search.hasCover === undefined && search.enriched === undefined && search.hasDescription === undefined && search.inSeries === undefined && search.hasIsbn === undefined) {
@@ -509,47 +168,17 @@ function LibraryPage() {
             tileSize={tileSize}
             onTileSizeChange={setTileSize}
           />
-          {view === "table" && (
-            <div className="flex items-center gap-2 justify-end">
-              <Button
-                data-testid="edit-mode-toggle"
-                variant={editMode ? "default" : "outline"}
-                size="sm"
-                onClick={() => { setEditMode(!editMode); }}
-                aria-label={editMode ? "Exit edit mode" : "Enter edit mode"}
-              >
-                <Pencil className="mr-2 h-4 w-4" />
-                {editMode ? "Done" : "Edit"}
-              </Button>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={handleTextOverflowToggle}
-                aria-label={tablePrefs.textOverflow === "truncate" ? "Wrap text" : "Truncate text"}
-              >
-                {tablePrefs.textOverflow === "truncate" ? (
-                  <WrapText className="mr-2 h-4 w-4" />
-                ) : (
-                  <AlignJustify className="mr-2 h-4 w-4" />
-                )}
-                {tablePrefs.textOverflow === "truncate" ? "Wrap" : "Truncate"}
-              </Button>
-              <DataTableColumnPicker
-                columns={COLUMN_PICKER_ITEMS}
-                columnVisibility={tablePrefs.columnVisibility}
-                onToggle={handleColumnToggle}
-              />
-            </div>
-          )}
           {view === "grid" ? (
             <LibraryGrid works={filteredByReading} progressMap={progressMap} scanActive={isScanning} tileSize={tileSize} />
           ) : (
-            <VirtualizedDataTable
+            <LibraryTableView
+              works={filteredByReading}
               columns={columns}
-              data={filteredByReading}
-              showPagination={false}
-              columnVisibility={tablePrefs.columnVisibility}
-              textOverflow={tablePrefs.textOverflow}
+              editMode={editMode}
+              onEditModeToggle={() => { setEditMode(!editMode); }}
+              tablePrefs={tablePrefs}
+              onColumnToggle={handleColumnToggle}
+              onTextOverflowToggle={handleTextOverflowToggle}
               rowSelection={rowSelection}
               onRowSelectionChange={setRowSelection}
               sorting={tableSorting}
@@ -566,71 +195,14 @@ function LibraryPage() {
         </div>
       </div>
 
-      {selectedCount > 0 && (
-        <div className="fixed bottom-6 left-1/2 -translate-x-1/2 z-50 flex items-center gap-3 rounded-lg border bg-background p-3 shadow-lg">
-          <span className="text-sm font-medium">{selectedCount} work{selectedCount === 1 ? "" : "s"} selected</span>
-          <Button variant="outline" size="sm" onClick={() => { setAddToShelfOpen(true); }} data-testid="bulk-add-to-shelf-btn">
-            <FolderOpen className="mr-1.5 size-3.5" />
-            Add to Shelf
-          </Button>
-          <Button variant="destructive" size="sm" onClick={() => { setBulkDeleteOpen(true); }}>
-            <Trash2 className="mr-1.5 size-3.5" />
-            Delete Selected
-          </Button>
-          <Button variant="outline" size="sm" onClick={() => { setRowSelection({}); }}>
-            <X className="mr-1.5 size-3.5" />
-            Clear
-          </Button>
-        </div>
-      )}
-
-      <Dialog open={bulkDeleteOpen} onOpenChange={setBulkDeleteOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Delete {selectedCount} Work{selectedCount === 1 ? "" : "s"}</DialogTitle>
-            <DialogDescription>
-              This will remove {selectedCount} work{selectedCount === 1 ? "" : "s"} and all {selectedCount === 1 ? "its" : "their"} editions from the library.
-              The actual files on disk will not be affected.
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter>
-            <Button variant="outline" onClick={() => { setBulkDeleteOpen(false); }} disabled={bulkDeleting}>
-              Cancel
-            </Button>
-            <Button variant="destructive" onClick={() => { void handleBulkDelete(); }} disabled={bulkDeleting}>
-              {bulkDeleting ? "Deleting..." : "Delete"}
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog open={addToShelfOpen} onOpenChange={setAddToShelfOpen}>
-        <DialogContent>
-          <DialogHeader>
-            <DialogTitle>Add {selectedCount} Work{selectedCount === 1 ? "" : "s"} to Shelf</DialogTitle>
-          </DialogHeader>
-          <div className="space-y-2" data-testid="shelf-picker">
-            {shelves.length === 0 ? (
-              <p className="text-sm text-muted-foreground">No shelves created yet. Create one from the Shelves page.</p>
-            ) : (
-              shelves.map((shelf) => (
-                <Button
-                  key={shelf.id}
-                  variant="outline"
-                  className="w-full justify-start"
-                  onClick={() => { void handleAddToShelf(shelf.id); }}
-                  disabled={addingToShelf}
-                  data-testid={`shelf-pick-${shelf.id}`}
-                >
-                  <FolderOpen className="mr-2 size-4" />
-                  {shelf.name}
-                  <span className="ml-auto text-muted-foreground">{shelf._count.items} works</span>
-                </Button>
-              ))
-            )}
-          </div>
-        </DialogContent>
-      </Dialog>
+      <LibrarySelectionToolbar
+        selectedCount={selectedCount}
+        selectedWorkIds={selectedWorkIds}
+        shelves={shelves}
+        onDeleted={handleSelectionDone}
+        onAddedToShelf={handleSelectionDone}
+        onClearSelection={() => { setRowSelection({}); }}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Extracts cohesive logic out of `library.index.tsx` (637 → 208 lines) and `library.$workId.tsx` (632 → 394 lines) into 9 new focused modules, each with a co-located test file
- Pure functions first (`library-columns`, `library-filter-helpers`), then hook (`use-library-filters`), then components (`library-table-view`, `library-selection-toolbar`, `work-progress`, `edition-progress`, `shelf-membership`, `work-cover`)
- Red/Green TDD throughout — failing tests written before each extraction; all 100% coverage thresholds maintained

## New modules

| File | What it owns |
|---|---|
| `lib/library-columns.tsx` | `getFormats`, `COLUMN_PICKER_ITEMS`, `getColumns` |
| `lib/library-filter-helpers.ts` | `filterByReadingStatus`, `columnSortToParam`, `COLUMN_SORT_MAP`, `SORT_TO_COLUMN` |
| `hooks/use-library-filters.ts` | URL-synced filter/sort/pagination handlers + derived state |
| `components/library-table-view.tsx` | Table edit/overflow controls + `VirtualizedDataTable` |
| `components/library-selection-toolbar.tsx` | Floating selection bar + bulk-delete + add-to-shelf dialogs |
| `components/work-progress.tsx` | Read-only work-level progress display |
| `components/edition-progress.tsx` | Per-edition editable progress bars |
| `components/shelf-membership.tsx` | Shelf toggle badges (converted from internal router invalidation to `onToggled` callback) |
| `components/work-cover.tsx` | Cover image, upload, error fallback, cover search |

Closes #158