### PR TITLE
Make reading progress visible in both library views

### DIFF
--- a/apps/web/src/components/progress-bar.test.tsx
+++ b/apps/web/src/components/progress-bar.test.tsx
@@ -50,4 +50,17 @@ describe("ProgressBar", () => {
     const fill = bar.firstElementChild as HTMLElement;
     expect(fill.style.width).toBe("0%");
   });
+
+  it("renders with h-0.5 class by default (sm)", () => {
+    render(<ProgressBar percent={50} />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.className).toContain("h-0.5");
+  });
+
+  it("renders with h-1.5 class when size is md", () => {
+    render(<ProgressBar percent={50} size="md" />);
+    const bar = screen.getByRole("progressbar");
+    expect(bar.className).toContain("h-1.5");
+    expect(bar.className).not.toContain("h-0.5");
+  });
 });

--- a/apps/web/src/components/progress-bar.tsx
+++ b/apps/web/src/components/progress-bar.tsx
@@ -1,4 +1,4 @@
-export function ProgressBar({ percent }: { percent: number | null | undefined }) {
+export function ProgressBar({ percent, size = "sm" }: { percent: number | null | undefined; size?: "sm" | "md" }) {
   if (percent == null) return null;
 
   return (
@@ -7,7 +7,7 @@ export function ProgressBar({ percent }: { percent: number | null | undefined })
       aria-valuenow={percent}
       aria-valuemin={0}
       aria-valuemax={100}
-      className="h-0.5 w-full overflow-hidden rounded-full bg-muted"
+      className={`${size === "md" ? "h-1.5" : "h-0.5"} w-full overflow-hidden rounded-full bg-muted`}
     >
       <div
         className={`h-full transition-all ${percent >= 100 ? "bg-green-500" : "bg-primary"}`}

--- a/apps/web/src/components/work-card.tsx
+++ b/apps/web/src/components/work-card.tsx
@@ -62,7 +62,7 @@ export function WorkCard({ id, title, authors, enrichmentStatus, scanActive, for
           )}
         </div>
       </div>
-      <ProgressBar percent={progressPercent} />
+      <ProgressBar percent={progressPercent} size="md" />
     </Link>
   );
 }

--- a/apps/web/src/lib/library-columns.test.tsx
+++ b/apps/web/src/lib/library-columns.test.tsx
@@ -32,6 +32,7 @@ vi.mock("~/components/editable-table-cell", async () => {
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
+import { render, screen } from "@testing-library/react";
 import { getFormats, COLUMN_PICKER_ITEMS, getColumns } from "./library-columns";
 
 type LibraryWork = Parameters<typeof getFormats>[0];
@@ -108,6 +109,7 @@ describe("COLUMN_PICKER_ITEMS", () => {
   it("has expected shape", () => {
     expect(COLUMN_PICKER_ITEMS).toEqual([
       { id: "authors", label: "Author(s)" },
+      { id: "progress", label: "Progress" },
       { id: "formats", label: "Format" },
       { id: "publisher", label: "Publisher" },
       { id: "isbn", label: "ISBN" },
@@ -128,9 +130,9 @@ describe("getColumns", () => {
     return c;
   }
 
-  it("returns 6 columns", () => {
+  it("returns 7 columns", () => {
     const cols = getColumns(false, false, router);
-    expect(cols).toHaveLength(6);
+    expect(cols).toHaveLength(7);
   });
 
   it("first column is select with checkboxes", () => {
@@ -153,21 +155,58 @@ describe("getColumns", () => {
     expect(authorsCol.size).toBe(200);
   });
 
+  it("progress column has correct id, size, and sorting disabled", () => {
+    const progressCol = col(getColumns(false, false, router), 3);
+    expect(progressCol.id).toBe("progress");
+    expect(progressCol.size).toBe(120);
+    expect(progressCol.enableSorting).toBe(false);
+  });
+
   it("formats column has correct id and size", () => {
-    const formatsCol = col(getColumns(false, false, router), 3);
+    const formatsCol = col(getColumns(false, false, router), 4);
     expect(formatsCol.id).toBe("formats");
     expect(formatsCol.size).toBe(80);
   });
 
   it("publisher column has correct id and size", () => {
-    const publisherCol = col(getColumns(false, false, router), 4);
+    const publisherCol = col(getColumns(false, false, router), 5);
     expect(publisherCol.id).toBe("publisher");
     expect(publisherCol.size).toBe(150);
   });
 
   it("isbn column has correct id and size", () => {
-    const isbnCol = col(getColumns(false, false, router), 5);
+    const isbnCol = col(getColumns(false, false, router), 6);
     expect(isbnCol.id).toBe("isbn");
     expect(isbnCol.size).toBe(120);
+  });
+
+  it("progress column cell renders percentage when progressMap has entry", () => {
+    const progressMap = { "work-test": 42 };
+    const cols = getColumns(false, false, router, progressMap);
+    const progressCol = col(cols, 3);
+    const cellFn = progressCol.cell as (info: { row: { original: LibraryWork } }) => React.ReactNode;
+    const work = makeWork("Test");
+    const { container } = render(<>{cellFn({ row: { original: work } })}</>);
+    expect(container.textContent).toContain("42%");
+    expect(screen.getByRole("progressbar")).toBeTruthy();
+  });
+
+  it("progress column cell renders dash when progressMap has no entry", () => {
+    const cols = getColumns(false, false, router, {});
+    const progressCol = col(cols, 3);
+    const cellFn = progressCol.cell as (info: { row: { original: LibraryWork } }) => React.ReactNode;
+    const work = makeWork("Test");
+    const { container } = render(<>{cellFn({ row: { original: work } })}</>);
+    expect(container.textContent).toContain("—");
+    expect(screen.queryByRole("progressbar")).toBeNull();
+  });
+
+  it("progress column cell renders dash when progressMap is undefined", () => {
+    const cols = getColumns(false, false, router);
+    const progressCol = col(cols, 3);
+    const cellFn = progressCol.cell as (info: { row: { original: LibraryWork } }) => React.ReactNode;
+    const work = makeWork("Test");
+    const { container } = render(<>{cellFn({ row: { original: work } })}</>);
+    expect(container.textContent).toContain("—");
   });
 });

--- a/apps/web/src/lib/library-columns.tsx
+++ b/apps/web/src/lib/library-columns.tsx
@@ -3,6 +3,7 @@ import { Link } from "@tanstack/react-router";
 import { Badge } from "~/components/ui/badge";
 import { DataTableColumnHeader } from "~/components/data-table";
 import { EditableTableCell } from "~/components/editable-table-cell";
+import { ProgressBar } from "~/components/progress-bar";
 import { updateWorkServerFn, updateEditionServerFn, updateWorkAuthorsServerFn } from "~/lib/server-fns/editing";
 import { getAuthors } from "~/lib/sort-filter-works";
 import type { LibraryWork } from "~/lib/server-fns/library";
@@ -15,12 +16,13 @@ export function getFormats(work: LibraryWork): string[] {
 
 export const COLUMN_PICKER_ITEMS = [
   { id: "authors", label: "Author(s)" },
+  { id: "progress", label: "Progress" },
   { id: "formats", label: "Format" },
   { id: "publisher", label: "Publisher" },
   { id: "isbn", label: "ISBN" },
 ];
 
-export function getColumns(scanActive: boolean, editMode: boolean, router: { invalidate: () => void }): ColumnDef<LibraryWork>[] {
+export function getColumns(scanActive: boolean, editMode: boolean, router: { invalidate: () => void }, progressMap?: Record<string, number>): ColumnDef<LibraryWork>[] {
   return [
   {
     id: "select",
@@ -101,6 +103,23 @@ export function getColumns(scanActive: boolean, editMode: boolean, router: { inv
       return <span>{authorsStr}</span>;
     },
     size: 200,
+  },
+  {
+    id: "progress",
+    header: "Progress",
+    cell: ({ row }) => {
+      const percent = progressMap?.[row.original.id];
+      return (
+        <div className="flex items-center gap-2">
+          <div className="flex-1">
+            <ProgressBar percent={percent} size="md" />
+          </div>
+          <span className="text-xs text-muted-foreground">{percent != null ? `${String(percent)}%` : "—"}</span>
+        </div>
+      );
+    },
+    size: 120,
+    enableSorting: false,
   },
   {
     id: "formats",

--- a/apps/web/src/routes/_authenticated/library.index.tsx
+++ b/apps/web/src/routes/_authenticated/library.index.tsx
@@ -54,7 +54,7 @@ function LibraryPage() {
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [editMode, setEditMode] = useState(false);
   const isScanning = activeJobCount > 0;
-  const columns = useMemo(() => getColumns(isScanning, editMode, router), [isScanning, editMode, router]);
+  const columns = useMemo(() => getColumns(isScanning, editMode, router, progressMap), [isScanning, editMode, router, progressMap]);
   const newCount = totalCount - prevCount;
   const selectedCount = Object.keys(rowSelection).length;
 


### PR DESCRIPTION
## Summary

- The grid view progress bar was `h-0.5` (2px tall) — at low percentages like 1%, it was completely invisible
- The table view had no progress indicator at all

Adds a `size` prop to `ProgressBar`, uses `size="md"` (6px) on grid cards, and adds a progress column to the table view with a bar + percentage text. Both views now show reading progress at a glance.

Closes #164