### PR TITLE
Implement ebook variant ingest and scan reliability fixes for #189

### DIFF
--- a/apps/web/src/components/edition-tab-panel.test.tsx
+++ b/apps/web/src/components/edition-tab-panel.test.tsx
@@ -129,6 +129,41 @@ describe("EditionTabPanel", () => {
     expect(screen.getByText("PRESENT")).toBeTruthy();
   });
 
+  it("renders Amazon ebook variant files", () => {
+    const edition = {
+      ...baseEdition,
+      editionFiles: [
+        ...baseEdition.editionFiles,
+        {
+          id: "ef2",
+          editionId: "e1",
+          fileAssetId: "fa2",
+          role: "ALTERNATE_FORMAT",
+          fileAsset: {
+            ...(baseEdition.editionFiles[0] as (typeof baseEdition.editionFiles)[number]).fileAsset,
+            id: "fa2",
+            basename: "wind.azw",
+            extension: "azw",
+            mediaKind: "AZW",
+          },
+        },
+      ],
+    } as EditionType;
+
+    render(
+      <EditionTabPanel
+        edition={edition}
+        isLastEdition={false}
+        onEditionFieldSaved={vi.fn()}
+        onDeleteEdition={vi.fn()}
+        smtpConfigured={false}
+        kindleConfigured={false}
+      />,
+    );
+
+    expect(screen.getByText("wind.azw")).toBeTruthy();
+  });
+
   it("renders delete button", () => {
     render(
       <EditionTabPanel

--- a/apps/web/src/components/edition-tab-panel.tsx
+++ b/apps/web/src/components/edition-tab-panel.tsx
@@ -11,7 +11,7 @@ import type { WorkDetail } from "~/lib/server-fns/work-detail";
 
 type EditionType = WorkDetail["editions"][number];
 
-const KINDLE_COMPATIBLE_MEDIA_KINDS = new Set(["EPUB", "PDF"]);
+const KINDLE_COMPATIBLE_MEDIA_KINDS = new Set(["EPUB", "MOBI", "AZW", "AZW3", "PDF"]);
 
 interface EditionTabPanelProps {
   edition: EditionType;
@@ -110,7 +110,7 @@ export function EditionTabPanel({
           <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Files</div>
           <div className="space-y-1 text-sm">
             {(() => {
-              const CONTENT_MEDIA_KINDS = new Set(["EPUB", "PDF", "CBZ", "AUDIO"]);
+              const CONTENT_MEDIA_KINDS = new Set(["EPUB", "MOBI", "AZW", "AZW3", "PDF", "CBZ", "AUDIO"]);
               const contentFiles = edition.editionFiles.filter(
                 (ef) => CONTENT_MEDIA_KINDS.has(ef.fileAsset.mediaKind),
               );

--- a/apps/web/src/lib/server-fns/duplicates.test.ts
+++ b/apps/web/src/lib/server-fns/duplicates.test.ts
@@ -123,6 +123,19 @@ describe("getDuplicatesServerFn", () => {
     expect(result.map((r: { id: string }) => r.id)).toEqual(["dup-ok", "dup-null-sides"]);
   });
 
+  it("excludes candidates involving audio, cover, or other file kinds", async () => {
+    findManyMock.mockResolvedValue([
+      { id: "dup-ok", leftFileAsset: { mediaKind: "EPUB" }, rightFileAsset: { mediaKind: "PDF" }, leftEdition: null, rightEdition: null },
+      { id: "dup-audio-file", leftFileAsset: { mediaKind: "AUDIO" }, rightFileAsset: { mediaKind: "EPUB" }, leftEdition: null, rightEdition: null },
+      { id: "dup-other-file", leftFileAsset: { mediaKind: "OTHER" }, rightFileAsset: { mediaKind: "EPUB" }, leftEdition: null, rightEdition: null },
+      { id: "dup-cover-file", leftFileAsset: { mediaKind: "COVER" }, rightFileAsset: { mediaKind: "EPUB" }, leftEdition: null, rightEdition: null },
+      { id: "dup-left-edition-audio", leftFileAsset: null, rightFileAsset: null, leftEdition: { editionFiles: [{ fileAsset: { mediaKind: "AUDIO" } }], formatFamily: "AUDIOBOOK" }, rightEdition: { editionFiles: [], formatFamily: "EBOOK" } },
+      { id: "dup-right-edition-other", leftFileAsset: null, rightFileAsset: null, leftEdition: { editionFiles: [], formatFamily: "EBOOK" }, rightEdition: { editionFiles: [{ fileAsset: { mediaKind: "OTHER" } }], formatFamily: "EBOOK" } },
+    ]);
+    const result = await getDuplicatesServerFn({ data: {} });
+    expect(result.map((r: { id: string }) => r.id)).toEqual(["dup-ok"]);
+  });
+
   it("does not filter cross-format candidates (handled at detection time)", async () => {
     findManyMock.mockResolvedValue([
       { id: "dup-cross", leftFileAsset: null, rightFileAsset: null, leftEdition: { editionFiles: [], formatFamily: "EBOOK" }, rightEdition: { editionFiles: [], formatFamily: "AUDIOBOOK" } },

--- a/apps/web/src/lib/server-fns/duplicates.ts
+++ b/apps/web/src/lib/server-fns/duplicates.ts
@@ -11,6 +11,7 @@ export const getDuplicatesServerFn = createServerFn({
   .inputValidator(getDuplicatesSchema)
   .handler(async ({ data }) => {
     const { db } = await import("@bookhouse/db");
+    const EXCLUDED_MEDIA_KINDS = new Set(["SIDECAR", "AUDIO", "COVER", "OTHER"]);
     const rows = await db.duplicateCandidate.findMany({
       ...(data.status ? { where: { status: data.status } } : {}),
       include: {
@@ -34,12 +35,11 @@ export const getDuplicatesServerFn = createServerFn({
       orderBy: { confidence: "desc" },
     });
     return rows.filter((r) => {
-      // Exclude candidates involving sidecar files (direct or via edition files)
-      const leftIsSidecar = r.leftFileAsset?.mediaKind === "SIDECAR"
-        || r.leftEdition?.editionFiles.some((ef) => ef.fileAsset.mediaKind === "SIDECAR");
-      const rightIsSidecar = r.rightFileAsset?.mediaKind === "SIDECAR"
-        || r.rightEdition?.editionFiles.some((ef) => ef.fileAsset.mediaKind === "SIDECAR");
-      if (leftIsSidecar || rightIsSidecar) return false;
+      const leftHasExcludedMediaKind = (r.leftFileAsset?.mediaKind !== undefined && EXCLUDED_MEDIA_KINDS.has(r.leftFileAsset.mediaKind))
+        || r.leftEdition?.editionFiles.some((ef) => EXCLUDED_MEDIA_KINDS.has(ef.fileAsset.mediaKind));
+      const rightHasExcludedMediaKind = (r.rightFileAsset?.mediaKind !== undefined && EXCLUDED_MEDIA_KINDS.has(r.rightFileAsset.mediaKind))
+        || r.rightEdition?.editionFiles.some((ef) => EXCLUDED_MEDIA_KINDS.has(ef.fileAsset.mediaKind));
+      if (leftHasExcludedMediaKind || rightHasExcludedMediaKind) return false;
 
       return true;
     });

--- a/apps/web/src/lib/server-fns/library-health.ts
+++ b/apps/web/src/lib/server-fns/library-health.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
-import { IGNORED_BASENAMES } from "@bookhouse/ingest";
+
+const IGNORED_LIBRARY_FILE_BASENAMES = [".DS_Store", "Thumbs.db", "desktop.ini"] as const;
 
 export const getLibraryHealthServerFn = createServerFn({
   method: "GET",
@@ -32,7 +33,7 @@ export const getLibraryHealthServerFn = createServerFn({
         editionFiles: { none: {} },
         availabilityStatus: "PRESENT",
         mediaKind: { notIn: ["COVER", "SIDECAR"] },
-        basename: { notIn: Array.from(IGNORED_BASENAMES) },
+        basename: { notIn: [...IGNORED_LIBRARY_FILE_BASENAMES] },
       },
     }),
     db.matchSuggestion.count({ where: { reviewStatus: "PENDING" } }),
@@ -75,7 +76,7 @@ export const getOrphanedFilesServerFn = createServerFn({
       editionFiles: { none: {} },
       availabilityStatus: "PRESENT",
       mediaKind: { notIn: ["COVER", "SIDECAR"] },
-      basename: { notIn: Array.from(IGNORED_BASENAMES) },
+      basename: { notIn: [...IGNORED_LIBRARY_FILE_BASENAMES] },
     },
     select: {
       id: true,
@@ -106,4 +107,3 @@ export const deleteOrphanedFileServerFn = createServerFn({
     await db.fileAsset.delete({ where: { id: data.fileAssetId } });
     return { success: true };
   });
-

--- a/e2e/amazon-variants.spec.ts
+++ b/e2e/amazon-variants.spec.ts
@@ -1,0 +1,83 @@
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { test, expect } from "@playwright/test";
+import { db } from "@bookhouse/db";
+import { createIngestServices } from "../packages/ingest/src/index";
+import { cleanTestData, seedLibraryRoot } from "./helpers/seed";
+
+test.describe("Amazon ebook variants", () => {
+  let tempDirectory: string | null = null;
+
+  test.afterEach(async () => {
+    await cleanTestData();
+    if (tempDirectory !== null) {
+      await rm(tempDirectory, { force: true, recursive: true });
+      tempDirectory = null;
+    }
+  });
+
+  test("ingests MOBI and AZW as alternate files without duplicates or orphans", async ({ page }) => {
+    tempDirectory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-amazon-variants-"));
+    const bookDirectory = path.join(tempDirectory, "Patrick Rothfuss", "The Name of the Wind");
+    await mkdir(bookDirectory, { recursive: true });
+    await writeFile(path.join(bookDirectory, "book.mobi"), "mobi");
+    await writeFile(path.join(bookDirectory, "book.azw"), "azw");
+
+    const libraryRoot = await seedLibraryRoot({
+      name: "Amazon Variants Library",
+      path: tempDirectory,
+      kind: "EBOOKS",
+      scanMode: "FULL",
+    });
+
+    const services = createIngestServices({
+      enqueueLibraryJob: async () => undefined,
+    });
+
+    const scanResult = await services.scanLibraryRoot({ libraryRootId: libraryRoot.id });
+    for (const fileAssetId of scanResult.scannedFileAssetIds) {
+      await services.hashFileAsset({ fileAssetId });
+      await services.parseFileAssetMetadata({ fileAssetId });
+      await services.matchFileAssetToEdition({ fileAssetId });
+      await services.detectDuplicates({ fileAssetId });
+    }
+
+    const work = await db.work.findFirst({
+      where: { titleDisplay: "The Name of the Wind" },
+      include: {
+        editions: {
+          include: {
+            editionFiles: {
+              include: { fileAsset: true },
+            },
+          },
+        },
+      },
+    });
+
+    expect(work).not.toBeNull();
+    expect(work?.editions).toHaveLength(1);
+    expect(work?.editions[0]?.editionFiles).toHaveLength(2);
+
+    await page.goto(`/library/${work?.id}`);
+    await expect(page.getByText("book.mobi")).toBeVisible();
+    await expect(page.getByText("book.azw")).toBeVisible();
+
+    await page.goto("/duplicates");
+    await expect(page.getByText("No duplicates found")).toBeVisible();
+
+    await page.goto("/health");
+    await expect(page.getByText("No orphaned files")).toBeVisible();
+
+    const orphanedCount = await db.fileAsset.count({
+      where: {
+        editionFiles: { none: {} },
+        availabilityStatus: "PRESENT",
+        mediaKind: { notIn: ["COVER", "SIDECAR"] },
+        basename: { notIn: [".DS_Store", "Thumbs.db", "desktop.ini"] },
+      },
+    });
+    expect(orphanedCount).toBe(0);
+  });
+});

--- a/packages/db/prisma/migrations/20260402120000_add_amazon_ebook_media_kinds/migration.sql
+++ b/packages/db/prisma/migrations/20260402120000_add_amazon_ebook_media_kinds/migration.sql
@@ -1,0 +1,15 @@
+-- Add Amazon ebook media kinds.
+ALTER TYPE "MediaKind" ADD VALUE IF NOT EXISTS 'MOBI';
+ALTER TYPE "MediaKind" ADD VALUE IF NOT EXISTS 'AZW';
+ALTER TYPE "MediaKind" ADD VALUE IF NOT EXISTS 'AZW3';
+
+-- Reclassify existing file assets so they can be parsed and matched.
+UPDATE "FileAsset"
+SET "mediaKind" = CASE LOWER(COALESCE("extension", ''))
+  WHEN 'mobi' THEN 'MOBI'::"MediaKind"
+  WHEN 'azw' THEN 'AZW'::"MediaKind"
+  WHEN 'azw3' THEN 'AZW3'::"MediaKind"
+  ELSE "mediaKind"
+END
+WHERE "mediaKind" = 'OTHER'
+  AND LOWER(COALESCE("extension", '')) IN ('mobi', 'azw', 'azw3');

--- a/packages/db/prisma/migrations/20260402154000_add_kepub_media_kind/migration.sql
+++ b/packages/db/prisma/migrations/20260402154000_add_kepub_media_kind/migration.sql
@@ -1,0 +1,6 @@
+ALTER TYPE "MediaKind" ADD VALUE IF NOT EXISTS 'KEPUB';
+
+UPDATE "FileAsset"
+SET "mediaKind" = 'KEPUB'
+WHERE "extension" = 'kepub'
+  AND "mediaKind" = 'EPUB';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -19,6 +19,10 @@ enum ScanMode {
 
 enum MediaKind {
   EPUB
+  KEPUB
+  MOBI
+  AZW
+  AZW3
   PDF
   CBZ
   AUDIO

--- a/packages/domain/src/index.test.ts
+++ b/packages/domain/src/index.test.ts
@@ -22,6 +22,10 @@ describe("domain package", () => {
     expect(LibraryRootKind.MIXED).toBe("MIXED");
     expect(ScanMode.INCREMENTAL).toBe("INCREMENTAL");
     expect(MediaKind.EPUB).toBe("EPUB");
+    expect(MediaKind.KEPUB).toBe("KEPUB");
+    expect("MOBI" in MediaKind).toBe(true);
+    expect("AZW" in MediaKind).toBe(true);
+    expect("AZW3" in MediaKind).toBe(true);
     expect(AvailabilityStatus.MISSING).toBe("MISSING");
     expect(FormatFamily.EBOOK).toBe("EBOOK");
     expect(EditionFileRole.PRIMARY).toBe("PRIMARY");

--- a/packages/ingest/src/classification.test.ts
+++ b/packages/ingest/src/classification.test.ts
@@ -34,8 +34,12 @@ describe("classification helpers", () => {
 
   it("derives format family from media kind", () => {
     expect(deriveFormatFamily(MediaKind.EPUB)).toBe(FormatFamily.EBOOK);
+    expect(deriveFormatFamily(MediaKind.KEPUB)).toBe(FormatFamily.EBOOK);
     expect(deriveFormatFamily(MediaKind.PDF)).toBe(FormatFamily.EBOOK);
     expect(deriveFormatFamily(MediaKind.CBZ)).toBe(FormatFamily.EBOOK);
+    expect(deriveFormatFamily("MOBI" as MediaKind)).toBe(FormatFamily.EBOOK);
+    expect(deriveFormatFamily("AZW" as MediaKind)).toBe(FormatFamily.EBOOK);
+    expect(deriveFormatFamily("AZW3" as MediaKind)).toBe(FormatFamily.EBOOK);
     expect(deriveFormatFamily(MediaKind.AUDIO)).toBe(FormatFamily.AUDIOBOOK);
     expect(deriveFormatFamily(MediaKind.COVER)).toBeNull();
     expect(deriveFormatFamily(MediaKind.SIDECAR)).toBeNull();
@@ -61,15 +65,25 @@ describe("classification helpers", () => {
 
   it("classifies supported media kinds", () => {
     expect(classifyMediaKind("book.epub")).toBe(MediaKind.EPUB);
-    expect(classifyMediaKind("book.kepub")).toBe(MediaKind.EPUB);
-    expect(classifyMediaKind("book.mobi")).toBe(MediaKind.OTHER);
-    expect(classifyMediaKind("book.azw")).toBe(MediaKind.OTHER);
-    expect(classifyMediaKind("book.azw3")).toBe(MediaKind.OTHER);
+    expect(classifyMediaKind("book.kepub")).toBe(MediaKind.KEPUB);
+    expect(classifyMediaKind("book.mobi")).toBe("MOBI");
+    expect(classifyMediaKind("book.azw")).toBe("AZW");
+    expect(classifyMediaKind("book.azw3")).toBe("AZW3");
     expect(classifyMediaKind("book.pdf")).toBe(MediaKind.PDF);
     expect(classifyMediaKind("book.cbz")).toBe(MediaKind.CBZ);
     expect(classifyMediaKind("track.m4b")).toBe(MediaKind.AUDIO);
     expect(classifyMediaKind("cover.jpg")).toBe(MediaKind.COVER);
     expect(classifyMediaKind("metadata.xml")).toBe(MediaKind.SIDECAR);
     expect(classifyMediaKind("archive.bin")).toBe(MediaKind.OTHER);
+  });
+
+  it("classifies known library companion and junk files as sidecars, not books", () => {
+    expect(classifyMediaKind("metadata.db")).toBe(MediaKind.SIDECAR);
+    expect(classifyMediaKind("metadata.db-shm")).toBe(MediaKind.SIDECAR);
+    expect(classifyMediaKind("metadata.db-wal")).toBe(MediaKind.SIDECAR);
+    expect(classifyMediaKind("checksums.sfv")).toBe(MediaKind.SIDECAR);
+    expect(classifyMediaKind("private.key")).toBe(MediaKind.SIDECAR);
+    expect(classifyMediaKind("certificate.pem")).toBe(MediaKind.SIDECAR);
+    expect(classifyMediaKind("kindle.mbp")).toBe(MediaKind.SIDECAR);
   });
 });

--- a/packages/ingest/src/classification.ts
+++ b/packages/ingest/src/classification.ts
@@ -20,7 +20,8 @@ const AUDIO_EXTENSIONS = new Set([
 ]);
 
 const COVER_EXTENSIONS = new Set(["jpeg", "jpg", "png", "webp"]);
-const SIDECAR_EXTENSIONS = new Set(["cue", "json", "nfo", "opf", "txt", "xml"]);
+const SIDECAR_EXTENSIONS = new Set(["cue", "db", "json", "key", "mbp", "nfo", "opf", "pem", "sfv", "txt", "xml"]);
+const SIDECAR_BASENAME_SUFFIXES = [".db-shm", ".db-wal"] as const;
 
 export function normalizeRootPath(rootPath: string): string {
   return path.resolve(rootPath);
@@ -50,18 +51,34 @@ export function getFileExtension(filePath: string): string | null {
 }
 
 export function deriveFormatFamily(mediaKind: MediaKind): FormatFamily | null {
-  if (mediaKind === MediaKind.EPUB || mediaKind === MediaKind.PDF || mediaKind === MediaKind.CBZ) return FormatFamily.EBOOK;
+  if (
+    mediaKind === MediaKind.EPUB ||
+    mediaKind === MediaKind.KEPUB ||
+    mediaKind === MediaKind.MOBI ||
+    mediaKind === MediaKind.AZW ||
+    mediaKind === MediaKind.AZW3 ||
+    mediaKind === MediaKind.PDF ||
+    mediaKind === MediaKind.CBZ
+  ) return FormatFamily.EBOOK;
   if (mediaKind === MediaKind.AUDIO) return FormatFamily.AUDIOBOOK;
   return null;
 }
 
 export function classifyMediaKind(filePath: string): MediaKind {
   const extension = getFileExtension(filePath);
+  const basename = path.basename(filePath).toLowerCase();
 
   switch (extension) {
     case "epub":
-    case "kepub":
       return MediaKind.EPUB;
+    case "kepub":
+      return MediaKind.KEPUB;
+    case "mobi":
+      return MediaKind.MOBI;
+    case "azw":
+      return MediaKind.AZW;
+    case "azw3":
+      return MediaKind.AZW3;
     case "pdf":
       return MediaKind.PDF;
     case "cbz":
@@ -78,7 +95,10 @@ export function classifyMediaKind(filePath: string): MediaKind {
     return MediaKind.COVER;
   }
 
-  if (extension !== null && SIDECAR_EXTENSIONS.has(extension)) {
+  if (
+    (extension !== null && SIDECAR_EXTENSIONS.has(extension)) ||
+    SIDECAR_BASENAME_SUFFIXES.some((suffix) => basename.endsWith(suffix))
+  ) {
     return MediaKind.SIDECAR;
   }
 

--- a/packages/ingest/src/covers.test.ts
+++ b/packages/ingest/src/covers.test.ts
@@ -258,6 +258,32 @@ describe("processCoverForWork", () => {
     expect(result.updated).toBe(true);
   });
 
+  it("uses adjacent cover for KEPUB instead of EPUB cover extraction", async () => {
+    const deps = createMockDeps({
+      db: {
+        fileAsset: {
+          findUnique: vi.fn().mockResolvedValue({
+            id: "fa-1",
+            absolutePath: "/books/author/title/book.kepub",
+            mediaKind: MediaKind.KEPUB,
+          }),
+        },
+        work: {
+          findUnique: vi.fn().mockResolvedValue({ id: "w-1" }),
+          update: vi.fn().mockResolvedValue({}),
+        },
+      },
+      detectAdjacentCover: vi.fn().mockResolvedValue("/books/author/title/cover.jpg"),
+    });
+
+    const result = await processCoverForWork(createInput(), deps);
+
+    expect(deps.extractEpubCover).not.toHaveBeenCalled();
+    expect(deps.detectAdjacentCover).toHaveBeenCalled();
+    expect(result.source).toBe("adjacent");
+    expect(result.updated).toBe(true);
+  });
+
   it("returns updated=false when no cover found", async () => {
     const workUpdate = vi.fn().mockResolvedValue({});
     const deps = createMockDeps({

--- a/packages/ingest/src/index.test.ts
+++ b/packages/ingest/src/index.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest";
+import * as ingest from "./index";
+
+describe("ingest package barrel", () => {
+  it("re-exports the primary runtime entry points", () => {
+    expect(ingest.classifyMediaKind("/books/Book.kepub")).toBe("KEPUB");
+    expect(ingest.deriveFormatFamily("EPUB")).toBe("EBOOK");
+    expect(typeof ingest.createIngestServices).toBe("function");
+    expect(typeof ingest.extractEpubCover).toBe("function");
+    expect(typeof ingest.processCoverForWork).toBe("function");
+    expect(typeof ingest.hashFileContents).toBe("function");
+    expect(typeof ingest.searchOpenLibrary).toBe("function");
+    expect(typeof ingest.enrichContributor).toBe("function");
+    expect(typeof ingest.cascadeCleanupOrphans).toBe("function");
+    expect(ingest.SCAN_PROGRESS_INTERVAL).toBeGreaterThan(0);
+    expect(ingest.PARTIAL_HASH_BYTES).toBeGreaterThan(0);
+    expect(ingest.VALID_WORK_ID.test("work-1")).toBe(true);
+  });
+});

--- a/packages/ingest/src/services.runtime.test.ts
+++ b/packages/ingest/src/services.runtime.test.ts
@@ -21,6 +21,8 @@ const fileAssetUpsertMock = vi.fn(() => Promise.resolve({
 }));
 const editionFindManyMock = vi.fn(() => Promise.resolve([]));
 const editionFileFindManyMock = vi.fn(() => Promise.resolve([]));
+const editionCreateMock = vi.fn(({ data }) => Promise.resolve({ id: "edition-1", ...data }));
+const editionFileCreateMock = vi.fn(({ data }) => Promise.resolve({ id: "edition-file-1", ...data }));
 const editionUpdateMock = vi.fn(() => Promise.reject(new Error("not used")));
 let runtimeLibraryRoot: RuntimeLibraryRoot = {
   id: "root-1",
@@ -31,6 +33,7 @@ let runtimeLibraryRoot: RuntimeLibraryRoot = {
 const libraryRootFindUniqueMock = vi.fn(() => Promise.resolve(runtimeLibraryRoot));
 const workUpdateMock = vi.fn(() => Promise.reject(new Error("not used")));
 const workFindManyMock = vi.fn(() => Promise.resolve([]));
+const workCreateMock = vi.fn(({ data }) => Promise.resolve({ id: "work-1", ...data }));
 const seriesCreateMock = vi.fn(() => Promise.resolve({ id: "series-1", name: "test" }));
 
 vi.mock("@bookhouse/db", () => ({
@@ -59,7 +62,7 @@ vi.mock("@bookhouse/db", () => ({
       findMany: vi.fn(() => Promise.resolve([])),
     },
     edition: {
-      create: vi.fn(() => Promise.reject(new Error("not used"))),
+      create: editionCreateMock,
       findMany: editionFindManyMock,
       findFirst: vi.fn(() => Promise.resolve(null)),
       findUnique: vi.fn(() => Promise.resolve(null)),
@@ -70,12 +73,12 @@ vi.mock("@bookhouse/db", () => ({
       findFirst: vi.fn(() => Promise.resolve(null)),
     },
     editionFile: {
-      create: vi.fn(() => Promise.reject(new Error("not used"))),
+      create: editionFileCreateMock,
       findMany: editionFileFindManyMock,
       findFirst: vi.fn(() => Promise.resolve(null)),
     },
     work: {
-      create: vi.fn(() => Promise.reject(new Error("not used"))),
+      create: workCreateMock,
       findMany: workFindManyMock,
       findUnique: vi.fn(() => Promise.resolve(null)),
       update: workUpdateMock,
@@ -96,6 +99,7 @@ vi.mock("@bookhouse/domain", () => ({
     AUTHOR: "AUTHOR",
   },
   EditionFileRole: {
+    ALTERNATE_FORMAT: "ALTERNATE_FORMAT",
     PRIMARY: "PRIMARY",
   },
   FormatFamily: {
@@ -103,9 +107,12 @@ vi.mock("@bookhouse/domain", () => ({
   },
   MediaKind: {
     AUDIO: "AUDIO",
+    AZW: "AZW",
+    AZW3: "AZW3",
     CBZ: "CBZ",
     COVER: "COVER",
     EPUB: "EPUB",
+    MOBI: "MOBI",
     OTHER: "OTHER",
     PDF: "PDF",
     SIDECAR: "SIDECAR",
@@ -137,6 +144,8 @@ beforeEach(() => {
   editionFileFindManyMock.mockResolvedValue([]);
   editionFindManyMock.mockReset();
   editionFindManyMock.mockResolvedValue([]);
+  editionCreateMock.mockClear();
+  editionFileCreateMock.mockClear();
   fileAssetFindManyMock.mockReset();
   fileAssetFindManyMock.mockResolvedValue([]);
   fileAssetUpdateManyMock.mockReset();
@@ -153,6 +162,7 @@ beforeEach(() => {
   });
   libraryRootFindUniqueMock.mockReset();
   libraryRootFindUniqueMock.mockImplementation(() => Promise.resolve(runtimeLibraryRoot));
+  workCreateMock.mockClear();
   workFindManyMock.mockReset();
   workFindManyMock.mockResolvedValue([]);
 });

--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -660,6 +660,7 @@ describe("ingest services", () => {
       metadata: null,
       mtime: new Date("2024-01-01T00:00:00.000Z"),
       partialHash: "partial",
+      relativePath: "book.epub",
       sizeBytes: 10n,
     };
 
@@ -1641,6 +1642,58 @@ describe("ingest services", () => {
 
     expect(result.createdStubWorkIds).toHaveLength(0);
     expect(state.works.size).toBe(0);
+  });
+
+  it("creates one stub edition for ebook variants discovered in the same scan", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-ebook-variant-scan-"));
+    tempDirectories.push(directory);
+
+    await mkdir(path.join(directory, "Patrick Rothfuss", "The Name of the Wind"), { recursive: true });
+    await writeFile(path.join(directory, "Patrick Rothfuss", "The Name of the Wind", "The Name of the Wind.epub"), "epub");
+    await writeFile(path.join(directory, "Patrick Rothfuss", "The Name of the Wind", "The Name of the Wind.kepub"), "kepub");
+
+    const state = createEmptyState(directory);
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+    });
+
+    expect(result.createdStubWorkIds).toHaveLength(1);
+    expect(state.works.size).toBe(1);
+    expect(state.editions.size).toBe(1);
+    expect([...state.editionFiles.values()]).toHaveLength(2);
+    expect([...state.editionFiles.values()].map((editionFile) => editionFile.role)).toEqual([
+      EditionFileRole.PRIMARY,
+      EditionFileRole.ALTERNATE_FORMAT,
+    ]);
+  });
+
+  it("collapses punctuation-only ebook variant titles discovered in the same scan", async () => {
+    const directory = await mkdtemp(path.join(os.tmpdir(), "bookhouse-ebook-variant-punctuation-"));
+    tempDirectories.push(directory);
+
+    await mkdir(path.join(directory, "Author", "!!!"), { recursive: true });
+    await writeFile(path.join(directory, "Author", "!!!", "!!!.epub"), "epub");
+    await writeFile(path.join(directory, "Author", "!!!", "!!!.kepub"), "kepub");
+
+    const state = createEmptyState(directory);
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.scanLibraryRoot({
+      libraryRootId: "root-1",
+    });
+
+    expect(result.createdStubWorkIds).toHaveLength(1);
+    expect(state.works.size).toBe(1);
+    expect(state.editions.size).toBe(1);
+    expect([...state.editionFiles.values()]).toHaveLength(2);
   });
 
   it("skips stubs for files that already have an edition file link", async () => {
@@ -2859,6 +2912,50 @@ describe("ingest services", () => {
     );
   });
 
+  it("enqueues metadata parsing after hashing Amazon ebook variants", async () => {
+    const state = createEmptyState("/tmp/root");
+    const existing: TestFileAsset = {
+      absolutePath: "/tmp/root/Author/Title/book.mobi",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.mobi",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "mobi",
+      fullHash: null,
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.MOBI,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: null,
+      relativePath: "Author/Title/book.mobi",
+      sizeBytes: 4n,
+    };
+    state.fileAssets.set(existing.absolutePath, existing);
+    state.fileAssetsById.set(existing.id, existing);
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+      hashFile: vi.fn(async () => {
+        await Promise.resolve();
+        return {
+          fullHash: "next-full",
+          mtime: new Date("2025-01-01T00:00:00.000Z"),
+          partialHash: "next-partial",
+          sizeBytes: 12n,
+        };
+      }),
+    });
+
+    await services.hashFileAsset({ fileAssetId: "file-1" });
+
+    expect(enqueueLibraryJob).toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.PARSE_FILE_ASSET_METADATA,
+      { fileAssetId: "file-1" },
+    );
+  });
+
   it("detects moved file by fullHash and transfers edition links from MISSING asset", async () => {
     const state = createEmptyState("/tmp/root");
 
@@ -3342,6 +3439,152 @@ describe("ingest services", () => {
     });
   });
 
+  it("parses KEPUB and Amazon ebook variants from path-derived metadata without calling EPUB parser", async () => {
+    const state = createEmptyState("/tmp/root");
+    const existing: TestFileAsset = {
+      absolutePath: "/tmp/root/Patrick Rothfuss/The Name of the Wind/book.azw",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.azw",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "azw",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.AZW,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "partial",
+      relativePath: "Patrick Rothfuss/The Name of the Wind/book.azw",
+      sizeBytes: 4n,
+    };
+    state.fileAssets.set(existing.absolutePath, existing);
+    state.fileAssetsById.set(existing.id, existing);
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const parseEpub = vi.fn();
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+      parseEpub,
+    });
+
+    const result = await services.parseFileAssetMetadata({ fileAssetId: "file-1" });
+
+    expect(result).toMatchObject({
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      fileAssetId: "file-1",
+      skipped: false,
+    });
+    expect(parseEpub).not.toHaveBeenCalled();
+    expect(state.fileAssetsById.get("file-1")?.metadata).toMatchObject({
+      source: "filename",
+      status: "parsed",
+      normalized: {
+        authors: ["Patrick Rothfuss"],
+        title: "The Name of the Wind",
+      },
+    });
+    expect(enqueueLibraryJob).toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
+      { fileAssetId: "file-1" },
+    );
+  });
+
+  it("parses KEPUB metadata from path-derived metadata without calling EPUB parser", async () => {
+    const state = createEmptyState("/tmp/root");
+    const existing: TestFileAsset = {
+      absolutePath: "/tmp/root/Patrick Rothfuss/The Name of the Wind/book.kepub",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.kepub",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "kepub",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.KEPUB,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "partial",
+      relativePath: "Patrick Rothfuss/The Name of the Wind/book.kepub",
+      sizeBytes: 4n,
+    };
+    state.fileAssets.set(existing.absolutePath, existing);
+    state.fileAssetsById.set(existing.id, existing);
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const parseEpub = vi.fn();
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+      parseEpub,
+    });
+
+    const result = await services.parseFileAssetMetadata({ fileAssetId: "file-1" });
+
+    expect(result).toMatchObject({
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      fileAssetId: "file-1",
+      skipped: false,
+    });
+    expect(parseEpub).not.toHaveBeenCalled();
+    expect(state.fileAssetsById.get("file-1")?.metadata).toMatchObject({
+      source: "filename",
+      status: "parsed",
+      normalized: {
+        authors: ["Patrick Rothfuss"],
+        title: "The Name of the Wind",
+      },
+    });
+  });
+
+  it("parses Amazon ebook variants from a flat path without inferring an author", async () => {
+    const state = createEmptyState("/tmp/root");
+    const existing: TestFileAsset = {
+      absolutePath: "/tmp/root/book.mobi",
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      basename: "book.mobi",
+      ctime: new Date("2024-01-01T00:00:00.000Z"),
+      extension: "mobi",
+      fullHash: "full",
+      id: "file-1",
+      lastSeenAt: null,
+      libraryRootId: "root-1",
+      mediaKind: MediaKind.MOBI,
+      metadata: null,
+      mtime: new Date("2024-01-01T00:00:00.000Z"),
+      partialHash: "partial",
+      relativePath: "book.mobi",
+      sizeBytes: 4n,
+    };
+    state.fileAssets.set(existing.absolutePath, existing);
+    state.fileAssetsById.set(existing.id, existing);
+    const enqueueLibraryJob = vi.fn(() => Promise.resolve(undefined));
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob,
+    });
+
+    const result = await services.parseFileAssetMetadata({ fileAssetId: "file-1" });
+
+    expect(result).toMatchObject({
+      availabilityStatus: AvailabilityStatus.PRESENT,
+      fileAssetId: "file-1",
+      skipped: false,
+    });
+    expect(state.fileAssetsById.get("file-1")?.metadata).toMatchObject({
+      source: "filename",
+      status: "parsed",
+      normalized: {
+        authors: [],
+        title: "book",
+      },
+    });
+    expect(enqueueLibraryJob).toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION,
+      { fileAssetId: "file-1" },
+    );
+  });
+
   it("uses a fallback warning for non-Error EPUB parse failures", async () => {
     const state = createEmptyState("/tmp/root");
     const existing: TestFileAsset = {
@@ -3660,6 +3903,265 @@ describe("ingest services", () => {
     });
     expect([...state.contributors.values()]).toHaveLength(1);
     expect([...state.editionContributors.values()]).toHaveLength(2);
+  });
+
+  it("links Amazon ebook variants to an existing ebook edition as alternate formats", async () => {
+    const state = createEmptyState("/tmp/root");
+    addFileAsset(state, {
+      absolutePath: "/tmp/root/Patrick Rothfuss/The Name of the Wind/book.azw",
+      basename: "book.azw",
+      extension: "azw",
+      mediaKind: MediaKind.AZW,
+      relativePath: "Patrick Rothfuss/The Name of the Wind/book.azw",
+      metadata: {
+        normalized: {
+          authors: ["Patrick Rothfuss"],
+          identifiers: { unknown: [] },
+          title: "The Name of the Wind",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "filename",
+        status: "parsed",
+        warnings: [],
+      } as FileAsset["metadata"],
+    });
+    addWork(state, {
+      titleCanonical: canonicalizeBookTitle("The Name of the Wind") ?? "the name of the wind",
+      titleDisplay: "The Name of the Wind",
+    });
+    addEdition(state);
+    addContributor(state, {
+      nameCanonical: canonicalizeContributorNames(["Patrick Rothfuss"])[0] ?? "patrick rothfuss",
+      nameDisplay: "Patrick Rothfuss",
+    });
+    addEditionContributor(state);
+    addFileAsset(state, {
+      id: "file-2",
+      absolutePath: "/tmp/root/Patrick Rothfuss/The Name of the Wind/book.mobi",
+      basename: "book.mobi",
+      extension: "mobi",
+      mediaKind: MediaKind.MOBI,
+      relativePath: "Patrick Rothfuss/The Name of the Wind/book.mobi",
+    });
+    addEditionFile(state, {
+      editionId: "edition-1",
+      fileAssetId: "file-2",
+      id: "edition-file-2",
+      role: EditionFileRole.PRIMARY,
+    });
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.matchFileAssetToEdition({ fileAssetId: "file-1" });
+
+    expect(result).toMatchObject({
+      createdEdition: false,
+      createdEditionFile: true,
+      editionId: "edition-1",
+      workId: "work-1",
+      skipped: false,
+    });
+    expect(state.editions.size).toBe(1);
+    expect([...state.editionFiles.values()]).toHaveLength(2);
+    expect(
+      [...state.editionFiles.values()].find((editionFile) => editionFile.fileAssetId === "file-1")?.role,
+    ).toBe(EditionFileRole.ALTERNATE_FORMAT);
+  });
+
+  it("creates a new ebook edition when an Amazon variant matches a work with only an audiobook edition", async () => {
+    const state = createEmptyState("/tmp/root");
+    addFileAsset(state, {
+      absolutePath: "/tmp/root/Andy Weir/Project Hail Mary/book.azw3",
+      basename: "book.azw3",
+      extension: "azw3",
+      mediaKind: MediaKind.AZW3,
+      relativePath: "Andy Weir/Project Hail Mary/book.azw3",
+      metadata: {
+        normalized: {
+          authors: ["Andy Weir"],
+          identifiers: { unknown: [] },
+          title: "Project Hail Mary",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "filename",
+        status: "parsed",
+        warnings: [],
+      } as FileAsset["metadata"],
+    });
+    addWork(state, {
+      titleCanonical: canonicalizeBookTitle("Project Hail Mary") ?? "project hail mary",
+      titleDisplay: "Project Hail Mary",
+    });
+    addEdition(state, {
+      formatFamily: FormatFamily.AUDIOBOOK,
+    });
+    addContributor(state, {
+      nameCanonical: canonicalizeContributorNames(["Andy Weir"])[0] ?? "andy weir",
+      nameDisplay: "Andy Weir",
+    });
+    addEditionContributor(state);
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.matchFileAssetToEdition({ fileAssetId: "file-1" });
+
+    expect(result).toMatchObject({
+      createdEdition: true,
+      createdEditionFile: true,
+      createdWork: false,
+      workId: "work-1",
+      skipped: false,
+    });
+    expect([...state.editions.values()]).toHaveLength(2);
+    expect(
+      [...state.editions.values()].find((edition) => edition.id === result.editionId)?.formatFamily,
+    ).toBe(FormatFamily.EBOOK);
+    expect(
+      [...state.editionFiles.values()].find((editionFile) => editionFile.fileAssetId === "file-1")?.role,
+    ).toBe(EditionFileRole.PRIMARY);
+  });
+
+  it("links audio files to an existing edition as audio tracks", async () => {
+    const state = createEmptyState("/tmp/root");
+    addFileAsset(state, {
+      absolutePath: "/tmp/root/Andy Weir/Project Hail Mary/chapter-01.mp3",
+      basename: "chapter-01.mp3",
+      extension: "mp3",
+      mediaKind: MediaKind.AUDIO,
+      relativePath: "Andy Weir/Project Hail Mary/chapter-01.mp3",
+      metadata: {
+        normalized: {
+          authors: ["Andy Weir"],
+          identifiers: { isbn13: "9780593135204", unknown: [] },
+          title: "Project Hail Mary",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "audiobook-json",
+        status: "parsed",
+        warnings: [],
+      } as FileAsset["metadata"],
+    });
+    addWork(state, {
+      titleCanonical: canonicalizeBookTitle("Project Hail Mary") ?? "project hail mary",
+      titleDisplay: "Project Hail Mary",
+    });
+    addEdition(state, {
+      formatFamily: FormatFamily.AUDIOBOOK,
+      isbn13: "9780593135204",
+    });
+    addContributor(state, {
+      nameCanonical: canonicalizeContributorNames(["Andy Weir"])[0] ?? "andy weir",
+      nameDisplay: "Andy Weir",
+    });
+    addEditionContributor(state);
+    addFileAsset(state, {
+      id: "file-2",
+      absolutePath: "/tmp/root/Andy Weir/Project Hail Mary/metadata.json",
+      basename: "metadata.json",
+      extension: "json",
+      mediaKind: MediaKind.SIDECAR,
+      relativePath: "Andy Weir/Project Hail Mary/metadata.json",
+    });
+    addEditionFile(state, {
+      editionId: "edition-1",
+      fileAssetId: "file-2",
+      id: "edition-file-2",
+      role: EditionFileRole.PRIMARY,
+    });
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.matchFileAssetToEdition({ fileAssetId: "file-1" });
+
+    expect(result).toMatchObject({
+      createdEdition: false,
+      createdEditionFile: true,
+      editionId: "edition-1",
+      workId: "work-1",
+      skipped: false,
+    });
+    expect(
+      [...state.editionFiles.values()].find((editionFile) => editionFile.fileAssetId === "file-1")?.role,
+    ).toBe(EditionFileRole.AUDIO_TRACK);
+  });
+
+  it("keeps non-Amazon ebook matches as primary files on existing editions", async () => {
+    const state = createEmptyState("/tmp/root");
+    addFileAsset(state, {
+      absolutePath: "/tmp/root/N. K. Jemisin/The Fifth Season/alternate.epub",
+      basename: "alternate.epub",
+      extension: "epub",
+      mediaKind: MediaKind.EPUB,
+      relativePath: "N. K. Jemisin/The Fifth Season/alternate.epub",
+      metadata: {
+        normalized: {
+          authors: ["N. K. Jemisin"],
+          identifiers: { isbn13: "9780316229292", unknown: [] },
+          title: "The Fifth Season",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "epub",
+        status: "parsed",
+        warnings: [],
+      } as FileAsset["metadata"],
+    });
+    addWork(state, {
+      titleCanonical: canonicalizeBookTitle("The Fifth Season") ?? "the fifth season",
+      titleDisplay: "The Fifth Season",
+    });
+    addEdition(state, {
+      isbn13: "9780316229292",
+    });
+    addContributor(state, {
+      nameCanonical: canonicalizeContributorNames(["N. K. Jemisin"])[0] ?? "n k jemisin",
+      nameDisplay: "N. K. Jemisin",
+    });
+    addEditionContributor(state);
+    addFileAsset(state, {
+      id: "file-2",
+      absolutePath: "/tmp/root/N. K. Jemisin/The Fifth Season/original.epub",
+      basename: "original.epub",
+      extension: "epub",
+      mediaKind: MediaKind.EPUB,
+      relativePath: "N. K. Jemisin/The Fifth Season/original.epub",
+    });
+    addEditionFile(state, {
+      editionId: "edition-1",
+      fileAssetId: "file-2",
+      id: "edition-file-2",
+      role: EditionFileRole.PRIMARY,
+    });
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+    });
+
+    const result = await services.matchFileAssetToEdition({ fileAssetId: "file-1" });
+
+    expect(result).toMatchObject({
+      createdEdition: false,
+      createdEditionFile: true,
+      editionId: "edition-1",
+      workId: "work-1",
+      skipped: false,
+    });
+    expect(
+      [...state.editionFiles.values()].find((editionFile) => editionFile.fileAssetId === "file-1")?.role,
+    ).toBe(EditionFileRole.PRIMARY);
   });
 
   it("creates a new work, edition, contributors, and file link when no match exists", async () => {
@@ -8827,6 +9329,48 @@ describe("matchFileAssetToEdition enqueues follow-up jobs", () => {
       expect.anything(),
     );
   });
+
+  it("does not enqueue DETECT_DUPLICATES for an AUDIO file asset, but still enqueues MATCH_SUGGESTIONS", async () => {
+    const state = createEmptyState("/tmp/root");
+    addFileAsset(state, {
+      id: "file-audio",
+      absolutePath: "/tmp/root/Author/Book/chapter01.mp3",
+      basename: "chapter01.mp3",
+      extension: "mp3",
+      mediaKind: MediaKind.AUDIO,
+      relativePath: "Author/Book/chapter01.mp3",
+      metadata: {
+        normalized: {
+          authors: ["Andy Weir"],
+          identifiers: { unknown: [] },
+          title: "Project Hail Mary",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "audio-id3",
+        status: "parsed",
+        warnings: [],
+      } as object as FileAsset["metadata"],
+    });
+    const enqueueMock = vi.fn(() => Promise.resolve(undefined));
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: enqueueMock,
+    });
+
+    const result = await services.matchFileAssetToEdition({ fileAssetId: "file-audio" });
+
+    expect(result.skipped).toBe(false);
+    expect(result.mediaKind).toBe("AUDIO");
+    expect(enqueueMock).not.toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.DETECT_DUPLICATES,
+      expect.anything(),
+    );
+    expect(enqueueMock).toHaveBeenCalledWith(
+      LIBRARY_JOB_NAMES.MATCH_SUGGESTIONS,
+      { fileAssetId: "file-audio" },
+    );
+  });
 });
 
 describe("detectDuplicates", () => {
@@ -8942,6 +9486,22 @@ describe("detectDuplicates", () => {
     const result = await services.detectDuplicates({ fileAssetId: "file-1" });
 
     expect(result).toEqual({ fileAssetId: "file-1", skipped: true, candidatesCreated: 0 });
+  });
+
+  it("skips when file asset media kind is not eligible for duplicate detection", async () => {
+    const state = createEmptyState();
+    addDetectFileAsset(state, "file-1", "abc123", "/tmp/root/book.mp3", {
+      mediaKind: MediaKind.AUDIO,
+    });
+    addDetectWork(state, "work-1", "book title", "Book Title");
+    addDetectEdition(state, "edition-1", "work-1");
+    addDetectEditionFile(state, "ef-1", "edition-1", "file-1");
+    const services = createIngestServices({ db: createTestDb(state) });
+
+    const result = await services.detectDuplicates({ fileAssetId: "file-1" });
+
+    expect(result).toEqual({ fileAssetId: "file-1", skipped: true, candidatesCreated: 0 });
+    expect(state.duplicateCandidates.size).toBe(0);
   });
 
   it("SAME_HASH: creates candidate when another file asset has the same hash", async () => {
@@ -9282,6 +9842,22 @@ describe("detectDuplicates", () => {
     const result = await services.detectDuplicates({ fileAssetId: "file-1" });
 
     expect(result.candidatesCreated).toBe(0);
+  });
+
+  it("does not create SAME_HASH duplicate candidates for Amazon variants already linked to the same edition", async () => {
+    const state = createEmptyState();
+    addDetectFileAsset(state, "file-1", "samehash", "/tmp/root/book.mobi", { mediaKind: MediaKind.MOBI, extension: "mobi" });
+    addDetectFileAsset(state, "file-2", "samehash", "/tmp/root/book.azw", { mediaKind: MediaKind.AZW, extension: "azw" });
+    addDetectWork(state, "work-1", "book title", "Book Title");
+    addDetectEdition(state, "edition-1", "work-1");
+    addDetectEditionFile(state, "ef-1", "edition-1", "file-1");
+    addDetectEditionFile(state, "ef-2", "edition-1", "file-2");
+    const services = createIngestServices({ db: createTestDb(state) });
+
+    const result = await services.detectDuplicates({ fileAssetId: "file-1" });
+
+    expect(result.candidatesCreated).toBe(0);
+    expect(state.duplicateCandidates.size).toBe(0);
   });
 
   it("returns correct total count across multiple strategies", async () => {

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -53,7 +53,7 @@ export interface ParsedFileAssetMetadata {
   parsedAt: string;
   parserVersion: number;
   raw?: ParsedEpubMetadataRaw | ParsedOpfMetadataRaw | ParsedAudiobookMetadataJsonRaw | ParsedAudioId3TagsRaw;
-  source: "epub" | "opf-sidecar" | "audiobook-json" | "audio-id3";
+  source: "epub" | "opf-sidecar" | "audiobook-json" | "audio-id3" | "filename";
   status: "parsed" | "unparseable";
   warnings: string[];
 }
@@ -69,6 +69,7 @@ type FileAssetRecord = Pick<
   | "mtime"
   | "metadata"
   | "partialHash"
+  | "relativePath"
   | "sizeBytes"
 >;
 
@@ -577,13 +578,71 @@ function parseStoredMetadata(metadata: FileAsset["metadata"]): ParsedFileAssetMe
   const status = candidate["status"];
 
   if (
-    (source !== "epub" && source !== "opf-sidecar" && source !== "audiobook-json" && source !== "audio-id3") ||
+    (source !== "epub" && source !== "opf-sidecar" && source !== "audiobook-json" && source !== "audio-id3" && source !== "filename") ||
     (status !== "parsed" && status !== "unparseable")
   ) {
     return undefined;
   }
 
   return candidate as object as ParsedFileAssetMetadata;
+}
+
+const EBOOK_VARIANT_MEDIA_KINDS = new Set<MediaKind>([
+  MediaKind.KEPUB,
+  MediaKind.MOBI,
+  MediaKind.AZW,
+  MediaKind.AZW3,
+]);
+
+function isEbookVariant(mediaKind: MediaKind): boolean {
+  return EBOOK_VARIANT_MEDIA_KINDS.has(mediaKind);
+}
+
+const PATH_DERIVED_EBOOK_MEDIA_KINDS = new Set<MediaKind>([
+  MediaKind.KEPUB,
+  MediaKind.MOBI,
+  MediaKind.AZW,
+  MediaKind.AZW3,
+]);
+
+function usesPathDerivedEbookMetadata(mediaKind: MediaKind): boolean {
+  return PATH_DERIVED_EBOOK_MEDIA_KINDS.has(mediaKind);
+}
+
+const SCAN_GROUPED_EBOOK_MEDIA_KINDS = new Set<MediaKind>([
+  MediaKind.EPUB,
+  MediaKind.KEPUB,
+  MediaKind.MOBI,
+  MediaKind.AZW,
+  MediaKind.AZW3,
+]);
+
+function groupsWithSiblingEbookVariants(mediaKind: MediaKind): boolean {
+  return SCAN_GROUPED_EBOOK_MEDIA_KINDS.has(mediaKind);
+}
+
+function normalizePathSegment(value: string): string {
+  return value
+    .replace(/_/g, " ")
+    .replace(/(?<!\s)-(?!\s)/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function deriveEbookVariantMetadataFromPath(filePath: string): NormalizedBookMetadata {
+  const directoryPath = path.dirname(filePath);
+  const rawTitleSource = directoryPath === "."
+    ? path.basename(filePath, path.extname(filePath))
+    : path.basename(directoryPath);
+  const { title } = deriveTitleFromPath(rawTitleSource, MediaKind.EPUB);
+  const rawAuthorSource = directoryPath === "." ? "" : path.basename(path.dirname(directoryPath));
+  const author = normalizePathSegment(rawAuthorSource);
+
+  return {
+    authors: author === "" ? [] : [author],
+    identifiers: { unknown: [] },
+    title,
+  };
 }
 
 function getAuthorCanonicalsForWork(work: WorkMatchRecord): string[] {
@@ -646,16 +705,41 @@ async function ensureEditionFileLink(
   ingestDb: IngestDb,
   editionId: string,
   fileAssetId: string,
+  role: EditionFileRole = EditionFileRole.PRIMARY,
 ): Promise<boolean> {
   await ingestDb.editionFile.create({
     data: {
       editionId,
       fileAssetId,
-      role: EditionFileRole.PRIMARY,
+      role,
     },
   });
 
   return true;
+}
+
+async function determineEditionFileRole(
+  ingestDb: IngestDb,
+  editionId: string,
+  fileAsset: FileAssetRecord,
+): Promise<EditionFileRole> {
+  if (fileAsset.mediaKind === MediaKind.AUDIO) {
+    return EditionFileRole.AUDIO_TRACK;
+  }
+
+  const existingEditionFiles = await ingestDb.editionFile.findMany({
+    where: { editionId },
+  });
+
+  if (existingEditionFiles.length === 0) {
+    return EditionFileRole.PRIMARY;
+  }
+
+  if (isEbookVariant(fileAsset.mediaKind)) {
+    return EditionFileRole.ALTERNATE_FORMAT;
+  }
+
+  return EditionFileRole.PRIMARY;
 }
 
 async function ensureContributors(
@@ -953,6 +1037,7 @@ async function recoverUnchangedFile(
       if (!parsedMeta || parsedMeta.status !== "parsed") {
         if (
           upsertedFileAsset.mediaKind === MediaKind.EPUB ||
+          usesPathDerivedEbookMetadata(upsertedFileAsset.mediaKind) ||
           upsertedFileAsset.mediaKind === MediaKind.AUDIO
         ) {
           logger.info({ fileAssetId: upsertedFileAsset.id, reason: "missing or failed metadata" }, "Recovery: re-enqueueing PARSE");
@@ -1013,6 +1098,16 @@ async function duplicatePairExists(
   return existing !== null;
 }
 
+const DUPLICATE_MEDIA_KINDS: ReadonlySet<MediaKind> = new Set([
+  MediaKind.EPUB,
+  MediaKind.KEPUB,
+  MediaKind.MOBI,
+  MediaKind.AZW,
+  MediaKind.AZW3,
+  MediaKind.PDF,
+  MediaKind.CBZ,
+]);
+
 async function detectDuplicatesImpl(
   input: DetectDuplicatesInput,
   ingestDb: IngestDb,
@@ -1036,6 +1131,10 @@ async function detectDuplicatesImpl(
     return { fileAssetId: input.fileAssetId, skipped: true, candidatesCreated: 0 };
   }
 
+  if (!DUPLICATE_MEDIA_KINDS.has(fileAsset.mediaKind)) {
+    return { fileAssetId: input.fileAssetId, skipped: true, candidatesCreated: 0 };
+  }
+
   const work = await ingestDb.work.findUnique({ where: { id: edition.workId } });
 
   let candidatesCreated = 0;
@@ -1046,6 +1145,13 @@ async function detectDuplicatesImpl(
       where: { fullHash: fileAsset.fullHash, NOT: { id: fileAsset.id } },
     });
     for (const match of hashMatches) {
+      const matchEditionFile = await ingestDb.editionFile.findFirst({
+        where: { fileAssetId: match.id },
+      });
+      if (matchEditionFile?.editionId === edition.id) {
+        continue;
+      }
+
       const alreadyExists = await duplicatePairExists(
         ingestDb.duplicateCandidate,
         { fileAssetId: fileAsset.id },
@@ -1467,6 +1573,7 @@ export function createIngestServices(
     const enqueuedRecoveryJobs: string[] = [];
     const createdStubWorkIds: string[] = [];
     const seenAudioDirs = new Map<string, { workId: string; editionId: string }>();
+    const seenEbookVariantTitles = new Map<string, { workId: string; editionId: string }>();
     const unchangedSeenFileAssetIds: string[] = [];
 
     if (reportProgress) {
@@ -1630,40 +1737,63 @@ export function createIngestServices(
                 });
               }
             } else {
-              // Ebook file — create stub per file
-              const { title, titleCanonical } = deriveTitleFromPath(relativePath, upsertedFileAsset.mediaKind);
-              const stubWork = await ingestDb.work.create({
-                data: {
-                  enrichmentStatus: "STUB",
-                  sortTitle: null,
-                  titleCanonical,
-                  titleDisplay: title,
-                },
-              });
-              const stubEdition = await ingestDb.edition.create({
-                data: {
-                  asin: null,
-                  formatFamily,
-                  isbn10: null,
-                  isbn13: null,
-                  language: null,
-                  publishedAt: null,
-                  publisher: null,
+              const ebookVariantMetadata = usesPathDerivedEbookMetadata(upsertedFileAsset.mediaKind)
+                ? deriveEbookVariantMetadataFromPath(relativePath)
+                : null;
+              const title = ebookVariantMetadata?.title
+                ?? deriveTitleFromPath(relativePath, upsertedFileAsset.mediaKind).title;
+              const titleCanonical = canonicalizeBookTitle(title) ?? title.toLowerCase();
+
+              const existingEbookVariant = groupsWithSiblingEbookVariants(upsertedFileAsset.mediaKind)
+                ? seenEbookVariantTitles.get(titleCanonical)
+                : undefined;
+
+              if (existingEbookVariant) {
+                await ingestDb.editionFile.create({
+                  data: {
+                    editionId: existingEbookVariant.editionId,
+                    fileAssetId: upsertedFileAsset.id,
+                    role: EditionFileRole.ALTERNATE_FORMAT,
+                  },
+                });
+              } else {
+                // Ebook file — create stub per file
+                const stubWork = await ingestDb.work.create({
+                  data: {
+                    enrichmentStatus: "STUB",
+                    sortTitle: null,
+                    titleCanonical,
+                    titleDisplay: title,
+                  },
+                });
+                const stubEdition = await ingestDb.edition.create({
+                  data: {
+                    asin: null,
+                    formatFamily,
+                    isbn10: null,
+                    isbn13: null,
+                    language: null,
+                    publishedAt: null,
+                    publisher: null,
+                    workId: stubWork.id,
+                  },
+                });
+                await ingestDb.editionFile.create({
+                  data: {
+                    editionId: stubEdition.id,
+                    fileAssetId: upsertedFileAsset.id,
+                    role: EditionFileRole.PRIMARY,
+                  },
+                });
+                if (groupsWithSiblingEbookVariants(upsertedFileAsset.mediaKind)) {
+                  seenEbookVariantTitles.set(titleCanonical, { workId: stubWork.id, editionId: stubEdition.id });
+                }
+                createdStubWorkIds.push(stubWork.id);
+                await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
                   workId: stubWork.id,
-                },
-              });
-              await ingestDb.editionFile.create({
-                data: {
-                  editionId: stubEdition.id,
                   fileAssetId: upsertedFileAsset.id,
-                  role: EditionFileRole.PRIMARY,
-                },
-              });
-              createdStubWorkIds.push(stubWork.id);
-              await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
-                workId: stubWork.id,
-                fileAssetId: upsertedFileAsset.id,
-              });
+                });
+              }
             }
           }
         }
@@ -1796,6 +1926,7 @@ export function createIngestServices(
 
       if (
         fileAsset.mediaKind === MediaKind.EPUB ||
+        isEbookVariant(fileAsset.mediaKind) ||
         (fileAsset.mediaKind === MediaKind.SIDECAR && getFileExtension(fileAsset.absolutePath) === "opf") ||
         fileAsset.mediaKind === MediaKind.AUDIO ||
         (fileAsset.mediaKind === MediaKind.SIDECAR &&
@@ -2281,6 +2412,37 @@ export function createIngestServices(
       }
     }
 
+    if (usesPathDerivedEbookMetadata(fileAsset.mediaKind)) {
+      const metadata: ParsedFileAssetMetadata = {
+        normalized: deriveEbookVariantMetadataFromPath(fileAsset.relativePath),
+        parsedAt: now.toISOString(),
+        parserVersion: 1,
+        source: "filename",
+        status: "parsed",
+        warnings: [],
+      };
+
+      await ingestDb.fileAsset.update({
+        where: { id: fileAsset.id },
+        data: {
+          availabilityStatus: AvailabilityStatus.PRESENT,
+          lastSeenAt: now,
+          metadata: metadata as object as FileAsset["metadata"],
+        },
+      });
+
+      await enqueueJob(LIBRARY_JOB_NAMES.MATCH_FILE_ASSET_TO_EDITION, {
+        fileAssetId: fileAsset.id,
+      });
+
+      return {
+        availabilityStatus: AvailabilityStatus.PRESENT,
+        fileAssetId: fileAsset.id,
+        metadata,
+        skipped: false,
+      };
+    }
+
     if (fileAsset.mediaKind !== MediaKind.EPUB) {
       return {
         availabilityStatus: fileAsset.availabilityStatus,
@@ -2676,7 +2838,13 @@ export function createIngestServices(
       return null;
     }
 
-    const createdEditionFile = await ensureEditionFileLink(ingestDb, editionMatch.id, ctx.fileAsset.id);
+    const editionFileRole = await determineEditionFileRole(ingestDb, editionMatch.id, ctx.fileAsset);
+    const createdEditionFile = await ensureEditionFileLink(
+      ingestDb,
+      editionMatch.id,
+      ctx.fileAsset.id,
+      editionFileRole,
+    );
 
     await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
       workId: editionMatch.workId,
@@ -2741,6 +2909,64 @@ export function createIngestServices(
     }
 
     const workId = matchingWork.id;
+
+    if (!ctx.isAudiobook && isEbookVariant(ctx.fileAsset.mediaKind)) {
+      const existingEbookEdition = matchingWork.editions.find(
+        (edition) => edition.formatFamily === FormatFamily.EBOOK,
+      );
+
+      if (existingEbookEdition) {
+        await ingestDb.edition.update({
+          where: { id: existingEbookEdition.id },
+          data: {
+            asin: ctx.identifiers?.asin ?? existingEbookEdition.asin,
+            isbn10: ctx.identifiers?.isbn10 ?? existingEbookEdition.isbn10,
+            isbn13: ctx.identifiers?.isbn13 ?? existingEbookEdition.isbn13,
+            language: ctx.storedMetadata.normalized?.language ?? existingEbookEdition.language,
+          },
+        });
+
+        await ensureContributors(
+          ingestDb,
+          existingEbookEdition.id,
+          ctx.matchableMetadata.authors,
+          ContributorRole.AUTHOR,
+        );
+
+        const editionFileRole = await determineEditionFileRole(
+          ingestDb,
+          existingEbookEdition.id,
+          ctx.fileAsset,
+        );
+        const createdEditionFile = await ensureEditionFileLink(
+          ingestDb,
+          existingEbookEdition.id,
+          ctx.fileAsset.id,
+          editionFileRole,
+        );
+
+        await enqueueJob(LIBRARY_JOB_NAMES.PROCESS_COVER, {
+          workId,
+          fileAssetId: ctx.fileAsset.id,
+        });
+
+        return {
+          kind: "earlyReturn",
+          result: {
+            createdEdition: false,
+            createdEditionFile,
+            createdWork: false,
+            editionId: existingEbookEdition.id,
+            enrichedExistingWork: matchingWork.enrichmentStatus === "STUB",
+            enqueuedCoverJob: true,
+            fileAssetId: ctx.fileAsset.id,
+            mediaKind: ctx.fileAsset.mediaKind,
+            skipped: false,
+            workId,
+          },
+        };
+      }
+    }
 
     // Enrich stub work with sidecar metadata
     if (matchingWork.enrichmentStatus === "STUB") {
@@ -2884,12 +3110,30 @@ export function createIngestServices(
   async function matchFileAssetToEdition(
     input: MatchFileAssetToEditionInput,
   ): Promise<MatchFileAssetToEditionResult> {
-    const CONTENT_MEDIA_KINDS: ReadonlySet<string> = new Set([
-      MediaKind.EPUB, MediaKind.PDF, MediaKind.CBZ, MediaKind.AUDIO,
+    const DUPLICATE_CONTENT_MEDIA_KINDS: ReadonlySet<string> = new Set([
+      MediaKind.EPUB,
+      MediaKind.KEPUB,
+      MediaKind.MOBI,
+      MediaKind.AZW,
+      MediaKind.AZW3,
+      MediaKind.PDF,
+      MediaKind.CBZ,
+    ]);
+    const MATCH_SUGGESTION_MEDIA_KINDS: ReadonlySet<string> = new Set([
+      MediaKind.EPUB,
+      MediaKind.KEPUB,
+      MediaKind.MOBI,
+      MediaKind.AZW,
+      MediaKind.AZW3,
+      MediaKind.PDF,
+      MediaKind.CBZ,
+      MediaKind.AUDIO,
     ]);
     const result = await matchFileAssetToEditionCore(input);
-    if (!result.skipped && result.mediaKind !== undefined && CONTENT_MEDIA_KINDS.has(result.mediaKind)) {
+    if (!result.skipped && result.mediaKind !== undefined && DUPLICATE_CONTENT_MEDIA_KINDS.has(result.mediaKind)) {
       await enqueueJob(LIBRARY_JOB_NAMES.DETECT_DUPLICATES, { fileAssetId: input.fileAssetId });
+    }
+    if (!result.skipped && result.mediaKind !== undefined && MATCH_SUGGESTION_MEDIA_KINDS.has(result.mediaKind)) {
       await enqueueJob(LIBRARY_JOB_NAMES.MATCH_SUGGESTIONS, { fileAssetId: input.fileAssetId });
     }
     return result;
@@ -2902,7 +3146,15 @@ export function createIngestServices(
       where: { id: input.fileAssetId },
     });
 
-    const matchableMediaKinds: Set<MediaKind> = new Set([MediaKind.EPUB, MediaKind.AUDIO, MediaKind.SIDECAR]);
+    const matchableMediaKinds: Set<MediaKind> = new Set([
+      MediaKind.EPUB,
+      MediaKind.KEPUB,
+      MediaKind.MOBI,
+      MediaKind.AZW,
+      MediaKind.AZW3,
+      MediaKind.AUDIO,
+      MediaKind.SIDECAR,
+    ]);
 
     if (fileAsset === null || !matchableMediaKinds.has(fileAsset.mediaKind)) {
       return skippedResult(input.fileAssetId);

--- a/workers/library-worker/src/index.test.ts
+++ b/workers/library-worker/src/index.test.ts
@@ -984,6 +984,60 @@ describe("library worker", () => {
     });
   });
 
+  it("tolerates missing ImportJob during waiting-children completion phase", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      enrichWork: enrichWorkMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+    importJobUpdateMock.mockRejectedValueOnce({
+      code: "P2025",
+      name: "PrismaClientKnownRequestError",
+    });
+
+    await expect(processor(createMockJob({
+      data: { libraryRootId: "root-1", importJobId: "ij-missing", step: "waiting-children" },
+      name: "scan-library-root",
+    }) as never, "test-token")).resolves.toBeUndefined();
+
+    expect(loggerWarnMock).toHaveBeenCalledWith(
+      expect.objectContaining({ importJobId: "ij-missing", jobId: "job-1", jobName: "scan-library-root" }),
+      "ImportJob missing during completion phase; skipping SUCCEEDED update",
+    );
+  });
+
+  it("rethrows unexpected completion phase ImportJob update errors", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      enrichWork: enrichWorkMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+    const expectedError = new Error("db unavailable");
+    importJobUpdateMock.mockRejectedValueOnce(expectedError);
+
+    await expect(processor(createMockJob({
+      data: { libraryRootId: "root-1", importJobId: "ij-error", step: "waiting-children" },
+      name: "scan-library-root",
+    }) as never, "test-token")).rejects.toThrow("db unavailable");
+
+    expect(loggerWarnMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ importJobId: "ij-error" }),
+      "ImportJob missing during completion phase; skipping SUCCEEDED update",
+    );
+  });
+
   it("skips activeScanType reset in completion phase for non-scan jobs", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({

--- a/workers/library-worker/src/index.ts
+++ b/workers/library-worker/src/index.ts
@@ -238,11 +238,26 @@ export function createLibraryWorkerProcessor(
   if ((job.data as BaseJobPayload).step === "waiting-children") {
     logger.info({ jobId: job.id, jobName: job.name }, "All children finished, entering completion phase");
     if (importJobId && isScanJob) {
-      await db.importJob.update({
-        where: { id: importJobId, status: "RUNNING" },
-        data: { status: "SUCCEEDED", finishedAt: new Date(), scanStage: null, bullmqJobId: null },
-      });
-      logger.info({ jobId: job.id, importJobId }, "Scan marked SUCCEEDED");
+      try {
+        await db.importJob.update({
+          where: { id: importJobId, status: "RUNNING" },
+          data: { status: "SUCCEEDED", finishedAt: new Date(), scanStage: null, bullmqJobId: null },
+        });
+        logger.info({ jobId: job.id, importJobId }, "Scan marked SUCCEEDED");
+      } catch (error) {
+        const prismaError = typeof error === "object" &&
+          error !== null &&
+          "code" in error
+          ? error as { code?: string }
+          : null;
+        if (prismaError?.code !== "P2025") {
+          throw error;
+        }
+        logger.warn(
+          { jobId: job.id, jobName: job.name, importJobId },
+          "ImportJob missing during completion phase; skipping SUCCEEDED update",
+        );
+      }
     }
     if (isScanJob) activeScanType = null;
     return;


### PR DESCRIPTION
## Summary
- treat ebook container variants as alternate files on a single edition instead of duplicate candidates
- add explicit media kinds and ingest handling for MOBI, AZW, AZW3, and KEPUB, plus runtime and health fixes
- classify junk companion files as sidecars and suppress non-book duplicate noise

Closes #189
Closes #192

## Verification
- pnpm lint
- pnpm typecheck
- pnpm build
- pnpm test