### PR TITLE
Fix FULL scan reuse and add stub creation diagnostics

### DIFF
--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -4365,6 +4365,181 @@ describe("ingest services", () => {
     });
   });
 
+  it("logs rejected title matches before creating a new work", async () => {
+    const state = createEmptyState("/tmp/root");
+    const infoMock = vi.fn();
+    addFileAsset(state, {
+      metadata: {
+        normalized: {
+          authors: ["N. K. Jemisin"],
+          identifiers: { unknown: [] },
+          title: "The Fifth Season",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "epub",
+        status: "parsed",
+        warnings: [],
+      },
+    });
+    addWork(state, {
+      titleCanonical: canonicalizeBookTitle("The Fifth Season") ?? "the fifth season",
+      titleDisplay: "The Fifth Season",
+    });
+    addEdition(state);
+    addContributor(state, {
+      nameCanonical: canonicalizeContributorNames(["James S. A. Corey"])[0] ?? "james s a corey",
+      nameDisplay: "James S. A. Corey",
+    });
+    addEditionContributor(state);
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      logger: { info: infoMock, warn: vi.fn() },
+    });
+
+    await expect(
+      services.matchFileAssetToEdition({ fileAssetId: "file-1" }),
+    ).resolves.toMatchObject({
+      createdEdition: true,
+      createdWork: true,
+      fileAssetId: "file-1",
+      skipped: false,
+    });
+
+    expect(infoMock).toHaveBeenCalledWith(
+      {
+        authorCanonicalsExpected: canonicalizeContributorNames(["N. K. Jemisin"]),
+        createdWorkId: "work-2",
+        fileAssetId: "file-1",
+        matchStrategy: "exact-author-match",
+        matchingWorksByTitle: 1,
+        rejections: [
+          {
+            actualAuthorCanonicals: canonicalizeContributorNames(["James S. A. Corey"]),
+            rejectionReason: "author-mismatch",
+            workEnrichmentStatus: "ENRICHED",
+            workId: "work-1",
+          },
+        ],
+        titleCanonical: canonicalizeBookTitle("The Fifth Season") ?? "the fifth season",
+      },
+      "Created new work after title lookup found no reusable match",
+    );
+  });
+
+  it("logs empty title lookup results before creating a new work", async () => {
+    const state = createEmptyState("/tmp/root");
+    const infoMock = vi.fn();
+    addFileAsset(state, {
+      metadata: {
+        normalized: {
+          authors: ["N. K. Jemisin"],
+          identifiers: { unknown: [] },
+          title: "The Fifth Season",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "epub",
+        status: "parsed",
+        warnings: [],
+      },
+    });
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      logger: { info: infoMock, warn: vi.fn() },
+    });
+
+    await expect(
+      services.matchFileAssetToEdition({ fileAssetId: "file-1" }),
+    ).resolves.toMatchObject({
+      createdEdition: true,
+      createdWork: true,
+      fileAssetId: "file-1",
+      skipped: false,
+    });
+
+    expect(infoMock).toHaveBeenCalledWith(
+      {
+        authorCanonicalsExpected: canonicalizeContributorNames(["N. K. Jemisin"]),
+        createdWorkId: "work-1",
+        fileAssetId: "file-1",
+        matchStrategy: "exact-author-match",
+        matchingWorksByTitle: 0,
+        rejections: [],
+        titleCanonical: canonicalizeBookTitle("The Fifth Season") ?? "the fifth season",
+      },
+      "Created new work after title lookup found no reusable match",
+    );
+  });
+
+  it("logs author count mismatches before creating a new work", async () => {
+    const state = createEmptyState("/tmp/root");
+    const infoMock = vi.fn();
+    addFileAsset(state, {
+      metadata: {
+        normalized: {
+          authors: ["N. K. Jemisin", "Nora Jemisin"],
+          identifiers: { unknown: [] },
+          title: "The Fifth Season",
+        },
+        parsedAt: new Date("2025-01-01T00:00:00.000Z").toISOString(),
+        parserVersion: 1,
+        source: "epub",
+        status: "parsed",
+        warnings: [],
+      },
+    });
+    addWork(state, {
+      titleCanonical: canonicalizeBookTitle("The Fifth Season") ?? "the fifth season",
+      titleDisplay: "The Fifth Season",
+    });
+    addEdition(state);
+    addContributor(state, {
+      nameCanonical: canonicalizeContributorNames(["N. K. Jemisin"])[0] ?? "n k jemisin",
+      nameDisplay: "N. K. Jemisin",
+    });
+    addEditionContributor(state);
+
+    const services = createIngestServices({
+      db: createTestDb(state),
+      enqueueLibraryJob: vi.fn(() => Promise.resolve(undefined)),
+      logger: { info: infoMock, warn: vi.fn() },
+    });
+
+    await expect(
+      services.matchFileAssetToEdition({ fileAssetId: "file-1" }),
+    ).resolves.toMatchObject({
+      createdEdition: true,
+      createdWork: true,
+      fileAssetId: "file-1",
+      skipped: false,
+    });
+
+    expect(infoMock).toHaveBeenCalledWith(
+      {
+        authorCanonicalsExpected: canonicalizeContributorNames(["N. K. Jemisin", "Nora Jemisin"]),
+        createdWorkId: "work-2",
+        fileAssetId: "file-1",
+        matchStrategy: "exact-author-match",
+        matchingWorksByTitle: 1,
+        rejections: [
+          {
+            actualAuthorCanonicals: canonicalizeContributorNames(["N. K. Jemisin"]),
+            rejectionReason: "author-count-mismatch",
+            workEnrichmentStatus: "ENRICHED",
+            workId: "work-1",
+          },
+        ],
+        titleCanonical: canonicalizeBookTitle("The Fifth Season") ?? "the fifth season",
+      },
+      "Created new work after title lookup found no reusable match",
+    );
+  });
+
   it("returns the existing edition mapping when the file is already linked", async () => {
     const state = createEmptyState("/tmp/root");
     addFileAsset(state, {

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -331,9 +331,17 @@ export interface IngestDb {
   };
 }
 
+type IngestLogValue =
+  | string
+  | number
+  | boolean
+  | null
+  | IngestLogValue[]
+  | { [key: string]: IngestLogValue };
+
 export interface IngestLogger {
-  info(obj: Record<string, string | number | boolean | null>, msg: string): void;
-  warn(obj: Record<string, string | number | boolean | null>, msg: string): void;
+  info(obj: Record<string, IngestLogValue>, msg: string): void;
+  warn(obj: Record<string, IngestLogValue>, msg: string): void;
 }
 
 export interface IngestDependencies {
@@ -2889,11 +2897,12 @@ export function createIngestServices(
       },
       where: { titleCanonical: ctx.matchableMetadata.titleCanonical },
     });
+    const authorCanonicalsExpected = ctx.matchableMetadata.authorCanonicals;
     let matchingWork = matchingWorks.find((work) => {
       const existingAuthors = getAuthorCanonicalsForWork(work);
       return existingAuthors.length > 0 &&
-        existingAuthors.length === ctx.matchableMetadata.authorCanonicals.length &&
-        existingAuthors.every((author, index) => author === ctx.matchableMetadata.authorCanonicals[index]);
+        existingAuthors.length === authorCanonicalsExpected.length &&
+        existingAuthors.every((author, index) => author === authorCanonicalsExpected[index]);
     });
 
     // Fallback for audiobook stubs: match by title when stub has no authors
@@ -2912,6 +2921,35 @@ export function createIngestServices(
           titleDisplay: ctx.matchableMetadata.title,
         },
       });
+      const rejections = matchingWorks.map((work) => {
+        const actualAuthorCanonicals = getAuthorCanonicalsForWork(work);
+        let rejectionReason = "author-mismatch";
+
+        if (actualAuthorCanonicals.length === 0) {
+          rejectionReason = "missing-authors";
+        } else if (actualAuthorCanonicals.length !== authorCanonicalsExpected.length) {
+          rejectionReason = "author-count-mismatch";
+        }
+
+        return {
+          actualAuthorCanonicals,
+          rejectionReason,
+          workEnrichmentStatus: work.enrichmentStatus,
+          workId: work.id,
+        };
+      });
+      logger.info(
+        {
+          authorCanonicalsExpected,
+          createdWorkId: createdWorkRecord.id,
+          fileAssetId: ctx.fileAsset.id,
+          matchStrategy: ctx.isAudiobook ? "audiobook-stub-fallback" : "exact-author-match",
+          matchingWorksByTitle: matchingWorks.length,
+          rejections,
+          titleCanonical: ctx.matchableMetadata.titleCanonical,
+        },
+        "Created new work after title lookup found no reusable match",
+      );
       return { kind: "workReady", workId: createdWorkRecord.id, createdWork: true };
     }
 


### PR DESCRIPTION
## Summary
- avoid rehashing unchanged, already-linked files during manual FULL scans
- keep those unchanged linked files on the recovery path so follow-up jobs still run
- add structured diagnostics when title lookup falls back to creating a new work stub

## Verification
- `pnpm test`
- `pnpm lint`
- `pnpm typecheck`
- `pnpm build`

Closes #190
Closes #191