### PR TITLE
Library: toggle between Works and Editions view

### DIFF
--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -67,7 +67,7 @@ export function AppSidebar({ user }: { user: AuthenticatedUser }) {
         <SidebarMenu>
           <SidebarMenuItem>
             <SidebarMenuButton size="lg" asChild>
-              <Link to="/library" search={{ page: 1, pageSize: 50, sort: "title-asc" as const }}>
+              <Link to="/library" search={{ page: 1, pageSize: 50, sort: "title-asc" as const, view: "works" as const }}>
                 <div className="flex aspect-square size-8 items-center justify-center rounded-lg bg-primary text-primary-foreground">
                   <BookOpen className="size-4" />
                 </div>

--- a/apps/web/src/components/library-table-view.test.tsx
+++ b/apps/web/src/components/library-table-view.test.tsx
@@ -28,6 +28,9 @@ const defaultProps = {
   onRowSelectionChange: vi.fn(),
   sorting: [],
   onSortingChange: vi.fn(),
+  viewMode: "works" as const,
+  onViewModeChange: vi.fn(),
+  columnPickerItems: [{ id: "authors", label: "Author(s)" }],
 };
 
 describe("LibraryTableView", () => {
@@ -86,5 +89,36 @@ describe("LibraryTableView", () => {
     const table = screen.getByTestId("virtualized-data-table");
     expect(table.getAttribute("data-column-visibility")).toBe(JSON.stringify({ isbn: false }));
     expect(table.getAttribute("data-text-overflow")).toBe("wrap");
+  });
+
+  it("renders Works/Editions view mode toggle", () => {
+    render(<LibraryTableView {...defaultProps} />);
+    expect(screen.getByRole("button", { name: /works view/i })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /editions view/i })).toBeTruthy();
+  });
+
+  it("highlights active view mode button", () => {
+    render(<LibraryTableView {...defaultProps} viewMode="editions" />);
+    const editionsBtn = screen.getByRole("button", { name: /editions view/i });
+    expect(editionsBtn.getAttribute("data-active")).toBe("true");
+  });
+
+  it("calls onViewModeChange when Editions button is clicked", () => {
+    const onViewModeChange = vi.fn();
+    render(<LibraryTableView {...defaultProps} onViewModeChange={onViewModeChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /editions view/i }));
+    expect(onViewModeChange).toHaveBeenCalledWith("editions");
+  });
+
+  it("calls onViewModeChange with works when Works button is clicked", () => {
+    const onViewModeChange = vi.fn();
+    render(<LibraryTableView {...defaultProps} viewMode="editions" onViewModeChange={onViewModeChange} />);
+    fireEvent.click(screen.getByRole("button", { name: /works view/i }));
+    expect(onViewModeChange).toHaveBeenCalledWith("works");
+  });
+
+  it("shows edit mode toggle in editions view", () => {
+    render(<LibraryTableView {...defaultProps} viewMode="editions" />);
+    expect(screen.getByTestId("edit-mode-toggle")).toBeTruthy();
   });
 });

--- a/apps/web/src/components/library-table-view.tsx
+++ b/apps/web/src/components/library-table-view.tsx
@@ -1,9 +1,8 @@
 import type { ColumnDef, OnChangeFn, RowSelectionState, SortingState, Updater } from "@tanstack/react-table";
-import { AlignJustify, Pencil, WrapText } from "lucide-react";
+import { AlignJustify, BookOpen, Library, Pencil, WrapText } from "lucide-react";
 import { VirtualizedDataTable } from "~/components/data-table";
 import { DataTableColumnPicker } from "~/components/data-table/data-table-column-picker";
 import { Button } from "~/components/ui/button";
-import { COLUMN_PICKER_ITEMS } from "~/lib/library-columns";
 
 interface LibraryTableViewProps<T> {
   works: T[];
@@ -17,6 +16,9 @@ interface LibraryTableViewProps<T> {
   onRowSelectionChange: OnChangeFn<RowSelectionState>;
   sorting: SortingState;
   onSortingChange: (updater: Updater<SortingState>) => void;
+  viewMode: "works" | "editions";
+  onViewModeChange: (mode: "works" | "editions") => void;
+  columnPickerItems: { id: string; label: string }[];
 }
 
 export function LibraryTableView<T>({
@@ -31,20 +33,47 @@ export function LibraryTableView<T>({
   onRowSelectionChange,
   sorting,
   onSortingChange,
+  viewMode,
+  onViewModeChange,
+  columnPickerItems,
 }: LibraryTableViewProps<T>) {
   return (
     <>
       <div className="flex items-center gap-2 justify-end">
+        <div className="flex items-center rounded-md border mr-auto">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => { onViewModeChange("works"); }}
+            aria-label="Works view"
+            data-active={viewMode === "works"}
+            className="rounded-r-none data-[active=true]:bg-muted"
+          >
+            <Library className="mr-1 h-4 w-4" />
+            Works
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => { onViewModeChange("editions"); }}
+            aria-label="Editions view"
+            data-active={viewMode === "editions"}
+            className="rounded-l-none data-[active=true]:bg-muted"
+          >
+            <BookOpen className="mr-1 h-4 w-4" />
+            Editions
+          </Button>
+        </div>
         <Button
-          data-testid="edit-mode-toggle"
-          variant={editMode ? "default" : "outline"}
-          size="sm"
-          onClick={onEditModeToggle}
-          aria-label={editMode ? "Exit edit mode" : "Enter edit mode"}
-        >
-          <Pencil className="mr-2 h-4 w-4" />
-          {editMode ? "Done" : "Edit"}
-        </Button>
+            data-testid="edit-mode-toggle"
+            variant={editMode ? "default" : "outline"}
+            size="sm"
+            onClick={onEditModeToggle}
+            aria-label={editMode ? "Exit edit mode" : "Enter edit mode"}
+          >
+            <Pencil className="mr-2 h-4 w-4" />
+            {editMode ? "Done" : "Edit"}
+          </Button>
         <Button
           variant="outline"
           size="sm"
@@ -59,7 +88,7 @@ export function LibraryTableView<T>({
           {tablePrefs.textOverflow === "truncate" ? "Wrap" : "Truncate"}
         </Button>
         <DataTableColumnPicker
-          columns={COLUMN_PICKER_ITEMS}
+          columns={columnPickerItems}
           columnVisibility={tablePrefs.columnVisibility}
           onToggle={onColumnToggle}
         />

--- a/apps/web/src/components/library-toolbar.tsx
+++ b/apps/web/src/components/library-toolbar.tsx
@@ -13,8 +13,9 @@ import {
 import type { ReadingFilter } from "~/lib/sort-filter-works";
 import type { LibraryView } from "~/hooks/use-library-view-preference";
 import type { GridTileSize } from "~/hooks/use-grid-tile-size";
+import type { LibrarySearchParams } from "~/lib/library-search-schema";
 
-export type SortValue = "title-asc" | "title-desc" | "author-asc" | "author-desc" | "format-asc" | "format-desc" | "recent";
+export type SortValue = LibrarySearchParams["sort"];
 
 interface LibraryToolbarProps {
   searchValue: string;

--- a/apps/web/src/hooks/use-library-filters.test.ts
+++ b/apps/web/src/hooks/use-library-filters.test.ts
@@ -19,7 +19,7 @@ describe("useLibraryFilters", () => {
     }
   });
 
-  const defaultSearch = { page: 1, pageSize: 50, sort: "title-asc" as const };
+  const defaultSearch = { page: 1, pageSize: 50, sort: "title-asc" as const, view: "works" as const };
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -167,5 +167,56 @@ describe("useLibraryFilters", () => {
     expect(result.current.currentFilters.format).toEqual(["EBOOK"]);
     expect(result.current.currentFilters.hasCover).toBe(true);
     expect(result.current.currentFilters.authorId).toEqual(["a1"]);
+  });
+
+  it("handleViewModeChange navigates with view, resets sort and page", () => {
+    const { result } = renderHook(() =>
+      useLibraryFilters({ search: { ...defaultSearch, sort: "author-desc" as const, page: 3 }, navigate: mockNavigate }),
+    );
+    act(() => {
+      result.current.handleViewModeChange("editions");
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+    const merged = extractSearch(mockNavigate)({});
+    expect(merged.view).toBe("editions");
+    expect(merged.sort).toBe("title-asc");
+    expect(merged.page).toBe(1);
+  });
+
+  it("tableSorting uses custom sortToColumn map when provided", () => {
+    const customSortToColumn = {
+      "publisher-asc": { id: "publisher", desc: false },
+    };
+    const { result } = renderHook(() =>
+      useLibraryFilters({
+        search: { ...defaultSearch, sort: "publisher-asc" as const },
+        navigate: mockNavigate,
+        sortToColumn: customSortToColumn,
+      }),
+    );
+    expect(result.current.tableSorting).toEqual([{ id: "publisher", desc: false }]);
+  });
+
+  it("handleColumnSort uses custom sortMap when provided", () => {
+    const customSortMap = {
+      publisher: { asc: "publisher-asc" as const, desc: "publisher-desc" as const },
+    };
+    const customSortToColumn = {
+      "publisher-asc": { id: "publisher", desc: false },
+    };
+    const { result } = renderHook(() =>
+      useLibraryFilters({
+        search: { ...defaultSearch, sort: "publisher-asc" as const },
+        navigate: mockNavigate,
+        sortMap: customSortMap,
+        sortToColumn: customSortToColumn,
+      }),
+    );
+    act(() => {
+      result.current.handleColumnSort(() => [{ id: "publisher", desc: true }]);
+    });
+    expect(mockNavigate).toHaveBeenCalled();
+    const merged = extractSearch(mockNavigate)({});
+    expect(merged.sort).toBe("publisher-desc");
   });
 });

--- a/apps/web/src/hooks/use-library-filters.ts
+++ b/apps/web/src/hooks/use-library-filters.ts
@@ -10,12 +10,19 @@ type NavigateFn = (opts: {
   replace: boolean;
 }) => void | Promise<void>;
 
+type SortMapType = Record<string, { asc: LibrarySearchParams["sort"]; desc: LibrarySearchParams["sort"] }>;
+type SortToColumnType = Record<string, { id: string; desc: boolean }>;
+
 interface UseLibraryFiltersOptions {
   search: LibrarySearchParams;
   navigate: NavigateFn;
+  sortMap?: SortMapType;
+  sortToColumn?: SortToColumnType;
 }
 
-export function useLibraryFilters({ search, navigate }: UseLibraryFiltersOptions) {
+export function useLibraryFilters({ search, navigate, sortMap, sortToColumn }: UseLibraryFiltersOptions) {
+  const activeSortMap = sortMap ?? COLUMN_SORT_MAP;
+  const activeSortToColumn = sortToColumn ?? SORT_TO_COLUMN;
   const updateSearch = useCallback(
     (updates: Partial<LibrarySearchParams>) => {
       void navigate({
@@ -61,16 +68,23 @@ export function useLibraryFilters({ search, navigate }: UseLibraryFiltersOptions
   );
 
   const tableSorting: SortingState = useMemo(() => {
-    const mapped = SORT_TO_COLUMN[search.sort];
+    const mapped = activeSortToColumn[search.sort];
     return mapped ? [mapped] : [];
-  }, [search.sort]);
+  }, [search.sort, activeSortToColumn]);
 
   const handleColumnSort = useCallback(
     (updater: Updater<SortingState>) => {
       const newState = (updater as (prev: SortingState) => SortingState)(tableSorting);
-      updateSearch({ sort: columnSortToParam(newState, COLUMN_SORT_MAP) });
+      updateSearch({ sort: columnSortToParam(newState, activeSortMap) });
     },
-    [tableSorting, updateSearch],
+    [tableSorting, updateSearch, activeSortMap],
+  );
+
+  const handleViewModeChange = useCallback(
+    (view: "works" | "editions") => {
+      updateSearch({ view, sort: "title-asc", page: 1 });
+    },
+    [updateSearch],
   );
 
   const handlePageChange = useCallback(
@@ -103,6 +117,7 @@ export function useLibraryFilters({ search, navigate }: UseLibraryFiltersOptions
     handleSearchChange,
     handleSortChange,
     handleColumnSort,
+    handleViewModeChange,
     handlePageChange,
     handlePageSizeChange,
     tableSorting,

--- a/apps/web/src/lib/library-edition-columns.test.tsx
+++ b/apps/web/src/lib/library-edition-columns.test.tsx
@@ -1,0 +1,600 @@
+// @vitest-environment happy-dom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { useState } from "react";
+import {
+  useReactTable,
+  getCoreRowModel,
+  flexRender,
+  type RowSelectionState,
+} from "@tanstack/react-table";
+import {
+  getEditionColumns,
+  getEditionAuthors,
+  getEditionNarrators,
+  formatPagesOrDuration,
+  EDITION_COLUMN_PICKER_ITEMS,
+} from "./library-edition-columns";
+import type { LibraryEdition } from "~/lib/server-fns/library";
+
+vi.mock("@tanstack/react-router", () => ({
+  Link: ({ children, ...props }: { children?: React.ReactNode; to?: string; params?: object; search?: object; className?: string }) => (
+    <a href={props.to} {...props}>{children}</a>
+  ),
+}));
+
+vi.mock("~/components/data-table", () => ({
+  DataTableColumnHeader: ({ title }: { title: string }) => <span>{title}</span>,
+}));
+
+const updateEditionServerFnMock = vi.fn().mockResolvedValue({});
+const updateWorkAuthorsServerFnMock = vi.fn().mockResolvedValue({});
+const updateEditionNarratorsServerFnMock = vi.fn().mockResolvedValue({});
+vi.mock("~/lib/server-fns/editing", () => ({
+  updateEditionServerFn: (args: object): Promise<object> => updateEditionServerFnMock(args) as Promise<object>,
+  updateWorkAuthorsServerFn: (args: object): Promise<object> => updateWorkAuthorsServerFnMock(args) as Promise<object>,
+  updateEditionNarratorsServerFn: (args: object): Promise<object> => updateEditionNarratorsServerFnMock(args) as Promise<object>,
+}));
+
+const mockRouter = { invalidate: vi.fn() };
+
+const makeEdition = (overrides?: Partial<LibraryEdition>): LibraryEdition =>
+  ({
+    id: "e-1",
+    workId: "w-1",
+    formatFamily: "EBOOK",
+    publisher: "Penguin",
+    publishedAt: new Date("2024-01-15"),
+    isbn13: "9780123456789",
+    isbn10: "0123456789",
+    asin: "B01ABCDEFG",
+    language: "en",
+    pageCount: 300,
+    duration: null,
+    editedFields: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    work: {
+      titleDisplay: "Test Book",
+      titleCanonical: "test book",
+      sortTitle: null,
+      id: "w-1",
+      description: null,
+      coverPath: null,
+      coverColors: null,
+      seriesId: null,
+      seriesPosition: null,
+      enrichmentStatus: "ENRICHED",
+      editedFields: [],
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      series: null,
+      editions: [
+        {
+          id: "e-1",
+          contributors: [
+            { id: "ec-1", editionId: "e-1", contributorId: "c-1", role: "AUTHOR", contributor: { id: "c-1", nameDisplay: "Alice", nameCanonical: "alice", editedFields: [], createdAt: new Date(), updatedAt: new Date() } },
+          ],
+        },
+      ],
+    },
+    contributors: [
+      { id: "ec-1", editionId: "e-1", contributorId: "c-1", role: "AUTHOR", contributor: { id: "c-1", nameDisplay: "Alice", nameCanonical: "alice", editedFields: [], createdAt: new Date(), updatedAt: new Date() } },
+      { id: "ec-2", editionId: "e-1", contributorId: "c-2", role: "NARRATOR", contributor: { id: "c-2", nameDisplay: "Bob", nameCanonical: "bob", editedFields: [], createdAt: new Date(), updatedAt: new Date() } },
+    ],
+    ...overrides,
+  }) as LibraryEdition;
+
+function TestTable({ data, editMode = false }: { data: LibraryEdition[]; editMode?: boolean }) {
+  const columns = getEditionColumns(editMode, mockRouter);
+  const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
+  const table = useReactTable({
+    data,
+    columns,
+    getCoreRowModel: getCoreRowModel(),
+    enableRowSelection: true,
+    onRowSelectionChange: setRowSelection,
+    state: { rowSelection },
+  });
+  return (
+    <table>
+      <thead>
+        {table.getHeaderGroups().map((hg) => (
+          <tr key={hg.id}>
+            {hg.headers.map((h) => (
+              <th key={h.id}>{flexRender(h.column.columnDef.header, h.getContext())}</th>
+            ))}
+          </tr>
+        ))}
+      </thead>
+      <tbody>
+        {table.getRowModel().rows.map((row) => (
+          <tr key={row.id}>
+            {row.getVisibleCells().map((cell) => (
+              <td key={cell.id}>{flexRender(cell.column.columnDef.cell, cell.getContext())}</td>
+            ))}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+}
+
+describe("getEditionAuthors", () => {
+  it("aggregates authors from all work editions", () => {
+    const edition = {
+      contributors: [],
+      work: {
+        editions: [
+          { contributors: [{ role: "AUTHOR", contributor: { nameDisplay: "Alice" } }] },
+          { contributors: [{ role: "AUTHOR", contributor: { nameDisplay: "Charlie" } }, { role: "NARRATOR", contributor: { nameDisplay: "Bob" } }] },
+        ],
+      },
+    };
+    expect(getEditionAuthors(edition as Parameters<typeof getEditionAuthors>[0])).toBe("Alice, Charlie");
+  });
+
+  it("deduplicates authors across editions", () => {
+    const edition = {
+      contributors: [],
+      work: {
+        editions: [
+          { contributors: [{ role: "AUTHOR", contributor: { nameDisplay: "Alice" } }] },
+          { contributors: [{ role: "AUTHOR", contributor: { nameDisplay: "Alice" } }] },
+        ],
+      },
+    };
+    expect(getEditionAuthors(edition as Parameters<typeof getEditionAuthors>[0])).toBe("Alice");
+  });
+
+  it("returns em dash when no authors across any edition", () => {
+    const edition = {
+      contributors: [{ role: "NARRATOR", contributor: { nameDisplay: "Bob" } }],
+      work: {
+        editions: [
+          { contributors: [{ role: "NARRATOR", contributor: { nameDisplay: "Bob" } }] },
+        ],
+      },
+    };
+    expect(getEditionAuthors(edition as Parameters<typeof getEditionAuthors>[0])).toBe("\u2014");
+  });
+
+  it("returns em dash for work with no edition contributors", () => {
+    const edition = {
+      contributors: [],
+      work: { editions: [{ contributors: [] }] },
+    };
+    expect(getEditionAuthors(edition as Parameters<typeof getEditionAuthors>[0])).toBe("\u2014");
+  });
+});
+
+describe("getEditionNarrators", () => {
+  it("extracts NARRATOR contributors", () => {
+    const edition = {
+      contributors: [
+        { role: "AUTHOR", contributor: { nameDisplay: "Alice" } },
+        { role: "NARRATOR", contributor: { nameDisplay: "Bob" } },
+        { role: "NARRATOR", contributor: { nameDisplay: "Charlie" } },
+      ],
+    };
+    expect(getEditionNarrators(edition as Parameters<typeof getEditionNarrators>[0])).toBe("Bob, Charlie");
+  });
+
+  it("returns em dash when no narrators", () => {
+    const edition = {
+      contributors: [{ role: "AUTHOR", contributor: { nameDisplay: "Alice" } }],
+    };
+    expect(getEditionNarrators(edition as Parameters<typeof getEditionNarrators>[0])).toBe("\u2014");
+  });
+});
+
+describe("formatPagesOrDuration", () => {
+  it("returns page count for EBOOK", () => {
+    expect(formatPagesOrDuration("EBOOK", 350, null)).toBe("350 pages");
+  });
+
+  it("returns formatted duration for AUDIOBOOK", () => {
+    expect(formatPagesOrDuration("AUDIOBOOK", null, 45000)).toBe("12h 30m");
+  });
+
+  it("returns em dash for EBOOK without pageCount", () => {
+    expect(formatPagesOrDuration("EBOOK", null, null)).toBe("\u2014");
+  });
+
+  it("returns em dash for AUDIOBOOK without duration", () => {
+    expect(formatPagesOrDuration("AUDIOBOOK", null, null)).toBe("\u2014");
+  });
+
+  it("returns page count string for 1 page", () => {
+    expect(formatPagesOrDuration("EBOOK", 1, null)).toBe("1 page");
+  });
+});
+
+describe("getEditionColumns", () => {
+  it("returns expected column IDs", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const ids = columns.map((c) => c.id ?? (c as { accessorKey?: string }).accessorKey);
+    expect(ids).toEqual([
+      "select",
+      "titleDisplay",
+      "authors",
+      "format",
+      "publisher",
+      "publishDate",
+      "pagesOrDuration",
+      "narrators",
+      "isbn13",
+      "isbn10",
+      "asin",
+    ]);
+  });
+
+  it("select column is not sortable or hideable", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const select = columns.find((c) => c.id === "select");
+    expect(select).toBeDefined();
+    expect(select?.enableSorting).toBe(false);
+    expect(select?.enableHiding).toBe(false);
+  });
+
+  it("titleDisplay column is not hideable", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const title = columns.find((c) => c.id === "titleDisplay");
+    expect(title).toBeDefined();
+    expect(title?.enableHiding).toBe(false);
+  });
+
+  it.each([
+    ["publisher", (e: LibraryEdition) => e.publisher ?? "\u2014"],
+    ["isbn13", (e: LibraryEdition) => e.isbn13 ?? "\u2014"],
+    ["isbn10", (e: LibraryEdition) => e.isbn10 ?? "\u2014"],
+    ["asin", (e: LibraryEdition) => e.asin ?? "\u2014"],
+  ] as const)("accessorFn for %s returns em dash for null", (colId, expectedFn) => {
+    const columns = getEditionColumns(false, mockRouter);
+    const col = columns.find((c) => c.id === colId);
+    const accessorFn = (col as { accessorFn?: (row: LibraryEdition) => string }).accessorFn;
+    expect(accessorFn?.(makeEdition({ [colId]: null } as Partial<LibraryEdition>))).toBe("\u2014");
+    expect(accessorFn?.(makeEdition())).toBe(expectedFn(makeEdition()));
+  });
+
+  it("accessorFn for publishDate returns the date", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const col = columns.find((c) => c.id === "publishDate");
+    const accessorFn = (col as { accessorFn?: (row: LibraryEdition) => Date | null }).accessorFn;
+    const date = new Date("2024-01-15");
+    expect(accessorFn?.(makeEdition({ publishedAt: date }))).toBe(date);
+    expect(accessorFn?.(makeEdition({ publishedAt: null }))).toBeNull();
+  });
+
+  it("accessorFn for pagesOrDuration formats correctly", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const col = columns.find((c) => c.id === "pagesOrDuration");
+    const accessorFn = (col as { accessorFn?: (row: LibraryEdition) => string }).accessorFn;
+    expect(accessorFn?.(makeEdition({ formatFamily: "EBOOK", pageCount: 200, duration: null }))).toBe("200 pages");
+    expect(accessorFn?.(makeEdition({ formatFamily: "AUDIOBOOK", pageCount: null, duration: 3600 }))).toBe("1h");
+  });
+
+  it("accessorFn for narrators extracts narrators", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const col = columns.find((c) => c.id === "narrators");
+    const accessorFn = (col as { accessorFn?: (row: LibraryEdition) => string }).accessorFn;
+    expect(accessorFn?.(makeEdition())).toBe("Bob");
+  });
+
+  it("accessorFn for titleDisplay returns work title", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const col = columns.find((c) => c.id === "titleDisplay");
+    const accessorFn = (col as { accessorFn?: (row: LibraryEdition) => string }).accessorFn;
+    expect(accessorFn?.(makeEdition())).toBe("Test Book");
+  });
+
+  it("accessorFn for authors extracts authors", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const col = columns.find((c) => c.id === "authors");
+    const accessorFn = (col as { accessorFn?: (row: LibraryEdition) => string }).accessorFn;
+    expect(accessorFn?.(makeEdition())).toBe("Alice");
+  });
+
+  it("accessorFn for format returns formatFamily", () => {
+    const columns = getEditionColumns(false, mockRouter);
+    const col = columns.find((c) => c.id === "format");
+    const accessorFn = (col as { accessorFn?: (row: LibraryEdition) => string }).accessorFn;
+    expect(accessorFn?.(makeEdition())).toBe("EBOOK");
+  });
+});
+
+describe("edition columns rendering", () => {
+  it("renders all column cells for an ebook edition", () => {
+    render(<TestTable data={[makeEdition()]} />);
+    expect(screen.getByText("Test Book")).toBeTruthy();
+    expect(screen.getByText("Alice")).toBeTruthy();
+    expect(screen.getByText("EBOOK")).toBeTruthy();
+    expect(screen.getByText("Penguin")).toBeTruthy();
+    expect(screen.getByText("300 pages")).toBeTruthy();
+    expect(screen.getByText("Bob")).toBeTruthy();
+    expect(screen.getByText("9780123456789")).toBeTruthy();
+    expect(screen.getByText("0123456789")).toBeTruthy();
+    expect(screen.getByText("B01ABCDEFG")).toBeTruthy();
+  });
+
+  it("renders duration for audiobook edition", () => {
+    render(<TestTable data={[makeEdition({ formatFamily: "AUDIOBOOK", pageCount: null, duration: 36000 })]} />);
+    expect(screen.getByText("10h")).toBeTruthy();
+  });
+
+  it("renders em dash for null publisher", () => {
+    render(<TestTable data={[makeEdition({ publisher: null })]} />);
+    const cells = screen.getAllByText("\u2014");
+    expect(cells.length).toBeGreaterThan(0);
+  });
+
+  it("renders em dash for null isbn13, isbn10, asin", () => {
+    render(<TestTable data={[makeEdition({ isbn13: null, isbn10: null, asin: null })]} />);
+    // publisher is still "Penguin", publishedAt has a value, but isbn/asin should show dashes
+    const cells = screen.getAllByText("\u2014");
+    expect(cells.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("renders em dash for null publishedAt", () => {
+    render(<TestTable data={[makeEdition({ publishedAt: null })]} />);
+    const cells = screen.getAllByText("\u2014");
+    expect(cells.length).toBeGreaterThan(0);
+  });
+
+  it("select all checkbox toggles all rows", () => {
+    render(<TestTable data={[makeEdition()]} />);
+    const selectAll = screen.getByLabelText("Select all");
+    fireEvent.click(selectAll);
+    const rowCheckbox = screen.getByLabelText("Select row");
+    expect((rowCheckbox as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("select row checkbox toggles individual row", () => {
+    render(<TestTable data={[makeEdition()]} />);
+    const rowCheckbox = screen.getByLabelText("Select row");
+    fireEvent.click(rowCheckbox);
+    expect((rowCheckbox as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("renders column headers including ISBN and ASIN", () => {
+    render(<TestTable data={[makeEdition()]} />);
+    expect(screen.getByText("Title")).toBeTruthy();
+    expect(screen.getByText("Author(s)")).toBeTruthy();
+    expect(screen.getByText("Format")).toBeTruthy();
+    expect(screen.getByText("Publisher")).toBeTruthy();
+    expect(screen.getByText("Publish Date")).toBeTruthy();
+    expect(screen.getByText("Pages / Duration")).toBeTruthy();
+    expect(screen.getByText("Narrator(s)")).toBeTruthy();
+    expect(screen.getByText("ISBN-13")).toBeTruthy();
+    expect(screen.getByText("ISBN-10")).toBeTruthy();
+    expect(screen.getByText("ASIN")).toBeTruthy();
+  });
+
+  it("renders editable inputs when editMode is true", () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    // publisher, publishDate, pagesOrDuration, authors, narrators, isbn13, isbn10, asin = 8 inputs
+    expect(inputs.length).toBe(8);
+  });
+
+  it("editable publisher saves via updateEditionServerFn", async () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    // publisher is the 3rd editable field (after authors, then publisher)
+    const publisherInput = inputs.find((input) => (input as HTMLInputElement).value === "Penguin");
+    expect(publisherInput).toBeDefined();
+    fireEvent.change(publisherInput as HTMLInputElement, { target: { value: "New Press" } });
+    fireEvent.blur(publisherInput as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { publisher: "New Press" } },
+      });
+    });
+  });
+
+  it("editable isbn13 saves via updateEditionServerFn", async () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const isbn13Input = inputs.find((input) => (input as HTMLInputElement).value === "9780123456789");
+    expect(isbn13Input).toBeDefined();
+    fireEvent.change(isbn13Input as HTMLInputElement, { target: { value: "9780000000000" } });
+    fireEvent.blur(isbn13Input as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { isbn13: "9780000000000" } },
+      });
+    });
+  });
+
+  it("editable authors saves via updateWorkAuthorsServerFn", async () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const authorsInput = inputs.find((input) => (input as HTMLInputElement).value === "Alice");
+    expect(authorsInput).toBeDefined();
+    fireEvent.change(authorsInput as HTMLInputElement, { target: { value: "Alice, Charlie" } });
+    fireEvent.blur(authorsInput as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateWorkAuthorsServerFnMock).toHaveBeenCalledWith({
+        data: { workId: "w-1", authors: ["Alice", "Charlie"] },
+      });
+    });
+  });
+
+  it("editable narrators saves via updateEditionNarratorsServerFn", async () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const narratorsInput = inputs.find((input) => (input as HTMLInputElement).value === "Bob");
+    expect(narratorsInput).toBeDefined();
+    fireEvent.change(narratorsInput as HTMLInputElement, { target: { value: "Bob, Carol" } });
+    fireEvent.blur(narratorsInput as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionNarratorsServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", narrators: ["Bob", "Carol"] },
+      });
+    });
+  });
+
+  it("editable pagesOrDuration saves pageCount for ebooks", async () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const pagesInput = inputs.find((input) => (input as HTMLInputElement).value === "300");
+    expect(pagesInput).toBeDefined();
+    fireEvent.change(pagesInput as HTMLInputElement, { target: { value: "400" } });
+    fireEvent.blur(pagesInput as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { pageCount: "400" } },
+      });
+    });
+  });
+
+  it("editable isbn10 saves via updateEditionServerFn", async () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const isbn10Input = inputs.find((input) => (input as HTMLInputElement).value === "0123456789");
+    expect(isbn10Input).toBeDefined();
+    fireEvent.change(isbn10Input as HTMLInputElement, { target: { value: "0000000000" } });
+    fireEvent.blur(isbn10Input as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { isbn10: "0000000000" } },
+      });
+    });
+  });
+
+  it("editable asin saves via updateEditionServerFn", async () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const asinInput = inputs.find((input) => (input as HTMLInputElement).value === "B01ABCDEFG");
+    expect(asinInput).toBeDefined();
+    fireEvent.change(asinInput as HTMLInputElement, { target: { value: "B99ZZZZZZZ" } });
+    fireEvent.blur(asinInput as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { asin: "B99ZZZZZZZ" } },
+      });
+    });
+  });
+
+  it("editable publishDate saves via updateEditionServerFn", async () => {
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const dateInput = inputs.find((input) => (input as HTMLInputElement).value === "2024-01-15");
+    expect(dateInput).toBeDefined();
+    fireEvent.change(dateInput as HTMLInputElement, { target: { value: "2025-06-01" } });
+    fireEvent.blur(dateInput as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { publishedAt: "2025-06-01" } },
+      });
+    });
+  });
+
+  it("empty author save is a no-op", async () => {
+    updateWorkAuthorsServerFnMock.mockClear();
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const authorsInput = inputs.find((input) => (input as HTMLInputElement).value === "Alice");
+    expect(authorsInput).toBeDefined();
+    fireEvent.change(authorsInput as HTMLInputElement, { target: { value: "" } });
+    fireEvent.blur(authorsInput as HTMLInputElement);
+    // Small delay to ensure no async call was made
+    await new Promise((r) => { setTimeout(r, 50); });
+    expect(updateWorkAuthorsServerFnMock).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["Penguin", "publisher"],
+    ["9780123456789", "isbn13"],
+    ["0123456789", "isbn10"],
+    ["B01ABCDEFG", "asin"],
+    ["2024-01-15", "publishedAt"],
+  ] as const)("clearing %s sends null for %s", async (currentValue, field) => {
+    updateEditionServerFnMock.mockClear();
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const input = inputs.find((el) => (el as HTMLInputElement).value === currentValue);
+    expect(input).toBeDefined();
+    fireEvent.change(input as HTMLInputElement, { target: { value: "" } });
+    fireEvent.blur(input as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { [field]: null } },
+      });
+    });
+  });
+
+  it("renders empty inputs for null fields in edit mode", () => {
+    const edition = {
+      ...makeEdition({
+        isbn13: null, isbn10: null, asin: null, publisher: null, publishedAt: null,
+        pageCount: null, duration: null,
+        contributors: [],
+      }),
+      work: {
+        ...makeEdition().work,
+        editions: [{ ...makeEdition(), contributors: [] }],
+      },
+    } as LibraryEdition;
+    render(<TestTable data={[edition]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const emptyInputs = inputs.filter((el) => (el as HTMLInputElement).value === "");
+    // authors, publisher, publishDate, pageCount, narrators, isbn13, isbn10, asin = 8 empty
+    expect(emptyInputs.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it("renders empty duration input for audiobook with null duration in edit mode", () => {
+    const edition = makeEdition({ formatFamily: "AUDIOBOOK", duration: null, pageCount: null });
+    render(<TestTable data={[edition]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    // The duration field should be empty
+    const emptyInputs = inputs.filter((el) => (el as HTMLInputElement).value === "");
+    expect(emptyInputs.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("clearing pagesOrDuration sends null", async () => {
+    updateEditionServerFnMock.mockClear();
+    render(<TestTable data={[makeEdition()]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const pagesInput = inputs.find((el) => (el as HTMLInputElement).value === "300");
+    expect(pagesInput).toBeDefined();
+    fireEvent.change(pagesInput as HTMLInputElement, { target: { value: "" } });
+    fireEvent.blur(pagesInput as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { pageCount: null } },
+      });
+    });
+  });
+
+  it("editable pagesOrDuration saves duration for audiobooks", async () => {
+    render(<TestTable data={[makeEdition({ formatFamily: "AUDIOBOOK", pageCount: null, duration: 3600 })]} editMode={true} />);
+    const inputs = screen.getAllByRole("textbox");
+    const durationInput = inputs.find((input) => (input as HTMLInputElement).value === "3600");
+    expect(durationInput).toBeDefined();
+    fireEvent.change(durationInput as HTMLInputElement, { target: { value: "7200" } });
+    fireEvent.blur(durationInput as HTMLInputElement);
+    await vi.waitFor(() => {
+      expect(updateEditionServerFnMock).toHaveBeenCalledWith({
+        data: { editionId: "e-1", fields: { duration: "7200" } },
+      });
+    });
+  });
+});
+
+describe("EDITION_COLUMN_PICKER_ITEMS", () => {
+  it("lists all optional columns", () => {
+    const ids = EDITION_COLUMN_PICKER_ITEMS.map((item) => item.id);
+    expect(ids).toEqual([
+      "authors",
+      "format",
+      "publisher",
+      "publishDate",
+      "pagesOrDuration",
+      "narrators",
+      "isbn13",
+      "isbn10",
+      "asin",
+    ]);
+  });
+});

--- a/apps/web/src/lib/library-edition-columns.tsx
+++ b/apps/web/src/lib/library-edition-columns.tsx
@@ -1,0 +1,332 @@
+import type { ColumnDef } from "@tanstack/react-table";
+import { Link } from "@tanstack/react-router";
+import { Badge } from "~/components/ui/badge";
+import { DataTableColumnHeader } from "~/components/data-table";
+import { EditableTableCell } from "~/components/editable-table-cell";
+import { formatDuration } from "~/components/enrichment-dialog";
+import { updateEditionServerFn, updateWorkAuthorsServerFn, updateEditionNarratorsServerFn } from "~/lib/server-fns/editing";
+import type { LibraryEdition } from "~/lib/server-fns/library";
+
+type ContributorEdition = {
+  contributors: { role: string; contributor: { nameDisplay: string } }[];
+};
+
+type EditionWithWorkAuthors = ContributorEdition & {
+  work: {
+    editions: {
+      contributors: { role: string; contributor: { nameDisplay: string } }[];
+    }[];
+  };
+};
+
+export function getEditionAuthors(edition: EditionWithWorkAuthors): string {
+  // Aggregate authors from ALL editions of the work (same as Works view)
+  const authors = edition.work.editions
+    .flatMap((e) => e.contributors)
+    .filter((c) => c.role === "AUTHOR")
+    .map((c) => c.contributor.nameDisplay);
+  return [...new Set(authors)].join(", ") || "\u2014";
+}
+
+export function getEditionNarrators(edition: ContributorEdition): string {
+  const narrators = edition.contributors
+    .filter((c) => c.role === "NARRATOR")
+    .map((c) => c.contributor.nameDisplay);
+  return narrators.length > 0 ? narrators.join(", ") : "\u2014";
+}
+
+export function formatPagesOrDuration(
+  formatFamily: string,
+  pageCount: number | null,
+  duration: number | null,
+): string {
+  if (formatFamily === "AUDIOBOOK") {
+    return duration != null ? formatDuration(duration) : "\u2014";
+  }
+  if (pageCount != null) {
+    return pageCount === 1 ? "1 page" : `${String(pageCount)} pages`;
+  }
+  return "\u2014";
+}
+
+export const EDITION_COLUMN_PICKER_ITEMS = [
+  { id: "authors", label: "Author(s)" },
+  { id: "format", label: "Format" },
+  { id: "publisher", label: "Publisher" },
+  { id: "publishDate", label: "Publish Date" },
+  { id: "pagesOrDuration", label: "Pages / Duration" },
+  { id: "narrators", label: "Narrator(s)" },
+  { id: "isbn13", label: "ISBN-13" },
+  { id: "isbn10", label: "ISBN-10" },
+  { id: "asin", label: "ASIN" },
+];
+
+export function getEditionColumns(editMode: boolean, router: { invalidate: () => void }): ColumnDef<LibraryEdition>[] {
+  return [
+    {
+      id: "select",
+      header: ({ table }) => (
+        <input
+          type="checkbox"
+          checked={table.getIsAllPageRowsSelected()}
+          onChange={(e) => { table.toggleAllPageRowsSelected(e.target.checked); }}
+          aria-label="Select all"
+        />
+      ),
+      cell: ({ row }) => (
+        <input
+          type="checkbox"
+          checked={row.getIsSelected()}
+          onChange={(e) => { row.toggleSelected(e.target.checked); }}
+          aria-label="Select row"
+        />
+      ),
+      size: 40,
+      enableSorting: false,
+      enableHiding: false,
+    },
+    {
+      id: "titleDisplay",
+      accessorFn: (row) => row.work.titleDisplay,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Title" />
+      ),
+      cell: ({ row }) => (
+        <Link
+          to="/library/$workId"
+          params={{ workId: row.original.workId }}
+          search={{ page: 1, pageSize: 50, sort: "title-asc" as const }}
+          className="flex items-center gap-2"
+        >
+          {row.original.work.titleDisplay}
+        </Link>
+      ),
+      size: 300,
+      enableHiding: false,
+    },
+    {
+      id: "authors",
+      accessorFn: (row) => getEditionAuthors(row),
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Author(s)" />
+      ),
+      cell: ({ row }) => {
+        const authorsStr = getEditionAuthors(row.original);
+        if (editMode) {
+          return (
+            <EditableTableCell
+              value={authorsStr === "\u2014" ? "" : authorsStr}
+              editing={true}
+              onSave={async (val) => {
+                const authors = val.split(",").map((a) => a.trim()).filter((a) => a.length > 0);
+                if (authors.length === 0) return;
+                await updateWorkAuthorsServerFn({ data: { workId: row.original.workId, authors } });
+                router.invalidate();
+              }}
+            />
+          );
+        }
+        return <span>{authorsStr}</span>;
+      },
+      size: 200,
+    },
+    {
+      id: "format",
+      accessorFn: (row) => row.formatFamily,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Format" />
+      ),
+      cell: ({ row }) => (
+        <Badge variant="secondary" className="px-1.5 py-0 text-[10px]">
+          {row.original.formatFamily}
+        </Badge>
+      ),
+      size: 120,
+    },
+    {
+      id: "publisher",
+      accessorFn: (row) => row.publisher ?? "\u2014",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Publisher" />
+      ),
+      cell: ({ row }) => {
+        if (editMode) {
+          return (
+            <EditableTableCell
+              value={row.original.publisher ?? ""}
+              editing={true}
+              onSave={async (val) => {
+                await updateEditionServerFn({ data: { editionId: row.original.id, fields: { publisher: val || null } } });
+                router.invalidate();
+              }}
+            />
+          );
+        }
+        return <span>{row.original.publisher ?? "\u2014"}</span>;
+      },
+      size: 180,
+    },
+    {
+      id: "publishDate",
+      accessorFn: (row) => row.publishedAt,
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Publish Date" />
+      ),
+      cell: ({ row }) => {
+        if (editMode) {
+          const dateStr = row.original.publishedAt
+            ? new Date(row.original.publishedAt).toISOString().slice(0, 10)
+            : "";
+          return (
+            <EditableTableCell
+              value={dateStr}
+              editing={true}
+              onSave={async (val) => {
+                await updateEditionServerFn({ data: { editionId: row.original.id, fields: { publishedAt: val || null } } });
+                router.invalidate();
+              }}
+            />
+          );
+        }
+        return (
+          <span>
+            {row.original.publishedAt
+              ? new Date(row.original.publishedAt).toLocaleDateString()
+              : "\u2014"}
+          </span>
+        );
+      },
+      size: 130,
+    },
+    {
+      id: "pagesOrDuration",
+      accessorFn: (row) => formatPagesOrDuration(row.formatFamily, row.pageCount, row.duration),
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Pages / Duration" />
+      ),
+      cell: ({ row }) => {
+        if (editMode) {
+          const isAudiobook = row.original.formatFamily === "AUDIOBOOK";
+          const rawVal = isAudiobook
+            ? (row.original.duration != null ? String(row.original.duration) : "")
+            : (row.original.pageCount != null ? String(row.original.pageCount) : "");
+          const field = isAudiobook ? "duration" : "pageCount";
+          return (
+            <EditableTableCell
+              value={rawVal}
+              editing={true}
+              onSave={async (val) => {
+                await updateEditionServerFn({ data: { editionId: row.original.id, fields: { [field]: val || null } } });
+                router.invalidate();
+              }}
+            />
+          );
+        }
+        return (
+          <span>
+            {formatPagesOrDuration(
+              row.original.formatFamily,
+              row.original.pageCount,
+              row.original.duration,
+            )}
+          </span>
+        );
+      },
+      size: 140,
+    },
+    {
+      id: "narrators",
+      accessorFn: (row) => getEditionNarrators(row),
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="Narrator(s)" />
+      ),
+      cell: ({ row }) => {
+        const narratorsStr = getEditionNarrators(row.original);
+        if (editMode) {
+          return (
+            <EditableTableCell
+              value={narratorsStr === "\u2014" ? "" : narratorsStr}
+              editing={true}
+              onSave={async (val) => {
+                const narrators = val.split(",").map((a) => a.trim()).filter((a) => a.length > 0);
+                await updateEditionNarratorsServerFn({ data: { editionId: row.original.id, narrators } });
+                router.invalidate();
+              }}
+            />
+          );
+        }
+        return <span>{narratorsStr}</span>;
+      },
+      size: 180,
+    },
+    {
+      id: "isbn13",
+      accessorFn: (row) => row.isbn13 ?? "\u2014",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ISBN-13" />
+      ),
+      cell: ({ row }) => {
+        if (editMode) {
+          return (
+            <EditableTableCell
+              value={row.original.isbn13 ?? ""}
+              editing={true}
+              onSave={async (val) => {
+                await updateEditionServerFn({ data: { editionId: row.original.id, fields: { isbn13: val || null } } });
+                router.invalidate();
+              }}
+            />
+          );
+        }
+        return <span>{row.original.isbn13 ?? "\u2014"}</span>;
+      },
+      size: 150,
+    },
+    {
+      id: "isbn10",
+      accessorFn: (row) => row.isbn10 ?? "\u2014",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ISBN-10" />
+      ),
+      cell: ({ row }) => {
+        if (editMode) {
+          return (
+            <EditableTableCell
+              value={row.original.isbn10 ?? ""}
+              editing={true}
+              onSave={async (val) => {
+                await updateEditionServerFn({ data: { editionId: row.original.id, fields: { isbn10: val || null } } });
+                router.invalidate();
+              }}
+            />
+          );
+        }
+        return <span>{row.original.isbn10 ?? "\u2014"}</span>;
+      },
+      size: 130,
+    },
+    {
+      id: "asin",
+      accessorFn: (row) => row.asin ?? "\u2014",
+      header: ({ column }) => (
+        <DataTableColumnHeader column={column} title="ASIN" />
+      ),
+      cell: ({ row }) => {
+        if (editMode) {
+          return (
+            <EditableTableCell
+              value={row.original.asin ?? ""}
+              editing={true}
+              onSave={async (val) => {
+                await updateEditionServerFn({ data: { editionId: row.original.id, fields: { asin: val || null } } });
+                router.invalidate();
+              }}
+            />
+          );
+        }
+        return <span>{row.original.asin ?? "\u2014"}</span>;
+      },
+      size: 130,
+    },
+  ];
+}

--- a/apps/web/src/lib/library-edition-filter-helpers.test.ts
+++ b/apps/web/src/lib/library-edition-filter-helpers.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from "vitest";
+import { columnSortToParam } from "./library-filter-helpers";
+import {
+  EDITION_COLUMN_SORT_MAP,
+  EDITION_SORT_TO_COLUMN,
+} from "./library-edition-filter-helpers";
+
+describe("EDITION_COLUMN_SORT_MAP", () => {
+  it("maps titleDisplay to title-asc/title-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.titleDisplay).toEqual({ asc: "title-asc", desc: "title-desc" });
+  });
+
+  it("maps authors to author-asc/author-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.authors).toEqual({ asc: "author-asc", desc: "author-desc" });
+  });
+
+  it("maps format to format-asc/format-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.format).toEqual({ asc: "format-asc", desc: "format-desc" });
+  });
+
+  it("maps publisher to publisher-asc/publisher-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.publisher).toEqual({ asc: "publisher-asc", desc: "publisher-desc" });
+  });
+
+  it("maps publishDate to publishDate-asc/publishDate-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.publishDate).toEqual({ asc: "publishDate-asc", desc: "publishDate-desc" });
+  });
+
+  it("maps pagesOrDuration to pageCount-asc/pageCount-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.pagesOrDuration).toEqual({ asc: "pageCount-asc", desc: "pageCount-desc" });
+  });
+
+  it("maps narrators to narrator-asc/narrator-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.narrators).toEqual({ asc: "narrator-asc", desc: "narrator-desc" });
+  });
+
+  it("maps isbn13 to isbn13-asc/isbn13-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.isbn13).toEqual({ asc: "isbn13-asc", desc: "isbn13-desc" });
+  });
+
+  it("maps isbn10 to isbn10-asc/isbn10-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.isbn10).toEqual({ asc: "isbn10-asc", desc: "isbn10-desc" });
+  });
+
+  it("maps asin to asin-asc/asin-desc", () => {
+    expect(EDITION_COLUMN_SORT_MAP.asin).toEqual({ asc: "asin-asc", desc: "asin-desc" });
+  });
+});
+
+describe("EDITION_SORT_TO_COLUMN", () => {
+  it.each([
+    ["title-asc", { id: "titleDisplay", desc: false }],
+    ["title-desc", { id: "titleDisplay", desc: true }],
+    ["author-asc", { id: "authors", desc: false }],
+    ["author-desc", { id: "authors", desc: true }],
+    ["format-asc", { id: "format", desc: false }],
+    ["format-desc", { id: "format", desc: true }],
+    ["publisher-asc", { id: "publisher", desc: false }],
+    ["publisher-desc", { id: "publisher", desc: true }],
+    ["publishDate-asc", { id: "publishDate", desc: false }],
+    ["publishDate-desc", { id: "publishDate", desc: true }],
+    ["pageCount-asc", { id: "pagesOrDuration", desc: false }],
+    ["pageCount-desc", { id: "pagesOrDuration", desc: true }],
+    ["narrator-asc", { id: "narrators", desc: false }],
+    ["narrator-desc", { id: "narrators", desc: true }],
+    ["isbn13-asc", { id: "isbn13", desc: false }],
+    ["isbn13-desc", { id: "isbn13", desc: true }],
+    ["isbn10-asc", { id: "isbn10", desc: false }],
+    ["isbn10-desc", { id: "isbn10", desc: true }],
+    ["asin-asc", { id: "asin", desc: false }],
+    ["asin-desc", { id: "asin", desc: true }],
+  ] as const)("maps %s correctly", (sortKey, expected) => {
+    expect(EDITION_SORT_TO_COLUMN[sortKey]).toEqual(expected);
+  });
+});
+
+describe("columnSortToParam with EDITION_COLUMN_SORT_MAP", () => {
+  it("returns publisher-desc for publisher descending", () => {
+    expect(
+      columnSortToParam([{ id: "publisher", desc: true }], EDITION_COLUMN_SORT_MAP),
+    ).toBe("publisher-desc");
+  });
+
+  it("returns narrator-asc for narrators ascending", () => {
+    expect(
+      columnSortToParam([{ id: "narrators", desc: false }], EDITION_COLUMN_SORT_MAP),
+    ).toBe("narrator-asc");
+  });
+});

--- a/apps/web/src/lib/library-edition-filter-helpers.ts
+++ b/apps/web/src/lib/library-edition-filter-helpers.ts
@@ -1,0 +1,37 @@
+import type { LibrarySearchParams } from "~/lib/library-search-schema";
+
+export const EDITION_COLUMN_SORT_MAP: Record<string, { asc: LibrarySearchParams["sort"]; desc: LibrarySearchParams["sort"] }> = {
+  titleDisplay: { asc: "title-asc", desc: "title-desc" },
+  authors: { asc: "author-asc", desc: "author-desc" },
+  format: { asc: "format-asc", desc: "format-desc" },
+  publisher: { asc: "publisher-asc", desc: "publisher-desc" },
+  publishDate: { asc: "publishDate-asc", desc: "publishDate-desc" },
+  pagesOrDuration: { asc: "pageCount-asc", desc: "pageCount-desc" },
+  narrators: { asc: "narrator-asc", desc: "narrator-desc" },
+  isbn13: { asc: "isbn13-asc", desc: "isbn13-desc" },
+  isbn10: { asc: "isbn10-asc", desc: "isbn10-desc" },
+  asin: { asc: "asin-asc", desc: "asin-desc" },
+};
+
+export const EDITION_SORT_TO_COLUMN: Record<string, { id: string; desc: boolean }> = {
+  "title-asc": { id: "titleDisplay", desc: false },
+  "title-desc": { id: "titleDisplay", desc: true },
+  "author-asc": { id: "authors", desc: false },
+  "author-desc": { id: "authors", desc: true },
+  "format-asc": { id: "format", desc: false },
+  "format-desc": { id: "format", desc: true },
+  "publisher-asc": { id: "publisher", desc: false },
+  "publisher-desc": { id: "publisher", desc: true },
+  "publishDate-asc": { id: "publishDate", desc: false },
+  "publishDate-desc": { id: "publishDate", desc: true },
+  "pageCount-asc": { id: "pagesOrDuration", desc: false },
+  "pageCount-desc": { id: "pagesOrDuration", desc: true },
+  "narrator-asc": { id: "narrators", desc: false },
+  "narrator-desc": { id: "narrators", desc: true },
+  "isbn13-asc": { id: "isbn13", desc: false },
+  "isbn13-desc": { id: "isbn13", desc: true },
+  "isbn10-asc": { id: "isbn10", desc: false },
+  "isbn10-desc": { id: "isbn10", desc: true },
+  "asin-asc": { id: "asin", desc: false },
+  "asin-desc": { id: "asin", desc: true },
+};

--- a/apps/web/src/lib/library-search-schema.test.ts
+++ b/apps/web/src/lib/library-search-schema.test.ts
@@ -8,6 +8,7 @@ describe("librarySearchSchema", () => {
       page: 1,
       pageSize: 50,
       sort: "title-asc",
+      view: "works",
     });
   });
 
@@ -82,5 +83,33 @@ describe("librarySearchSchema", () => {
 
   it("rejects invalid format values", () => {
     expect(() => librarySearchSchema.parse({ format: ["INVALID"] })).toThrow();
+  });
+
+  it("defaults view to works", () => {
+    const result = librarySearchSchema.parse({});
+    expect(result.view).toBe("works");
+  });
+
+  it("parses view=editions", () => {
+    const result = librarySearchSchema.parse({ view: "editions" });
+    expect(result.view).toBe("editions");
+  });
+
+  it("rejects invalid view values", () => {
+    expect(() => librarySearchSchema.parse({ view: "invalid" })).toThrow();
+  });
+
+  it.each([
+    "publisher-asc", "publisher-desc",
+    "publishDate-asc", "publishDate-desc",
+    "pageCount-asc", "pageCount-desc",
+    "duration-asc", "duration-desc",
+    "narrator-asc", "narrator-desc",
+    "isbn13-asc", "isbn13-desc",
+    "isbn10-asc", "isbn10-desc",
+    "asin-asc", "asin-desc",
+  ])("parses edition sort value %s", (sort) => {
+    const result = librarySearchSchema.parse({ sort });
+    expect(result.sort).toBe(sort);
   });
 });

--- a/apps/web/src/lib/library-search-schema.ts
+++ b/apps/web/src/lib/library-search-schema.ts
@@ -14,11 +14,27 @@ const coerceBool = z.preprocess((val) => {
   return val;
 }, z.boolean().optional());
 
+export const SORT_OPTIONS = [
+  "title-asc", "title-desc",
+  "author-asc", "author-desc",
+  "format-asc", "format-desc",
+  "recent",
+  "publisher-asc", "publisher-desc",
+  "publishDate-asc", "publishDate-desc",
+  "pageCount-asc", "pageCount-desc",
+  "duration-asc", "duration-desc",
+  "narrator-asc", "narrator-desc",
+  "isbn13-asc", "isbn13-desc",
+  "isbn10-asc", "isbn10-desc",
+  "asin-asc", "asin-desc",
+] as const;
+
 export const librarySearchSchema = z
   .object({
     page: z.coerce.number().int().min(1).default(1),
     pageSize: z.coerce.number().int().min(1).max(100).default(50),
-    sort: z.enum(["title-asc", "title-desc", "author-asc", "author-desc", "format-asc", "format-desc", "recent"]).default("title-asc"),
+    sort: z.enum(SORT_OPTIONS).default("title-asc"),
+    view: z.enum(["works", "editions"]).default("works"),
     q: z.string().optional(),
     format: coerceToArray(z.enum(["EBOOK", "AUDIOBOOK"])),
     authorId: coerceToArray(z.string()),

--- a/apps/web/src/lib/server-fns/library.test.ts
+++ b/apps/web/src/lib/server-fns/library.test.ts
@@ -17,11 +17,13 @@ vi.mock("@tanstack/react-start", () => ({
 const findManyMock = vi.fn();
 const countMock = vi.fn();
 const editionGroupByMock = vi.fn();
+const editionFindManyMock = vi.fn();
+const editionCountMock = vi.fn();
 
 vi.mock("@bookhouse/db", () => ({
   db: {
     work: { findMany: findManyMock, count: countMock },
-    edition: { groupBy: editionGroupByMock },
+    edition: { groupBy: editionGroupByMock, findMany: editionFindManyMock, count: editionCountMock },
   },
 }));
 
@@ -29,6 +31,7 @@ import {
   getLibraryWorksServerFn,
   getFilteredLibraryWorksServerFn,
   getAllFilteredWorkIdsServerFn,
+  getFilteredLibraryEditionsServerFn,
 } from "./library";
 
 describe("getLibraryWorksServerFn", () => {
@@ -917,5 +920,496 @@ describe("getAllFilteredWorkIdsServerFn", () => {
 
     const call = findManyMock.mock.calls[0] as [{ where: Record<string, string> }];
     expect(call[0].where).toBeTruthy();
+  });
+});
+
+describe("getFilteredLibraryEditionsServerFn", () => {
+  beforeEach(() => {
+    editionFindManyMock.mockReset();
+    editionCountMock.mockReset();
+  });
+
+  it("returns paginated editions with defaults", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    const result = await getFilteredLibraryEditionsServerFn({ data: {} });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        skip: 0,
+        take: 50,
+        orderBy: { work: { titleCanonical: "asc" } },
+      }),
+    );
+    expect(result).toEqual({ editions: [], totalCount: 0 });
+  });
+
+  it("applies page and pageSize", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(100);
+    await getFilteredLibraryEditionsServerFn({ data: { page: 3, pageSize: 20 } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ skip: 40, take: 20 }),
+    );
+  });
+
+  it("sorts by title-desc via nested work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "title-desc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { work: { titleCanonical: "desc" } } }),
+    );
+  });
+
+  it("sorts by publisher-asc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "publisher-asc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { publisher: "asc" } }),
+    );
+  });
+
+  it("sorts by publisher-desc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "publisher-desc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { publisher: "desc" } }),
+    );
+  });
+
+  it("sorts by publishDate-asc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "publishDate-asc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { publishedAt: "asc" } }),
+    );
+  });
+
+  it("sorts by publishDate-desc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "publishDate-desc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { publishedAt: "desc" } }),
+    );
+  });
+
+  it("sorts by pageCount-asc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "pageCount-asc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { pageCount: "asc" } }),
+    );
+  });
+
+  it("sorts by duration-desc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "duration-desc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { duration: "desc" } }),
+    );
+  });
+
+  it("sorts by format-asc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "format-asc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { formatFamily: "asc" } }),
+    );
+  });
+
+  it("sorts by recent", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "recent" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { createdAt: "desc" } }),
+    );
+  });
+
+  it("sorts by author-asc using two-step approach", async () => {
+    const lightweightEditions = [
+      { id: "e-b", contributors: [{ contributor: { nameCanonical: "bravo" } }] },
+      { id: "e-a", contributors: [{ contributor: { nameCanonical: "alpha" } }] },
+    ];
+    editionFindManyMock
+      .mockResolvedValueOnce(lightweightEditions)
+      .mockResolvedValueOnce([{ id: "e-a" }, { id: "e-b" }]);
+    editionCountMock.mockResolvedValue(2);
+    const result = await getFilteredLibraryEditionsServerFn({ data: { sort: "author-asc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledTimes(2);
+    const secondCall = (editionFindManyMock.mock.calls[1] as [{ where: { id: { in: string[] } } }])[0];
+    expect(secondCall.where.id.in).toEqual(["e-a", "e-b"]);
+    expect(result.editions.map((e: { id: string }) => e.id)).toEqual(["e-a", "e-b"]);
+  });
+
+  it("sorts by narrator-asc using two-step approach", async () => {
+    const lightweightEditions = [
+      { id: "e-b", contributors: [{ contributor: { nameCanonical: "zach" } }] },
+      { id: "e-a", contributors: [{ contributor: { nameCanonical: "anna" } }] },
+    ];
+    editionFindManyMock
+      .mockResolvedValueOnce(lightweightEditions)
+      .mockResolvedValueOnce([{ id: "e-a" }, { id: "e-b" }]);
+    editionCountMock.mockResolvedValue(2);
+    const result = await getFilteredLibraryEditionsServerFn({ data: { sort: "narrator-asc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledTimes(2);
+    const secondCall = (editionFindManyMock.mock.calls[1] as [{ where: { id: { in: string[] } } }])[0];
+    expect(secondCall.where.id.in).toEqual(["e-a", "e-b"]);
+    expect(result.editions.map((e: { id: string }) => e.id)).toEqual(["e-a", "e-b"]);
+  });
+
+  it("sorts by author-desc with data", async () => {
+    const lightweightEditions = [
+      { id: "e-a", contributors: [{ contributor: { nameCanonical: "alpha" } }] },
+      { id: "e-b", contributors: [{ contributor: { nameCanonical: "bravo" } }] },
+    ];
+    editionFindManyMock
+      .mockResolvedValueOnce(lightweightEditions)
+      .mockResolvedValueOnce([{ id: "e-b" }, { id: "e-a" }]);
+    editionCountMock.mockResolvedValue(2);
+    const result = await getFilteredLibraryEditionsServerFn({ data: { sort: "author-desc" } });
+
+    const secondCall = (editionFindManyMock.mock.calls[1] as [{ where: { id: { in: string[] } } }])[0];
+    expect(secondCall.where.id.in).toEqual(["e-b", "e-a"]);
+    expect(result.editions.map((e: { id: string }) => e.id)).toEqual(["e-b", "e-a"]);
+  });
+
+  it("sorts by narrator-desc with data", async () => {
+    const lightweightEditions = [
+      { id: "e-a", contributors: [{ contributor: { nameCanonical: "alpha" } }] },
+      { id: "e-b", contributors: [{ contributor: { nameCanonical: "bravo" } }] },
+    ];
+    editionFindManyMock
+      .mockResolvedValueOnce(lightweightEditions)
+      .mockResolvedValueOnce([{ id: "e-b" }, { id: "e-a" }]);
+    editionCountMock.mockResolvedValue(2);
+    const result = await getFilteredLibraryEditionsServerFn({ data: { sort: "narrator-desc" } });
+
+    const secondCall = (editionFindManyMock.mock.calls[1] as [{ where: { id: { in: string[] } } }])[0];
+    expect(secondCall.where.id.in).toEqual(["e-b", "e-a"]);
+    expect(result.editions.map((e: { id: string }) => e.id)).toEqual(["e-b", "e-a"]);
+  });
+
+  it("editions with no contributors sort last", async () => {
+    const lightweightEditions = [
+      { id: "e-none", contributors: [] },
+      { id: "e-a", contributors: [{ contributor: { nameCanonical: "alpha" } }] },
+    ];
+    editionFindManyMock
+      .mockResolvedValueOnce(lightweightEditions)
+      .mockResolvedValueOnce([{ id: "e-a" }, { id: "e-none" }]);
+    editionCountMock.mockResolvedValue(2);
+    const result = await getFilteredLibraryEditionsServerFn({ data: { sort: "author-asc" } });
+
+    const secondCall = (editionFindManyMock.mock.calls[1] as [{ where: { id: { in: string[] } } }])[0];
+    expect(secondCall.where.id.in).toEqual(["e-a", "e-none"]);
+    expect(result.editions.map((e: { id: string }) => e.id)).toEqual(["e-a", "e-none"]);
+  });
+
+  it("includes correct relations", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: {} });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        include: {
+          work: {
+            include: {
+              series: true,
+              editions: {
+                include: {
+                  contributors: {
+                    where: { role: "AUTHOR" },
+                    include: { contributor: true },
+                  },
+                },
+              },
+            },
+          },
+          contributors: { include: { contributor: true } },
+        },
+      }),
+    );
+  });
+
+  it("filters by text query via work title", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { q: "hobbit" } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        work: expect.objectContaining({
+          OR: [
+            { titleDisplay: { contains: "hobbit", mode: "insensitive" } },
+            { titleCanonical: { contains: "hobbit", mode: "insensitive" } },
+          ],
+        }) as object,
+      }),
+    );
+  });
+
+  it("filters by format directly on edition", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { format: ["EBOOK"] } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        formatFamily: { in: ["EBOOK"] },
+      }),
+    );
+  });
+
+  it("filters by authorId via contributors", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { authorId: ["author-1"] } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        contributors: {
+          some: {
+            contributorId: { in: ["author-1"] },
+            role: "AUTHOR",
+          },
+        },
+      }),
+    );
+  });
+
+  it("filters by seriesId via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { seriesId: ["series-1"] } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        work: expect.objectContaining({
+          seriesId: { in: ["series-1"] },
+        }) as object,
+      }),
+    );
+  });
+
+  it("filters by hasCover via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { hasCover: true } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        work: expect.objectContaining({
+          coverPath: { not: null },
+        }) as object,
+      }),
+    );
+  });
+
+  it("always includes availability filter", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: {} });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(
+      expect.objectContaining({
+        editionFiles: {
+          some: {
+            fileAsset: { availabilityStatus: "PRESENT", mediaKind: { notIn: ["KEPUB", "COVER", "SIDECAR"] } },
+          },
+        },
+      }),
+    );
+  });
+
+  it("passes same where to count as to findMany", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(5);
+    await getFilteredLibraryEditionsServerFn({ data: { format: ["AUDIOBOOK"] } });
+
+    const findManyWhere = (editionFindManyMock.mock.calls[0] as [{ where: object }])[0].where;
+    expect(editionCountMock).toHaveBeenCalledWith({ where: findManyWhere });
+  });
+
+  it("returns empty editions when two-step sort has no results", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    const result = await getFilteredLibraryEditionsServerFn({ data: { sort: "author-asc" } });
+
+    expect(result.editions).toEqual([]);
+    expect(result.totalCount).toBe(0);
+  });
+
+  it("sorts by pageCount-desc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "pageCount-desc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { pageCount: "desc" } }),
+    );
+  });
+
+  it("sorts by duration-asc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "duration-asc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { duration: "asc" } }),
+    );
+  });
+
+  it("sorts by format-desc", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort: "format-desc" } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: { formatFamily: "desc" } }),
+    );
+  });
+
+  it.each([
+    ["isbn13-asc", { isbn13: "asc" }],
+    ["isbn13-desc", { isbn13: "desc" }],
+    ["isbn10-asc", { isbn10: "asc" }],
+    ["isbn10-desc", { isbn10: "desc" }],
+    ["asin-asc", { asin: "asc" }],
+    ["asin-desc", { asin: "desc" }],
+  ] as const)("sorts by %s", async (sort, expectedOrderBy) => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { sort } });
+
+    expect(editionFindManyMock).toHaveBeenCalledWith(
+      expect.objectContaining({ orderBy: expectedOrderBy }),
+    );
+  });
+
+  it("filters by enriched true via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { enriched: true } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(expect.objectContaining({
+      work: expect.objectContaining({ enrichmentStatus: "ENRICHED" }) as object,
+    }));
+  });
+
+  it("filters by enriched false via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { enriched: false } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(expect.objectContaining({
+      work: expect.objectContaining({ enrichmentStatus: "STUB" }) as object,
+    }));
+  });
+
+  it("filters by hasDescription true via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { hasDescription: true } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(expect.objectContaining({
+      work: expect.objectContaining({ description: { not: null } }) as object,
+    }));
+  });
+
+  it("filters by hasDescription false via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { hasDescription: false } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(expect.objectContaining({
+      work: expect.objectContaining({ description: null }) as object,
+    }));
+  });
+
+  it("filters by inSeries true via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { inSeries: true } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(expect.objectContaining({
+      work: expect.objectContaining({ seriesId: { not: null } }) as object,
+    }));
+  });
+
+  it("filters by inSeries false via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { inSeries: false } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(expect.objectContaining({
+      work: expect.objectContaining({ seriesId: null }) as object,
+    }));
+  });
+
+  it("filters by hasCover false via work", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({ data: { hasCover: false } });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where).toEqual(expect.objectContaining({
+      work: expect.objectContaining({ coverPath: null }) as object,
+    }));
+  });
+
+  it("combines multiple work-level filters with AND", async () => {
+    editionFindManyMock.mockResolvedValue([]);
+    editionCountMock.mockResolvedValue(0);
+    await getFilteredLibraryEditionsServerFn({
+      data: { q: "test", hasCover: true, seriesId: ["s-1"] },
+    });
+
+    const call = (editionFindManyMock.mock.calls[0] as [{ where: Record<string, object> }])[0];
+    expect(call.where.work).toEqual(
+      expect.objectContaining({
+        AND: expect.arrayContaining([
+          expect.objectContaining({
+            OR: [
+              { titleDisplay: { contains: "test", mode: "insensitive" } },
+              { titleCanonical: { contains: "test", mode: "insensitive" } },
+            ],
+          }),
+        ]) as object[],
+      }),
+    );
   });
 });

--- a/apps/web/src/lib/server-fns/library.ts
+++ b/apps/web/src/lib/server-fns/library.ts
@@ -1,6 +1,7 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 import type { Prisma } from "@bookhouse/db";
+import { SORT_OPTIONS } from "~/lib/library-search-schema";
 
 const FORMAT_FAMILIES = ["EBOOK", "AUDIOBOOK"] as const;
 
@@ -56,7 +57,7 @@ export type LibraryWork = Awaited<
 const filterSchema = z.object({
   page: z.number().int().min(1).default(1),
   pageSize: z.number().int().min(1).max(100).default(50),
-  sort: z.enum(["title-asc", "title-desc", "author-asc", "author-desc", "format-asc", "format-desc", "recent"]).default("title-asc"),
+  sort: z.enum(SORT_OPTIONS).default("title-asc"),
   q: z.string().optional(),
   format: z.array(z.enum(["EBOOK", "AUDIOBOOK"])).optional(),
   authorId: z.array(z.string()).optional(),
@@ -366,6 +367,252 @@ export const getFilteredLibraryWorksServerFn = createServerFn({
 export type FilteredLibraryResult = Awaited<
   ReturnType<typeof getFilteredLibraryWorksServerFn>
 >;
+
+// ---------- Editions view ----------
+
+const EDITION_VIEW_INCLUDE = {
+  work: {
+    include: {
+      series: true,
+      editions: {
+        include: {
+          contributors: {
+            where: { role: "AUTHOR" as const },
+            include: { contributor: true },
+          },
+        },
+      },
+    },
+  },
+  contributors: { include: { contributor: true } },
+} as const;
+
+function buildEditionWhere(data: z.infer<typeof filterSchema>): Prisma.EditionWhereInput {
+  const where: Prisma.EditionWhereInput = {};
+  const workConditions: Prisma.WorkWhereInput[] = [];
+
+  if (data.q) {
+    workConditions.push({
+      OR: [
+        { titleDisplay: { contains: data.q, mode: "insensitive" } },
+        { titleCanonical: { contains: data.q, mode: "insensitive" } },
+      ],
+    });
+  }
+
+  if (data.format && data.format.length > 0) {
+    where.formatFamily = { in: data.format };
+  }
+
+  if (data.authorId && data.authorId.length > 0) {
+    where.contributors = {
+      some: {
+        contributorId: { in: data.authorId },
+        role: "AUTHOR",
+      },
+    };
+  }
+
+  if (data.seriesId && data.seriesId.length > 0) {
+    workConditions.push({ seriesId: { in: data.seriesId } });
+  }
+
+  if (data.hasCover === true) {
+    workConditions.push({ coverPath: { not: null } });
+  } else if (data.hasCover === false) {
+    workConditions.push({ coverPath: null });
+  }
+
+  if (data.enriched === true) {
+    workConditions.push({ enrichmentStatus: "ENRICHED" });
+  } else if (data.enriched === false) {
+    workConditions.push({ enrichmentStatus: "STUB" });
+  }
+
+  if (data.hasDescription === true) {
+    workConditions.push({ description: { not: null } });
+  } else if (data.hasDescription === false) {
+    workConditions.push({ description: null });
+  }
+
+  if (data.inSeries === true) {
+    workConditions.push({ seriesId: { not: null } });
+  } else if (data.inSeries === false) {
+    workConditions.push({ seriesId: null });
+  }
+
+  if (workConditions.length === 1) {
+    where.work = workConditions[0];
+  } else if (workConditions.length > 1) {
+    where.work = { AND: workConditions };
+  }
+
+  where.editionFiles = {
+    some: {
+      fileAsset: { availabilityStatus: "PRESENT", mediaKind: { notIn: [...KEPUB_EXCLUDED_MEDIA_KINDS] } },
+    },
+  };
+
+  return where;
+}
+
+type EditionOrderBy = Prisma.EditionOrderByWithRelationInput;
+
+function buildEditionOrderBy(sort: string): EditionOrderBy {
+  switch (sort) {
+    case "title-desc":
+      return { work: { titleCanonical: "desc" } };
+    case "publisher-asc":
+      return { publisher: "asc" };
+    case "publisher-desc":
+      return { publisher: "desc" };
+    case "publishDate-asc":
+      return { publishedAt: "asc" };
+    case "publishDate-desc":
+      return { publishedAt: "desc" };
+    case "pageCount-asc":
+      return { pageCount: "asc" };
+    case "pageCount-desc":
+      return { pageCount: "desc" };
+    case "duration-asc":
+      return { duration: "asc" };
+    case "duration-desc":
+      return { duration: "desc" };
+    case "format-asc":
+      return { formatFamily: "asc" };
+    case "format-desc":
+      return { formatFamily: "desc" };
+    case "isbn13-asc":
+      return { isbn13: "asc" };
+    case "isbn13-desc":
+      return { isbn13: "desc" };
+    case "isbn10-asc":
+      return { isbn10: "asc" };
+    case "isbn10-desc":
+      return { isbn10: "desc" };
+    case "asin-asc":
+      return { asin: "asc" };
+    case "asin-desc":
+      return { asin: "desc" };
+    case "recent":
+      return { createdAt: "desc" };
+    default:
+      return { work: { titleCanonical: "asc" } };
+  }
+}
+
+const EDITION_CONTRIBUTOR_SORT_OPTIONS = new Set([
+  "author-asc", "author-desc",
+  "narrator-asc", "narrator-desc",
+]);
+
+const EDITION_CONTRIBUTOR_SORT_SELECT = {
+  id: true,
+  contributors: {
+    select: { contributor: { select: { nameCanonical: true } } },
+  },
+} as const;
+
+type LightweightEditionContributor = {
+  id: string;
+  contributors: { contributor: { nameCanonical: string } }[];
+};
+
+type EditionContributorSortOption = "author-asc" | "author-desc" | "narrator-asc" | "narrator-desc";
+
+function extractEditionContributorSortKey(edition: LightweightEditionContributor): string {
+  return edition.contributors
+    .map((c) => c.contributor.nameCanonical)
+    .sort()[0] ?? "\uffff";
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any -- Prisma client's findMany has complex generics
+type EditionFindMany = (args: any) => Promise<any[]>;
+type EditionDbClient = { edition: { findMany: EditionFindMany } };
+
+async function fetchEditionsWithContributorSort(
+  db: EditionDbClient,
+  where: Prisma.EditionWhereInput,
+  page: number,
+  pageSize: number,
+  sort: EditionContributorSortOption,
+) {
+  const direction = sort.endsWith("-desc") ? "desc" : "asc";
+  const role = sort.startsWith("narrator") ? "NARRATOR" as const : "AUTHOR" as const;
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Prisma select narrows the type at runtime
+  const allEditions: LightweightEditionContributor[] = await db.edition.findMany({
+    where,
+    select: {
+      ...EDITION_CONTRIBUTOR_SORT_SELECT,
+      contributors: {
+        ...EDITION_CONTRIBUTOR_SORT_SELECT.contributors,
+        where: { role },
+      },
+    },
+  });
+
+  const sorted = allEditions
+    .map((e) => ({ id: e.id, key: extractEditionContributorSortKey(e) }))
+    .sort((a, b) =>
+      direction === "asc"
+        ? a.key.localeCompare(b.key)
+        : b.key.localeCompare(a.key),
+    );
+
+  const pageIds = sorted
+    .slice((page - 1) * pageSize, page * pageSize)
+    .map((e) => e.id);
+
+  if (pageIds.length === 0) return [] as Prisma.EditionGetPayload<{ include: typeof EDITION_VIEW_INCLUDE }>[];
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- Prisma include narrows the type at runtime
+  const fullEditions: Prisma.EditionGetPayload<{ include: typeof EDITION_VIEW_INCLUDE }>[] = await db.edition.findMany({
+    where: { id: { in: pageIds } },
+    include: EDITION_VIEW_INCLUDE,
+  });
+
+  const byId = Object.fromEntries(fullEditions.map((e) => [e.id, e]));
+  return pageIds.map((id) => byId[id]).filter(Boolean) as typeof fullEditions;
+}
+
+export const getFilteredLibraryEditionsServerFn = createServerFn({
+  method: "GET",
+})
+  .inputValidator(filterSchema)
+  .handler(async ({ data }) => {
+    const { db } = await import("@bookhouse/db");
+
+    const parsed = filterSchema.parse(data);
+    const where = buildEditionWhere(parsed);
+
+    const editionsPromise = EDITION_CONTRIBUTOR_SORT_OPTIONS.has(parsed.sort)
+      ? fetchEditionsWithContributorSort(
+          db,
+          where,
+          parsed.page,
+          parsed.pageSize,
+          parsed.sort as EditionContributorSortOption,
+        )
+      : db.edition.findMany({
+          where,
+          orderBy: buildEditionOrderBy(parsed.sort),
+          skip: (parsed.page - 1) * parsed.pageSize,
+          take: parsed.pageSize,
+          include: EDITION_VIEW_INCLUDE,
+        });
+
+    const [editions, totalCount] = await Promise.all([
+      editionsPromise,
+      db.edition.count({ where }),
+    ]);
+
+    return { editions, totalCount };
+  });
+
+export type LibraryEdition = Awaited<
+  ReturnType<typeof getFilteredLibraryEditionsServerFn>
+>["editions"][number];
 
 const idsOnlyFilterSchema = filterSchema.omit({ page: true, pageSize: true, sort: true });
 

--- a/apps/web/src/routes/_authenticated/-library.index.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.index.test.tsx
@@ -44,6 +44,7 @@ let mockLoaderData: {
     facetCounts: typeof defaultFacetCounts;
     totalFacetCounts: typeof defaultFacetCounts;
   };
+  editionsResult: { editions: object[]; totalCount: number } | null;
   activeJobCount: number;
   progressMap: Record<string, number>;
   shelves: { id: string; name: string; _count: { items: number } }[];
@@ -54,12 +55,13 @@ let mockLoaderData: {
     facetCounts: defaultFacetCounts,
     totalFacetCounts: defaultFacetCounts,
   },
+  editionsResult: null,
   activeJobCount: 0,
   progressMap: {},
   shelves: [],
 };
 
-let mockSearch: { page: number; pageSize: number; sort: string } = { page: 1, pageSize: 50, sort: "title-asc" };
+let mockSearch: Record<string, string | number | boolean | string[] | undefined> = { page: 1, pageSize: 50, sort: "title-asc" };
 const mockRouterInvalidate = vi.fn();
 const mockRouterNavigate = vi.fn();
 const mockRouter = { invalidate: mockRouterInvalidate, navigate: mockRouterNavigate };
@@ -134,9 +136,11 @@ vi.mock("~/hooks/use-sse", () => ({
 }));
 
 const getFilteredLibraryWorksServerFnMock = vi.fn();
+const getFilteredLibraryEditionsServerFnMock = vi.fn();
 const getAllFilteredWorkIdsServerFnMock = vi.fn().mockResolvedValue([]);
 vi.mock("~/lib/server-fns/library", () => ({
   getFilteredLibraryWorksServerFn: getFilteredLibraryWorksServerFnMock,
+  getFilteredLibraryEditionsServerFn: getFilteredLibraryEditionsServerFnMock,
   getAllFilteredWorkIdsServerFn: getAllFilteredWorkIdsServerFnMock,
 }));
 
@@ -325,6 +329,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -352,6 +357,27 @@ describe("LibraryPage", () => {
     expect(getBulkReadingProgressServerFnMock).toHaveBeenCalled();
     expect(result).toEqual({
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
+      activeJobCount: 0,
+      progressMap: {},
+      shelves: [],
+    });
+  });
+
+  it("loader fetches editions when view=editions", async () => {
+    getFilteredLibraryWorksServerFnMock.mockResolvedValueOnce({ works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts });
+    getFilteredLibraryEditionsServerFnMock.mockResolvedValueOnce({ editions: [], totalCount: 0 });
+    getActiveJobCountServerFnMock.mockResolvedValueOnce(0);
+    getBulkReadingProgressServerFnMock.mockResolvedValueOnce({});
+    const { Route } = await import("./library.index");
+    const deps = { page: 1, pageSize: 50, sort: "title-asc", view: "editions" };
+    const result = await asLoader<Record<string, string | object>, object>(Route.options.loader as object)({ deps });
+    // Works are fetched with pageSize: 1 for facet counts only
+    expect(getFilteredLibraryWorksServerFnMock).toHaveBeenCalledWith({ data: { ...deps, pageSize: 1 } });
+    expect(getFilteredLibraryEditionsServerFnMock).toHaveBeenCalledWith({ data: deps });
+    expect(result).toEqual({
+      libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: { editions: [], totalCount: 0 },
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -361,6 +387,7 @@ describe("LibraryPage", () => {
   it("renders 'Library' heading", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -380,6 +407,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -399,6 +427,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -420,6 +449,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -441,6 +471,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -461,6 +492,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -480,6 +512,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -500,6 +533,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -520,6 +554,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -539,6 +574,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -559,6 +595,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -579,6 +616,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -599,6 +637,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -620,6 +659,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -636,6 +676,7 @@ describe("LibraryPage", () => {
   it("renders LibraryToolbar", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -649,6 +690,7 @@ describe("LibraryPage", () => {
   it("renders LibraryFilters", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -662,6 +704,7 @@ describe("LibraryPage", () => {
   it("renders LibraryPagination", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -675,6 +718,7 @@ describe("LibraryPage", () => {
   it("shows empty state when no works and not scanning with no filters", async () => {
     mockLoaderData = {
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -689,6 +733,7 @@ describe("LibraryPage", () => {
   it("empty state links to settings/libraries", async () => {
     mockLoaderData = {
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -703,6 +748,7 @@ describe("LibraryPage", () => {
   it("does not show empty state when scanning with no works", async () => {
     mockLoaderData = {
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 1,
       progressMap: {},
       shelves: [],
@@ -715,9 +761,10 @@ describe("LibraryPage", () => {
   });
 
   it("does not show empty state when filters are active and results are empty", async () => {
-    mockSearch = { ...mockSearch, q: "something" } as typeof mockSearch;
+    mockSearch = { ...mockSearch, q: "something" };
     mockLoaderData = {
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -731,6 +778,7 @@ describe("LibraryPage", () => {
   it("shows scanning indicator when activeJobCount > 0", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 2,
       progressMap: {},
       shelves: [],
@@ -744,6 +792,7 @@ describe("LibraryPage", () => {
   it("shows scanning indicator with new count when totalCount > prevCount", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Old Book")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -756,6 +805,7 @@ describe("LibraryPage", () => {
 
     mockLoaderData = {
       libraryResult: { works: [makeWork("Old Book"), makeWork("New Book")], totalCount: 2, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 1,
       progressMap: {},
       shelves: [],
@@ -774,6 +824,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 1,
       progressMap: {},
       shelves: [],
@@ -793,6 +844,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -812,6 +864,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -826,6 +879,7 @@ describe("LibraryPage", () => {
     mockView = "grid";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: { "work-test": 42 },
       shelves: [],
@@ -842,6 +896,7 @@ describe("LibraryPage", () => {
     mockTileSize = "large";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -858,6 +913,7 @@ describe("LibraryPage", () => {
     mockTileSize = "small";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -872,6 +928,7 @@ describe("LibraryPage", () => {
   it("does not show scanning indicator when activeJobCount is 0", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -885,6 +942,7 @@ describe("LibraryPage", () => {
   it("navigates with search text when onSearchChange is called", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -903,6 +961,7 @@ describe("LibraryPage", () => {
   it("navigates with empty q when search is cleared", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -918,6 +977,7 @@ describe("LibraryPage", () => {
   it("navigates with sort when onSortChange is called", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -933,6 +993,7 @@ describe("LibraryPage", () => {
   it("navigates with filters when onFiltersChange is called", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -948,6 +1009,7 @@ describe("LibraryPage", () => {
   it("navigates with page when onPageChange is called", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 100, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -963,6 +1025,7 @@ describe("LibraryPage", () => {
   it("navigates with pageSize and page 1 when onPageSizeChange is called", async () => {
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 100, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -984,6 +1047,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: { "work-reading": 50, "work-done": 100 },
       shelves: [],
@@ -1011,6 +1075,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: { "work-done": 100 },
       shelves: [],
@@ -1035,6 +1100,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: { "work-done": 100 },
       shelves: [],
@@ -1051,9 +1117,10 @@ describe("LibraryPage", () => {
   });
 
   it("does not show empty state when format filter is active", async () => {
-    mockSearch = { ...mockSearch, format: ["EBOOK"] } as typeof mockSearch;
+    mockSearch = { ...mockSearch, format: ["EBOOK"] };
     mockLoaderData = {
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1065,9 +1132,10 @@ describe("LibraryPage", () => {
   });
 
   it("does not show empty state when authorId filter is active", async () => {
-    mockSearch = { ...mockSearch, authorId: ["a1"] } as typeof mockSearch;
+    mockSearch = { ...mockSearch, authorId: ["a1"] };
     mockLoaderData = {
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1079,9 +1147,10 @@ describe("LibraryPage", () => {
   });
 
   it("does not show empty state when seriesId filter is active", async () => {
-    mockSearch = { ...mockSearch, seriesId: ["s1"] } as typeof mockSearch;
+    mockSearch = { ...mockSearch, seriesId: ["s1"] };
     mockLoaderData = {
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1093,9 +1162,10 @@ describe("LibraryPage", () => {
   });
 
   it("does not show empty state when hasCover filter is active", async () => {
-    mockSearch = { ...mockSearch, hasCover: true } as typeof mockSearch;
+    mockSearch = { ...mockSearch, hasCover: true };
     mockLoaderData = {
       libraryResult: { works: [], totalCount: 0, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1107,9 +1177,10 @@ describe("LibraryPage", () => {
   });
 
   it("passes search params as toolbar search value", async () => {
-    mockSearch = { ...mockSearch, q: "test query" } as typeof mockSearch;
+    mockSearch = { ...mockSearch, q: "test query" };
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1121,9 +1192,10 @@ describe("LibraryPage", () => {
   });
 
   it("passes current filters from search to LibraryFilters", async () => {
-    mockSearch = { ...mockSearch, format: ["EBOOK"], hasCover: true } as typeof mockSearch;
+    mockSearch = { ...mockSearch, format: ["EBOOK"], hasCover: true };
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1140,6 +1212,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1155,6 +1228,7 @@ describe("LibraryPage", () => {
     mockView = "grid";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1172,6 +1246,7 @@ describe("LibraryPage", () => {
     mockTablePrefs = { columnVisibility: { authors: false }, textOverflow: "truncate" };
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1187,6 +1262,7 @@ describe("LibraryPage", () => {
     mockTablePrefs = { columnVisibility: {}, textOverflow: "truncate" };
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1207,6 +1283,7 @@ describe("LibraryPage", () => {
     mockTablePrefs = { columnVisibility: {}, textOverflow: "truncate" };
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1227,6 +1304,7 @@ describe("LibraryPage", () => {
     mockTablePrefs = { columnVisibility: {}, textOverflow: "wrap" };
     mockLoaderData = {
       libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1248,6 +1326,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1263,6 +1342,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1287,6 +1367,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1324,6 +1405,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A"), makeWork("Book B")], totalCount: 2, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1354,6 +1436,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A"), makeWork("Book B")], totalCount: 2, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1381,6 +1464,7 @@ describe("LibraryPage", () => {
         facetCounts: defaultFacetCounts,
         totalFacetCounts: defaultFacetCounts,
       },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1416,6 +1500,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1448,6 +1533,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1479,6 +1565,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1506,6 +1593,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1671,6 +1759,7 @@ describe("LibraryPage", () => {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
+      editionsResult: null,
       shelves: [{ id: "s1", name: "Fiction", _count: { items: 3 } }],
     };
     const { Route } = await import("./library.index");
@@ -1694,6 +1783,7 @@ describe("LibraryPage", () => {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
+      editionsResult: null,
       shelves: [{ id: "s1", name: "Fiction", _count: { items: 3 } }],
     };
     const { Route } = await import("./library.index");
@@ -1731,6 +1821,7 @@ describe("LibraryPage", () => {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
       activeJobCount: 0,
       progressMap: {},
+      editionsResult: null,
       shelves: [{ id: "s1", name: "Fiction", _count: { items: 3 } }],
     };
     const { Route } = await import("./library.index");
@@ -1761,6 +1852,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Book A")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1787,6 +1879,7 @@ describe("LibraryPage", () => {
     mockView = "table";
     mockLoaderData = {
       libraryResult: { works: [makeWork("Stable", ["Author"])], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
       activeJobCount: 0,
       progressMap: {},
       shelves: [],
@@ -1811,5 +1904,122 @@ describe("LibraryPage", () => {
 
     const laterColumns = capturedColumnRefs[capturedColumnRefs.length - 1];
     expect(laterColumns).toBe(firstColumns);
+  });
+
+  it("renders editions table when view=editions and table mode", async () => {
+    mockView = "table";
+    mockSearch = { page: 1, pageSize: 50, sort: "title-asc", view: "editions" };
+    mockLoaderData = {
+      libraryResult: { works: [], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: {
+        editions: [{
+          id: "e-1",
+          workId: "w-1",
+          formatFamily: "EBOOK",
+          publisher: "Penguin",
+          publishedAt: new Date("2024-01-15"),
+          isbn13: null,
+          isbn10: null,
+          asin: null,
+          language: "en",
+          pageCount: 300,
+          duration: null,
+          editedFields: [],
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          work: {
+            id: "w-1",
+            titleDisplay: "Edition Book",
+            titleCanonical: "edition book",
+            sortTitle: null,
+            description: null,
+            coverPath: null,
+            coverColors: null,
+            seriesId: null,
+            seriesPosition: null,
+            enrichmentStatus: "ENRICHED",
+            editedFields: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            series: null,
+            editions: [
+              { id: "e-1", contributors: [{ id: "ec-1", editionId: "e-1", contributorId: "c-1", role: "AUTHOR", contributor: { id: "c-1", nameDisplay: "Alice", nameCanonical: "alice", editedFields: [], createdAt: new Date(), updatedAt: new Date() } }] },
+            ],
+          },
+          contributors: [
+            { id: "ec-1", editionId: "e-1", contributorId: "c-1", role: "AUTHOR", contributor: { id: "c-1", nameDisplay: "Alice", nameCanonical: "alice", editedFields: [], createdAt: new Date(), updatedAt: new Date() } },
+          ],
+        }],
+        totalCount: 1,
+      },
+      activeJobCount: 0,
+      progressMap: {},
+      shelves: [],
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+
+    // Should render edition columns via the table
+    await waitFor(() => {
+      expect(screen.getByText("Edition Book")).toBeTruthy();
+    });
+  });
+
+  it("onViewChange to table does not reset view mode", async () => {
+    mockView = "grid";
+    mockSearch = { page: 1, pageSize: 50, sort: "title-asc" };
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: null,
+      activeJobCount: 0,
+      progressMap: {},
+      shelves: [],
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+
+    const toolbarViewChange = capturedToolbarProps.onViewChange as (v: string) => void;
+    toolbarViewChange("table");
+    expect(mockSetView).toHaveBeenCalledWith("table");
+  });
+
+  it("grid onViewChange with editions mode resets to works", async () => {
+    mockView = "table";
+    mockSearch = { page: 1, pageSize: 50, sort: "title-asc", view: "editions" };
+    mockLoaderData = {
+      libraryResult: { works: [makeWork("Test")], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: { editions: [], totalCount: 0 },
+      activeJobCount: 0,
+      progressMap: {},
+      shelves: [],
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+
+    // The toolbar onViewChange should call navigate with view=works when switching to grid from editions
+    const toolbarViewChange = capturedToolbarProps.onViewChange as (v: string) => void;
+    toolbarViewChange("grid");
+    expect(mockSetView).toHaveBeenCalledWith("grid");
+    expect(mockNavigate).toHaveBeenCalled();
+  });
+
+  it("editions pagination uses editionsResult totalCount", async () => {
+    mockView = "table";
+    mockSearch = { page: 1, pageSize: 50, sort: "title-asc", view: "editions" };
+    mockLoaderData = {
+      libraryResult: { works: [], totalCount: 1, facetCounts: defaultFacetCounts, totalFacetCounts: defaultFacetCounts },
+      editionsResult: { editions: [], totalCount: 42 },
+      activeJobCount: 0,
+      progressMap: {},
+      shelves: [],
+    };
+    const { Route } = await import("./library.index");
+    const LibraryPage = Route.options.component as React.ComponentType;
+    render(<LibraryPage />);
+
+    expect(capturedPaginationProps.totalCount).toBe(42);
   });
 });

--- a/apps/web/src/routes/_authenticated/library.$workId.tsx
+++ b/apps/web/src/routes/_authenticated/library.$workId.tsx
@@ -146,7 +146,7 @@ function WorkDetailPage() {
       await deleteWorkServerFn({ data: { workId: work.id } });
       toast.success(`"${work.titleDisplay}" deleted`);
       setDeleteWorkOpen(false);
-      void router.navigate({ to: "/library", search: { page: 1, pageSize: 50, sort: "title-asc" as const } });
+      void router.navigate({ to: "/library", search: { page: 1, pageSize: 50, sort: "title-asc" as const, view: "works" as const } });
     } catch (error) {
       toast.error(error instanceof Error ? error.message : "Failed to delete work");
     } finally {
@@ -160,7 +160,7 @@ function WorkDetailPage() {
       const result = await deleteEditionServerFn({ data: { editionId } });
       if (result.deletedWorkId) {
         toast.success("Edition deleted — work had no remaining editions and was also removed");
-        void router.navigate({ to: "/library", search: { page: 1, pageSize: 50, sort: "title-asc" as const } });
+        void router.navigate({ to: "/library", search: { page: 1, pageSize: 50, sort: "title-asc" as const, view: "works" as const } });
       } else {
         toast.success("Edition deleted");
         void router.invalidate();
@@ -245,7 +245,7 @@ function WorkDetailPage() {
   return (
     <div className="space-y-6">
       <nav className="flex items-center gap-1 text-sm text-muted-foreground">
-        <Link to="/library" search={{ page: 1, pageSize: 50, sort: "title-asc" as const }} className="hover:text-foreground">
+        <Link to="/library" search={{ page: 1, pageSize: 50, sort: "title-asc" as const, view: "works" as const }} className="hover:text-foreground">
           Library
         </Link>
         <ChevronRight className="size-4" />

--- a/apps/web/src/routes/_authenticated/library.index.tsx
+++ b/apps/web/src/routes/_authenticated/library.index.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { createFileRoute, Link, useNavigate, useRouter } from "@tanstack/react-router";
 import { useSSE } from "~/hooks/use-sse";
 import { useLibraryViewPreference } from "~/hooks/use-library-view-preference";
@@ -9,16 +9,18 @@ import type { RowSelectionState } from "@tanstack/react-table";
 import { BookOpen, Loader2 } from "lucide-react";
 import { LibrarySelectionToolbar } from "~/components/library-selection-toolbar";
 import { GridPageSkeleton } from "~/components/skeletons/grid-page-skeleton";
-import { getColumns } from "~/lib/library-columns";
+import { getColumns, COLUMN_PICKER_ITEMS } from "~/lib/library-columns";
+import { getEditionColumns, EDITION_COLUMN_PICKER_ITEMS } from "~/lib/library-edition-columns";
 import { LibraryTableView } from "~/components/library-table-view";
 import { filterByReadingStatus } from "~/lib/library-filter-helpers";
+import { EDITION_COLUMN_SORT_MAP, EDITION_SORT_TO_COLUMN } from "~/lib/library-edition-filter-helpers";
 import { LibraryToolbar } from "~/components/library-toolbar";
 import { LibraryGrid } from "~/components/library-grid";
 import { LibraryFilters } from "~/components/library-filters";
 import { LibraryPagination } from "~/components/library-pagination";
 import { librarySearchSchema } from "~/lib/library-search-schema";
 import type { ReadingFilter } from "~/lib/sort-filter-works";
-import { getFilteredLibraryWorksServerFn, getAllFilteredWorkIdsServerFn } from "~/lib/server-fns/library";
+import { getFilteredLibraryWorksServerFn, getFilteredLibraryEditionsServerFn, getAllFilteredWorkIdsServerFn } from "~/lib/server-fns/library";
 import { getActiveJobCountServerFn } from "~/lib/server-fns/import-jobs";
 import { getBulkReadingProgressServerFn } from "~/lib/server-fns/reading-progress";
 import { getShelvesServerFn } from "~/lib/server-fns/shelves";
@@ -27,20 +29,27 @@ export const Route = createFileRoute("/_authenticated/library/")({
   validateSearch: (search) => librarySearchSchema.parse(search),
   loaderDeps: ({ search }) => search,
   loader: async ({ deps }) => {
-    const [libraryResult, activeJobCount, progressMap, shelves] = await Promise.all([
-      getFilteredLibraryWorksServerFn({ data: deps }),
+    const isEditionsView = deps.view === "editions";
+
+    const [libraryResult, editionsResult, activeJobCount, progressMap, shelves] = await Promise.all([
+      getFilteredLibraryWorksServerFn({
+        data: isEditionsView ? { ...deps, pageSize: 1 } : deps,
+      }),
+      isEditionsView
+        ? getFilteredLibraryEditionsServerFn({ data: deps })
+        : Promise.resolve(null),
       getActiveJobCountServerFn(),
       getBulkReadingProgressServerFn(),
       getShelvesServerFn(),
     ]);
-    return { libraryResult, activeJobCount, progressMap, shelves };
+    return { libraryResult, editionsResult, activeJobCount, progressMap, shelves };
   },
   pendingComponent: GridPageSkeleton,
   component: LibraryPage,
 });
 
 function LibraryPage() {
-  const { libraryResult, activeJobCount, progressMap, shelves } = Route.useLoaderData();
+  const { libraryResult, editionsResult, activeJobCount, progressMap, shelves } = Route.useLoaderData();
   const { works, totalCount, facetCounts, totalFacetCounts } = libraryResult;
   const search = Route.useSearch();
   const navigate = useNavigate();
@@ -56,7 +65,9 @@ function LibraryPage() {
   const [selectingAll, setSelectingAll] = useState(false);
   const [editMode, setEditMode] = useState(false);
   const isScanning = activeJobCount > 0;
-  const columns = useMemo(() => getColumns(isScanning, editMode, router, progressMap), [isScanning, editMode, router, progressMap]);
+  const isEditionsView = search.view === "editions";
+  const workColumns = useMemo(() => getColumns(isScanning, editMode, router, progressMap), [isScanning, editMode, router, progressMap]);
+  const editionColumns = useMemo(() => getEditionColumns(editMode, router), [editMode, router]);
   const newCount = totalCount - prevCount;
 
   const filteredByReading = useMemo(
@@ -94,11 +105,27 @@ function LibraryPage() {
     handleSearchChange,
     handleSortChange,
     handleColumnSort,
+    handleViewModeChange,
     handlePageChange,
     handlePageSizeChange,
     tableSorting,
     currentFilters,
-  } = useLibraryFilters({ search, navigate });
+  } = useLibraryFilters({
+    search,
+    navigate,
+    ...(isEditionsView
+      ? { sortMap: EDITION_COLUMN_SORT_MAP, sortToColumn: EDITION_SORT_TO_COLUMN }
+      : {}),
+  });
+
+  const handleEditModeToggle = useCallback(() => { setEditMode(!editMode); }, [editMode]);
+
+  const handleDisplayViewChange = useCallback((v: "grid" | "table") => {
+    setView(v);
+    if (v === "grid" && isEditionsView) {
+      handleViewModeChange("works");
+    }
+  }, [isEditionsView, handleViewModeChange, setView]);
 
   const handleColumnToggle = (columnId: string) => {
     const current = tablePrefs.columnVisibility[columnId] !== false;
@@ -142,7 +169,9 @@ function LibraryPage() {
     void router.invalidate();
   };
 
-  if (totalCount === 0 && !isScanning && !search.q && !search.format && !search.authorId && !search.seriesId && search.hasCover === undefined && search.enriched === undefined && search.hasDescription === undefined && search.inSeries === undefined) {
+  const effectiveTotalCount = isEditionsView && editionsResult ? editionsResult.totalCount : totalCount;
+
+  if (totalCount === 0 && !isEditionsView && !isScanning && !search.q && !search.format && !search.authorId && !search.seriesId && search.hasCover === undefined && search.enriched === undefined && search.hasDescription === undefined && search.inSeries === undefined) {
     return (
       <div>
         <h1 className="text-2xl font-bold">Library</h1>
@@ -195,7 +224,7 @@ function LibraryPage() {
             sortValue={search.sort}
             onSortChange={handleSortChange}
             view={view}
-            onViewChange={setView}
+            onViewChange={handleDisplayViewChange}
             filterValue={readingFilter}
             onFilterChange={setReadingFilter}
             showSort={view !== "table"}
@@ -204,12 +233,29 @@ function LibraryPage() {
           />
           {view === "grid" ? (
             <LibraryGrid works={filteredByReading} progressMap={progressMap} scanActive={isScanning} tileSize={tileSize} />
+          ) : isEditionsView && editionsResult ? (
+            <LibraryTableView
+              works={editionsResult.editions}
+              columns={editionColumns}
+              editMode={editMode}
+              onEditModeToggle={handleEditModeToggle}
+              tablePrefs={tablePrefs}
+              onColumnToggle={handleColumnToggle}
+              onTextOverflowToggle={handleTextOverflowToggle}
+              rowSelection={{}}
+              onRowSelectionChange={setRowSelection}
+              sorting={tableSorting}
+              onSortingChange={handleColumnSort}
+              viewMode="editions"
+              onViewModeChange={handleViewModeChange}
+              columnPickerItems={EDITION_COLUMN_PICKER_ITEMS}
+            />
           ) : (
             <LibraryTableView
               works={filteredByReading}
-              columns={columns}
+              columns={workColumns}
               editMode={editMode}
-              onEditModeToggle={() => { setEditMode(!editMode); }}
+              onEditModeToggle={handleEditModeToggle}
               tablePrefs={tablePrefs}
               onColumnToggle={handleColumnToggle}
               onTextOverflowToggle={handleTextOverflowToggle}
@@ -217,12 +263,15 @@ function LibraryPage() {
               onRowSelectionChange={setRowSelection}
               sorting={tableSorting}
               onSortingChange={handleColumnSort}
+              viewMode="works"
+              onViewModeChange={handleViewModeChange}
+              columnPickerItems={COLUMN_PICKER_ITEMS}
             />
           )}
           <LibraryPagination
             page={search.page}
             pageSize={search.pageSize}
-            totalCount={totalCount}
+            totalCount={effectiveTotalCount}
             onPageChange={handlePageChange}
             onPageSizeChange={handlePageSizeChange}
           />

--- a/e2e/auth-redirect.spec.ts
+++ b/e2e/auth-redirect.spec.ts
@@ -3,10 +3,10 @@ import { test, expect } from "@playwright/test";
 test("unauthenticated visit to /library redirects to /auth/login", async ({
   request,
 }) => {
-  // TanStack Router redirects /library → /library?page=1&pageSize=50&sort=title-asc
+  // TanStack Router redirects /library → /library?page=1&pageSize=50&sort=title-asc&view=works
   // to fill in default search params before the auth guard runs. Requesting the
   // URL with those defaults already filled in goes straight to the auth check.
-  const response = await request.get("/library?page=1&pageSize=50&sort=title-asc", {
+  const response = await request.get("/library?page=1&pageSize=50&sort=title-asc&view=works", {
     maxRedirects: 0,
   });
 


### PR DESCRIPTION
## Summary

- Adds a Works/Editions segmented toggle in the Library table toolbar
- Editions view shows one row per edition with columns: title, authors, format, publisher, publish date, pages/duration, narrators, ISBN-13, ISBN-10, ASIN
- All edition columns support inline editing (publisher, dates, ISBN/ASIN via `updateEditionServerFn`; authors via `updateWorkAuthorsServerFn`; narrators via `updateEditionNarratorsServerFn`)
- Authors are aggregated from all editions of the work, matching Works view behavior
- Server-side sorting on all columns including ISBN/ASIN fields
- View mode stored in URL (`?view=editions`) for shareability
- Sort resets to title-asc when switching between modes; grid view forces Works mode

## Test plan

- Verified typecheck, lint, and 3525 tests passing with 100% coverage
- Toggle between Works and Editions in table view — columns and data change
- Click column headers to sort in Editions view
- Toggle Edit mode in Editions view — fields become editable inputs
- Edit publisher, ISBN, narrators etc. and verify save on blur
- Switch to grid view from Editions — should reset to Works mode
- URL updates with `?view=editions` and is shareable

Closes #210