### PR TITLE
Add KOReader sync, contributor sort keys, and Docker publishing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,3 +17,16 @@ NODE_ENV=development
 # Backup (optional — set if pg_dump/psql are not in PATH, e.g. in Docker-based dev environments)
 # PG_DUMP_PATH=/usr/lib/postgresql/17/bin/pg_dump
 # PSQL_PATH=/usr/lib/postgresql/17/bin/psql
+
+# Docker compose deploy (only used by docker-compose.yml)
+# Absolute host paths to your media libraries; mounted read-only into the worker.
+EBOOKS_PATH=/path/to/ebooks
+AUDIOBOOKS_PATH=/path/to/audiobooks
+# Image tag to pull from GHCR. Defaults to `latest`.
+# BOOKHOUSE_TAG=latest
+# Host port the web UI binds to. Defaults to 3000.
+# WEB_PORT=3000
+# Override DB credentials used inside the compose network.
+# POSTGRES_USER=bookhouse
+# POSTGRES_PASSWORD=bookhouse
+# POSTGRES_DB=bookhouse

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ concurrency:
 
 env:
   NODE_VERSION: "24"
-  PNPM_VERSION: "10.12.1"
+  PNPM_VERSION: "10.33.0"
   # Prisma 7's config loader resolves DATABASE_URL at import time (even for
   # `prisma generate`). A placeholder is sufficient — no real DB is needed.
   DATABASE_URL: postgresql://placeholder/placeholder

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,65 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAMESPACE: ${{ github.repository_owner }}
+
+jobs:
+  publish:
+    name: Build and push ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: web
+            image: bookhouse-web
+          - target: worker
+            image: bookhouse-worker
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAMESPACE }}/${{ matrix.image }}
+          tags: |
+            type=ref,event=branch
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,format=short
+            type=raw,value=latest,enable=${{ github.ref == format('refs/heads/{0}', 'main') }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          target: ${{ matrix.target }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha,scope=${{ matrix.target }}
+          cache-to: type=gha,scope=${{ matrix.target }},mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ test-results/
 playwright-report/
 coverage-json/
 coverage-json2/
+apps/guide

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,10 @@ COPY --from=build /app/node_modules node_modules
 RUN PRISMA_DIR="$(find /app/node_modules/.pnpm -path '*/node_modules/@prisma' | head -n1)" \
   && ln -s "$PRISMA_DIR" /app/node_modules/@prisma
 COPY --from=build /app/apps/web/.output .output
-CMD ["node", ".output/server/index.mjs"]
+COPY --from=build /app/packages/db/prisma packages/db/prisma
+COPY scripts/web-entrypoint.sh /usr/local/bin/web-entrypoint.sh
+RUN chmod +x /usr/local/bin/web-entrypoint.sh
+CMD ["/usr/local/bin/web-entrypoint.sh"]
 
 FROM base AS worker
 COPY --from=build /app/workers/library-worker/dist dist

--- a/apps/web/server/routes/api/koreader/auth-helper.test.ts
+++ b/apps/web/server/routes/api/koreader/auth-helper.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+import type { KoreaderAuthDeps } from "./auth-helper";
+
+vi.mock("h3", () => ({
+  getRequestHeader: (event: { _headers?: Record<string, string> }, name: string) =>
+    event._headers?.[name.toLowerCase()] ?? null,
+  createError: (opts: { statusCode: number; statusMessage: string; message: string }) => {
+    const err = new Error(opts.message) as Error & { statusCode: number; statusMessage: string };
+    err.statusCode = opts.statusCode;
+    err.statusMessage = opts.statusMessage;
+    return err;
+  },
+}));
+
+const { createKoreaderAuth } = await import("./auth-helper");
+
+function makeEvent(headers: Record<string, string> = {}): H3Event {
+  return { _headers: headers } as unknown as H3Event;
+}
+
+function makeDeps(overrides: Partial<KoreaderAuthDeps> = {}): KoreaderAuthDeps {
+  return {
+    findCredentialByUsername: vi.fn().mockResolvedValue({
+      id: "kc1",
+      userId: "u1",
+      username: "reader",
+      passwordHash: "salt:hash",
+      isEnabled: true,
+    }),
+    verifyPassword: vi.fn().mockResolvedValue(true),
+    ...overrides,
+  };
+}
+
+describe("createKoreaderAuth", () => {
+  it("returns auth result for valid headers", async () => {
+    const deps = makeDeps();
+    const auth = createKoreaderAuth(deps);
+
+    const result = await auth(makeEvent({
+      "x-auth-user": "reader",
+      "x-auth-key": "secret",
+    }));
+
+    expect(result).toEqual({
+      credentialId: "kc1",
+      userId: "u1",
+      username: "reader",
+    });
+  });
+
+  it("throws 401 when auth headers are missing", async () => {
+    const auth = createKoreaderAuth(makeDeps());
+
+    await expect(auth(makeEvent())).rejects.toThrow(expect.objectContaining({ statusCode: 401 }));
+  });
+
+  it("throws 403 when the credential is disabled", async () => {
+    const auth = createKoreaderAuth(makeDeps({
+      findCredentialByUsername: vi.fn().mockResolvedValue({
+        id: "kc1",
+        userId: "u1",
+        username: "reader",
+        passwordHash: "salt:hash",
+        isEnabled: false,
+      }),
+    }));
+
+    await expect(auth(makeEvent({
+      "x-auth-user": "reader",
+      "x-auth-key": "secret",
+    }))).rejects.toThrow(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it("throws 401 when the credential does not exist", async () => {
+    const auth = createKoreaderAuth(makeDeps({
+      findCredentialByUsername: vi.fn().mockResolvedValue(null),
+    }));
+
+    await expect(auth(makeEvent({
+      "x-auth-user": "reader",
+      "x-auth-key": "secret",
+    }))).rejects.toThrow(expect.objectContaining({ statusCode: 401 }));
+  });
+
+  it("throws 401 when the password is invalid", async () => {
+    const auth = createKoreaderAuth(makeDeps({
+      verifyPassword: vi.fn().mockResolvedValue(false),
+    }));
+
+    await expect(auth(makeEvent({
+      "x-auth-user": "reader",
+      "x-auth-key": "wrong",
+    }))).rejects.toThrow(expect.objectContaining({ statusCode: 401 }));
+  });
+});

--- a/apps/web/server/routes/api/koreader/auth-helper.ts
+++ b/apps/web/server/routes/api/koreader/auth-helper.ts
@@ -1,0 +1,61 @@
+import { createError, getRequestHeader } from "h3";
+import type { H3Event } from "h3";
+
+export interface KoreaderAuthDeps {
+  findCredentialByUsername: (username: string) => Promise<{
+    id: string;
+    userId: string;
+    username: string;
+    passwordHash: string;
+    isEnabled: boolean;
+  } | null>;
+  verifyPassword: (password: string, stored: string) => Promise<boolean>;
+}
+
+export interface KoreaderAuthResult {
+  credentialId: string;
+  userId: string;
+  username: string;
+}
+
+function createAuthError(statusCode: number, message: string): Error & {
+  statusCode: number;
+  statusMessage: string;
+} {
+  return createError({
+    statusCode,
+    statusMessage: statusCode === 403 ? "Forbidden" : "Unauthorized",
+    message,
+  }) as Error & { statusCode: number; statusMessage: string };
+}
+
+export function createKoreaderAuth(deps: KoreaderAuthDeps) {
+  return async (event: H3Event): Promise<KoreaderAuthResult> => {
+    const username = getRequestHeader(event, "x-auth-user");
+    const password = getRequestHeader(event, "x-auth-key");
+
+    if (!username || !password) {
+      throw createAuthError(401, "Unauthorized");
+    }
+
+    const credential = await deps.findCredentialByUsername(username);
+    if (!credential) {
+      throw createAuthError(401, "Unauthorized");
+    }
+
+    if (!credential.isEnabled) {
+      throw createAuthError(403, "Credential is disabled");
+    }
+
+    const valid = await deps.verifyPassword(password, credential.passwordHash);
+    if (!valid) {
+      throw createAuthError(401, "Unauthorized");
+    }
+
+    return {
+      credentialId: credential.id,
+      userId: credential.userId,
+      username: credential.username,
+    };
+  };
+}

--- a/apps/web/server/routes/api/koreader/syncs/progress.default.test.ts
+++ b/apps/web/server/routes/api/koreader/syncs/progress.default.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+
+const {
+  mockReadBody,
+  mockFindCredential,
+  mockVerifyPassword,
+  mockResolveKoreaderDocument,
+  mockFindFirst,
+  mockCreate,
+  mockUpdate,
+  mockEditionFileFindMany,
+  mockFileAssetUpdate,
+} = vi.hoisted(() => ({
+  mockReadBody: vi.fn(),
+  mockFindCredential: vi.fn(),
+  mockVerifyPassword: vi.fn(),
+  mockResolveKoreaderDocument: vi.fn(),
+  mockFindFirst: vi.fn(),
+  mockCreate: vi.fn(),
+  mockUpdate: vi.fn(),
+  mockEditionFileFindMany: vi.fn(),
+  mockFileAssetUpdate: vi.fn(),
+}));
+
+vi.mock("h3", async () => {
+  const actual = await vi.importActual<typeof import("h3")>("h3");
+  return {
+    ...actual,
+    defineEventHandler: (handler: (event: H3Event) => unknown) => handler,
+    getRequestHeader: (event: { _headers?: Record<string, string> }, name: string) =>
+      event._headers?.[name.toLowerCase()] ?? null,
+    readBody: mockReadBody,
+  };
+});
+
+vi.mock("@bookhouse/db", () => ({
+  db: {
+    koreaderCredential: {
+      findUnique: mockFindCredential,
+    },
+    editionFile: {
+      findMany: mockEditionFileFindMany,
+    },
+    fileAsset: {
+      update: mockFileAssetUpdate,
+    },
+    readingProgress: {
+      findFirst: mockFindFirst,
+      create: mockCreate,
+      update: mockUpdate,
+    },
+  },
+}));
+
+vi.mock("@bookhouse/opds", () => ({
+  verifyPassword: mockVerifyPassword,
+}));
+
+vi.mock("./shared", async () => {
+  return {
+    resolveKoreaderDocument: mockResolveKoreaderDocument,
+    resolveKoreaderTimestamp: (timestamp: number | undefined, fallback: Date) =>
+      typeof timestamp === "number" && !Number.isNaN(timestamp)
+        ? new Date(timestamp * 1000)
+        : fallback,
+  };
+});
+
+const { default: handler } = await import("./progress");
+
+describe("KOReader progress route default handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockReadBody.mockResolvedValue({
+      document: "abcd1234",
+      progress: "epubcfi(/6/2!/4/2/8)",
+      percentage: 55,
+      device: "KOReader",
+      device_id: "device-1",
+      timestamp: 1719835200,
+    });
+    mockFindCredential.mockResolvedValue({
+      id: "kc1",
+      userId: "u1",
+      username: "reader",
+      passwordHash: "salt:hash",
+      isEnabled: true,
+    });
+    mockVerifyPassword.mockResolvedValue(true);
+    mockEditionFileFindMany.mockResolvedValue([]);
+    mockFileAssetUpdate.mockResolvedValue({});
+    mockResolveKoreaderDocument.mockImplementation(async (deps) => {
+      await deps.findExactCandidates();
+      await deps.findUnhashedCandidates();
+      await deps.updateFileAssetHash("fa-1", "abcd1234");
+
+      return {
+        document: "abcd1234",
+        editionId: "ed-1",
+        fileAssetId: "fa-1",
+      };
+    });
+    mockFindFirst.mockResolvedValueOnce(null);
+    mockCreate.mockResolvedValue({ updatedAt: new Date("2024-07-01T12:00:00.000Z") });
+  });
+
+  it("wires the module default handler through auth, resolution, and create", async () => {
+    const result = await handler({
+      _headers: {
+        "x-auth-user": "reader",
+        "x-auth-key": "secret",
+      },
+    } as unknown as H3Event);
+
+    expect(mockFindCredential).toHaveBeenCalledWith({ where: { username: "reader" } });
+    expect(mockVerifyPassword).toHaveBeenCalledWith("secret", "salt:hash");
+    expect(mockResolveKoreaderDocument).toHaveBeenCalledWith(expect.objectContaining({
+      document: "abcd1234",
+      updateFileAssetHash: expect.any(Function),
+    }));
+    expect(mockEditionFileFindMany).toHaveBeenCalledTimes(2);
+    expect(mockFileAssetUpdate).toHaveBeenCalledWith({
+      where: { id: "fa-1" },
+      data: { koreaderHash: "abcd1234" },
+    });
+    expect(result).toEqual({
+      document: "abcd1234",
+      timestamp: 1719835200,
+    });
+    expect(mockCreate).toHaveBeenCalledWith({
+      data: {
+        userId: "u1",
+        editionId: "ed-1",
+        progressKind: "EBOOK",
+        percent: 55,
+        locator: {
+          koreader: {
+            document: "abcd1234",
+            progress: "epubcfi(/6/2!/4/2/8)",
+            percentage: 55,
+            device: "KOReader",
+            deviceId: "device-1",
+          },
+        },
+        source: "koreader",
+        updatedAt: new Date("2024-07-01T12:00:00.000Z"),
+      },
+      select: { updatedAt: true },
+    });
+  });
+
+  it("updates an existing koreader record when one already exists", async () => {
+    mockFindFirst.mockReset();
+    mockFindFirst.mockResolvedValueOnce({
+      updatedAt: new Date("2024-06-01T12:00:00.000Z"),
+    });
+    mockFindFirst.mockResolvedValueOnce({
+      id: "rp-1",
+    });
+    mockUpdate.mockResolvedValue({ updatedAt: new Date("2024-07-01T12:00:00.000Z") });
+
+    await handler({
+      _headers: {
+        "x-auth-user": "reader",
+        "x-auth-key": "secret",
+      },
+    } as unknown as H3Event);
+
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { id: "rp-1" },
+      data: {
+        percent: 55,
+        locator: {
+          koreader: {
+            document: "abcd1234",
+            progress: "epubcfi(/6/2!/4/2/8)",
+            percentage: 55,
+            device: "KOReader",
+            deviceId: "device-1",
+          },
+        },
+        source: "koreader",
+        updatedAt: new Date("2024-07-01T12:00:00.000Z"),
+      },
+      select: { updatedAt: true },
+    });
+  });
+
+  it("falls back to an empty object when readBody returns null", async () => {
+    mockReadBody.mockResolvedValueOnce(null);
+
+    await expect(handler({
+      _headers: {
+        "x-auth-user": "reader",
+        "x-auth-key": "secret",
+      },
+    } as unknown as H3Event)).rejects.toThrow(expect.objectContaining({ statusCode: 400 }));
+  });
+});

--- a/apps/web/server/routes/api/koreader/syncs/progress.test.ts
+++ b/apps/web/server/routes/api/koreader/syncs/progress.test.ts
@@ -1,0 +1,120 @@
+import { describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+import type { KoreaderProgressPutDeps } from "./progress";
+import { createKoreaderProgressPutHandler } from "./progress";
+
+function makeEvent(): H3Event {
+  return {} as H3Event;
+}
+
+function makeDeps(overrides: Partial<KoreaderProgressPutDeps> = {}): KoreaderProgressPutDeps {
+  return {
+    auth: vi.fn().mockResolvedValue({ credentialId: "kc1", userId: "u1", username: "reader" }),
+    readBody: vi.fn().mockResolvedValue({
+      document: "abcd1234",
+      progress: "epubcfi(/6/2!/4/2/8)",
+      percentage: 55,
+      device: "KOReader",
+      device_id: "device-1",
+    }),
+    resolveDocument: vi.fn().mockResolvedValue({
+      editionId: "ed-1",
+      fileAssetId: "fa-1",
+      document: "abcd1234",
+    }),
+    findExistingProgress: vi.fn().mockResolvedValue(null),
+    upsertProgress: vi.fn().mockResolvedValue({ updatedAt: new Date("2024-07-01T12:00:00.000Z") }),
+    now: vi.fn().mockReturnValue(new Date("2024-07-01T12:00:00.000Z")),
+    ...overrides,
+  };
+}
+
+describe("KOReader progress PUT route", () => {
+  it("creates a koreader progress record", async () => {
+    const deps = makeDeps();
+    const handler = createKoreaderProgressPutHandler(deps);
+
+    const result = await handler(makeEvent());
+
+    expect(deps.upsertProgress).toHaveBeenCalledWith({
+      userId: "u1",
+      editionId: "ed-1",
+      percent: 55,
+      progress: "epubcfi(/6/2!/4/2/8)",
+      device: "KOReader",
+      deviceId: "device-1",
+      document: "abcd1234",
+      timestamp: new Date("2024-07-01T12:00:00.000Z"),
+    });
+    expect(result).toEqual({
+      document: "abcd1234",
+      timestamp: 1719835200,
+    });
+  });
+
+  it("rejects unknown documents", async () => {
+    const deps = makeDeps({
+      resolveDocument: vi.fn().mockResolvedValue(null),
+    });
+    const handler = createKoreaderProgressPutHandler(deps);
+
+    await expect(handler(makeEvent())).rejects.toThrow(expect.objectContaining({ statusCode: 404 }));
+  });
+
+  it("rejects invalid payloads", async () => {
+    const deps = makeDeps({
+      readBody: vi.fn().mockResolvedValue({
+        document: "abcd1234",
+        percentage: 55,
+      }),
+    });
+    const handler = createKoreaderProgressPutHandler(deps);
+
+    await expect(handler(makeEvent())).rejects.toThrow(expect.objectContaining({ statusCode: 400 }));
+  });
+
+  it("skips stale device updates when the server record is newer", async () => {
+    const deps = makeDeps({
+      readBody: vi.fn().mockResolvedValue({
+        document: "abcd1234",
+        progress: "old-progress",
+        percentage: 20,
+        device: "KOReader",
+        device_id: "device-1",
+        timestamp: 1719830000,
+      }),
+      findExistingProgress: vi.fn().mockResolvedValue({
+        updatedAt: new Date("2024-07-01T12:00:00.000Z"),
+      }),
+    });
+    const handler = createKoreaderProgressPutHandler(deps);
+
+    const result = await handler(makeEvent());
+
+    expect(deps.upsertProgress).not.toHaveBeenCalled();
+    expect(result).toEqual({
+      document: "abcd1234",
+      timestamp: 1719835200,
+    });
+  });
+
+  it("uses the fallback clock when the device timestamp is invalid", async () => {
+    const deps = makeDeps({
+      readBody: vi.fn().mockResolvedValue({
+        document: "abcd1234",
+        progress: "epubcfi(/6/2!/4/2/8)",
+        percentage: 55,
+        device: "KOReader",
+        device_id: "device-1",
+        timestamp: Number.NaN,
+      }),
+    });
+    const handler = createKoreaderProgressPutHandler(deps);
+
+    await handler(makeEvent());
+
+    expect(deps.upsertProgress).toHaveBeenCalledWith(expect.objectContaining({
+      timestamp: new Date("2024-07-01T12:00:00.000Z"),
+    }));
+  });
+});

--- a/apps/web/server/routes/api/koreader/syncs/progress.ts
+++ b/apps/web/server/routes/api/koreader/syncs/progress.ts
@@ -1,0 +1,208 @@
+import { defineEventHandler, readBody, createError } from "h3";
+import type { H3Event } from "h3";
+import type { Prisma } from "@bookhouse/db";
+import type { KoreaderAuthResult } from "../auth-helper";
+import { resolveKoreaderTimestamp, type CandidateEditionFile, type KoreaderResolvedDocument } from "./shared";
+
+export interface KoreaderProgressPutDeps {
+  auth: (event: H3Event) => Promise<KoreaderAuthResult>;
+  readBody: (event: H3Event) => Promise<{
+    document?: string;
+    progress?: string;
+    percentage?: number;
+    device?: string;
+    device_id?: string;
+    timestamp?: number;
+  }>;
+  resolveDocument: (userId: string, document: string) => Promise<KoreaderResolvedDocument | null>;
+  findExistingProgress: (userId: string, editionId: string) => Promise<{ updatedAt: Date } | null>;
+  upsertProgress: (input: {
+    userId: string;
+    editionId: string;
+    percent: number;
+    progress: string;
+    device: string;
+    deviceId: string;
+    document: string;
+    timestamp: Date;
+  }) => Promise<{ updatedAt: Date }>;
+  now: () => Date;
+}
+
+type KoreaderProgressPayload = {
+  document: string;
+  progress: string;
+  percentage: number;
+  device: string;
+  device_id: string;
+  timestamp?: number;
+};
+
+function validatePayload(body: Awaited<ReturnType<KoreaderProgressPutDeps["readBody"]>>): asserts body is KoreaderProgressPayload {
+  if (
+    typeof body?.document !== "string" ||
+    typeof body.progress !== "string" ||
+    typeof body.percentage !== "number" ||
+    typeof body.device !== "string" ||
+    typeof body.device_id !== "string"
+  ) {
+    throw createError({
+      statusCode: 400,
+      statusMessage: "Bad Request",
+      message: "Invalid KOReader progress payload",
+    });
+  }
+}
+
+export function createKoreaderProgressPutHandler(deps: KoreaderProgressPutDeps) {
+  return async (event: H3Event) => {
+    const auth = await deps.auth(event);
+    const body = await deps.readBody(event);
+    validatePayload(body);
+
+    const document = await deps.resolveDocument(auth.userId, body.document);
+    if (!document) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: "Not Found",
+        message: "Unknown document",
+      });
+    }
+
+    const existing = await deps.findExistingProgress(auth.userId, document.editionId);
+    const deviceTimestamp = resolveKoreaderTimestamp(body.timestamp, deps.now());
+
+    if (!existing || deviceTimestamp.getTime() >= existing.updatedAt.getTime()) {
+      const saved = await deps.upsertProgress({
+        userId: auth.userId,
+        editionId: document.editionId,
+        percent: body.percentage,
+        progress: body.progress,
+        device: body.device,
+        deviceId: body.device_id,
+        document: body.document,
+        timestamp: deviceTimestamp,
+      });
+
+      return {
+        document: body.document,
+        timestamp: Math.floor(saved.updatedAt.getTime() / 1000),
+      };
+    }
+
+    return {
+      document: body.document,
+      timestamp: Math.floor(existing.updatedAt.getTime() / 1000),
+    };
+  };
+}
+
+export default defineEventHandler(async (event) => {
+  const { db } = await import("@bookhouse/db");
+  const { verifyPassword } = await import("@bookhouse/opds");
+  const { createKoreaderAuth } = await import("../auth-helper");
+  const { resolveKoreaderDocument } = await import("./shared");
+
+  const handler = createKoreaderProgressPutHandler({
+    auth: createKoreaderAuth({
+      findCredentialByUsername: (username) =>
+        db.koreaderCredential.findUnique({ where: { username } }),
+      verifyPassword,
+    }),
+    readBody: async (ev) => (await readBody(ev)) ?? {},
+    resolveDocument: (_userId, document) => resolveKoreaderDocument({
+      document,
+      findExactCandidates: () =>
+        db.editionFile.findMany({
+          where: {
+            fileAsset: {
+              koreaderHash: document.toLowerCase(),
+              availabilityStatus: "PRESENT",
+              mediaKind: { in: ["EPUB", "KEPUB"] },
+            },
+          },
+          include: {
+            fileAsset: {
+              select: {
+                id: true,
+                absolutePath: true,
+                availabilityStatus: true,
+                basename: true,
+                mediaKind: true,
+                koreaderHash: true,
+              },
+            },
+          },
+        }) as Promise<CandidateEditionFile[]>,
+      findUnhashedCandidates: () =>
+        db.editionFile.findMany({
+          where: {
+            fileAsset: {
+              koreaderHash: null,
+              availabilityStatus: "PRESENT",
+              mediaKind: { in: ["EPUB", "KEPUB"] },
+            },
+          },
+          include: {
+            fileAsset: {
+              select: {
+                id: true,
+                absolutePath: true,
+                availabilityStatus: true,
+                basename: true,
+                mediaKind: true,
+                koreaderHash: true,
+              },
+            },
+          },
+        }) as Promise<CandidateEditionFile[]>,
+      updateFileAssetHash: async (fileAssetId, koreaderHash) => {
+        await db.fileAsset.update({
+          where: { id: fileAssetId },
+          data: { koreaderHash },
+        });
+      },
+    }),
+    findExistingProgress: (userId, editionId) =>
+      db.readingProgress.findFirst({
+        where: { userId, editionId, progressKind: "EBOOK", source: "koreader" },
+        select: { updatedAt: true },
+      }),
+    upsertProgress: async ({ userId, editionId, percent, progress, device, deviceId, document, timestamp }) => {
+      const existing = await db.readingProgress.findFirst({
+        where: { userId, editionId, progressKind: "EBOOK", source: "koreader" },
+      });
+      const locator = {
+        koreader: {
+          document,
+          progress,
+          percentage: percent,
+          device,
+          deviceId,
+        },
+      } as Prisma.InputJsonValue;
+
+      return existing
+        ? db.readingProgress.update({
+            where: { id: existing.id },
+            data: { percent, locator, source: "koreader", updatedAt: timestamp },
+            select: { updatedAt: true },
+          })
+        : db.readingProgress.create({
+            data: {
+              userId,
+              editionId,
+              progressKind: "EBOOK",
+              percent,
+              locator,
+              source: "koreader",
+              updatedAt: timestamp,
+            },
+            select: { updatedAt: true },
+          });
+    },
+    now: () => new Date(),
+  });
+
+  return handler(event);
+});

--- a/apps/web/server/routes/api/koreader/syncs/progress/[document].default.test.ts
+++ b/apps/web/server/routes/api/koreader/syncs/progress/[document].default.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+
+const {
+  mockFindCredential,
+  mockVerifyPassword,
+  mockResolveKoreaderDocument,
+  mockFindFirst,
+  mockEditionFileFindMany,
+  mockFileAssetUpdate,
+} = vi.hoisted(() => ({
+  mockFindCredential: vi.fn(),
+  mockVerifyPassword: vi.fn(),
+  mockResolveKoreaderDocument: vi.fn(),
+  mockFindFirst: vi.fn(),
+  mockEditionFileFindMany: vi.fn(),
+  mockFileAssetUpdate: vi.fn(),
+}));
+
+vi.mock("h3", async () => {
+  const actual = await vi.importActual<typeof import("h3")>("h3");
+  return {
+    ...actual,
+    defineEventHandler: (handler: (event: H3Event) => unknown) => handler,
+    getRequestHeader: (event: { _headers?: Record<string, string> }, name: string) =>
+      event._headers?.[name.toLowerCase()] ?? null,
+  };
+});
+
+vi.mock("@bookhouse/db", () => ({
+  db: {
+    koreaderCredential: {
+      findUnique: mockFindCredential,
+    },
+    editionFile: {
+      findMany: mockEditionFileFindMany,
+    },
+    fileAsset: {
+      update: mockFileAssetUpdate,
+    },
+    readingProgress: {
+      findFirst: mockFindFirst,
+    },
+  },
+}));
+
+vi.mock("@bookhouse/opds", () => ({
+  verifyPassword: mockVerifyPassword,
+}));
+
+vi.mock("../shared", async () => {
+  return {
+    resolveKoreaderDocument: mockResolveKoreaderDocument,
+    resolveKoreaderTimestamp: (timestamp: number | undefined, fallback: Date) =>
+      typeof timestamp === "number" && !Number.isNaN(timestamp)
+        ? new Date(timestamp * 1000)
+        : fallback,
+  };
+});
+
+const { default: handler } = await import("./[document]");
+
+describe("KOReader progress document route default handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindCredential.mockResolvedValue({
+      id: "kc1",
+      userId: "u1",
+      username: "reader",
+      passwordHash: "salt:hash",
+      isEnabled: true,
+    });
+    mockVerifyPassword.mockResolvedValue(true);
+    mockEditionFileFindMany.mockResolvedValue([]);
+    mockFileAssetUpdate.mockResolvedValue({});
+    mockResolveKoreaderDocument.mockImplementation(async (deps) => {
+      await deps.findExactCandidates();
+      await deps.findUnhashedCandidates();
+      await deps.updateFileAssetHash("fa-1", "abcd1234");
+
+      return {
+        document: "abcd1234",
+        editionId: "ed-1",
+        fileAssetId: "fa-1",
+      };
+    });
+    mockFindFirst.mockResolvedValue({
+      percent: 55,
+      locator: {
+        koreader: {
+          document: "abcd1234",
+          progress: "epubcfi(/6/2!/4/2/8)",
+          percentage: 55,
+          device: "KOReader",
+          deviceId: "device-1",
+        },
+      },
+      updatedAt: new Date("2024-07-01T12:00:00.000Z"),
+    });
+  });
+
+  it("wires the module default handler through auth, resolution, and lookup", async () => {
+    const result = await handler({
+      _headers: {
+        "x-auth-user": "reader",
+        "x-auth-key": "secret",
+      },
+      context: {
+        params: {
+          document: "abcd1234",
+        },
+      },
+    } as unknown as H3Event);
+
+    expect(mockFindCredential).toHaveBeenCalledWith({ where: { username: "reader" } });
+    expect(mockVerifyPassword).toHaveBeenCalledWith("secret", "salt:hash");
+    expect(mockResolveKoreaderDocument).toHaveBeenCalledWith(expect.objectContaining({
+      document: "abcd1234",
+      updateFileAssetHash: expect.any(Function),
+    }));
+    expect(mockEditionFileFindMany).toHaveBeenCalledTimes(2);
+    expect(mockFileAssetUpdate).toHaveBeenCalledWith({
+      where: { id: "fa-1" },
+      data: { koreaderHash: "abcd1234" },
+    });
+    expect(mockFindFirst).toHaveBeenCalledWith({
+      where: { userId: "u1", editionId: "ed-1", progressKind: "EBOOK", source: "koreader" },
+      select: {
+        percent: true,
+        locator: true,
+        updatedAt: true,
+      },
+    });
+    expect(result).toEqual({
+      document: "abcd1234",
+      progress: "epubcfi(/6/2!/4/2/8)",
+      percentage: 55,
+      device: "KOReader",
+      device_id: "device-1",
+      timestamp: 1719835200,
+    });
+  });
+});

--- a/apps/web/server/routes/api/koreader/syncs/progress/[document].test.ts
+++ b/apps/web/server/routes/api/koreader/syncs/progress/[document].test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+import type { KoreaderProgressGetDeps } from "./[document]";
+import { createKoreaderProgressGetHandler } from "./[document]";
+
+function makeEvent(document = "abcd1234"): H3Event {
+  return {
+    context: { params: { document } },
+  } as unknown as H3Event;
+}
+
+function makeDeps(overrides: Partial<KoreaderProgressGetDeps> = {}): KoreaderProgressGetDeps {
+  return {
+    auth: vi.fn().mockResolvedValue({ credentialId: "kc1", userId: "u1", username: "reader" }),
+    resolveDocument: vi.fn().mockResolvedValue({ editionId: "ed-1", fileAssetId: "fa-1", document: "abcd1234" }),
+    findProgress: vi.fn().mockResolvedValue({
+      percent: 55,
+      locator: {
+        koreader: {
+          document: "abcd1234",
+          progress: "epubcfi(/6/2!/4/2/8)",
+          percentage: 55,
+          device: "KOReader",
+          deviceId: "device-1",
+        },
+      },
+      updatedAt: new Date("2024-07-01T12:00:00.000Z"),
+    }),
+    ...overrides,
+  };
+}
+
+describe("KOReader progress GET route", () => {
+  it("returns the stored koreader progress for a matched document", async () => {
+    const handler = createKoreaderProgressGetHandler(makeDeps());
+
+    await expect(handler(makeEvent())).resolves.toEqual({
+      document: "abcd1234",
+      progress: "epubcfi(/6/2!/4/2/8)",
+      percentage: 55,
+      device: "KOReader",
+      device_id: "device-1",
+      timestamp: 1719835200,
+    });
+  });
+
+  it("returns 404 for an unknown document", async () => {
+    const handler = createKoreaderProgressGetHandler(makeDeps({
+      resolveDocument: vi.fn().mockResolvedValue(null),
+    }));
+
+    await expect(handler(makeEvent())).rejects.toThrow(expect.objectContaining({ statusCode: 404 }));
+  });
+
+  it("returns 400 when the document route param is missing", async () => {
+    const handler = createKoreaderProgressGetHandler(makeDeps());
+
+    await expect(handler({
+      context: { params: {} },
+    } as unknown as H3Event)).rejects.toThrow(expect.objectContaining({ statusCode: 400 }));
+  });
+
+  it("returns 404 when there is no stored koreader locator", async () => {
+    const handler = createKoreaderProgressGetHandler(makeDeps({
+      findProgress: vi.fn().mockResolvedValue({
+        percent: 55,
+        locator: {},
+        updatedAt: new Date("2024-07-01T12:00:00.000Z"),
+      }),
+    }));
+
+    await expect(handler(makeEvent())).rejects.toThrow(expect.objectContaining({ statusCode: 404 }));
+  });
+});

--- a/apps/web/server/routes/api/koreader/syncs/progress/[document].ts
+++ b/apps/web/server/routes/api/koreader/syncs/progress/[document].ts
@@ -1,0 +1,138 @@
+import { defineEventHandler, createError } from "h3";
+import type { H3Event } from "h3";
+import type { KoreaderAuthResult } from "../../auth-helper";
+import { resolveKoreaderTimestamp, type CandidateEditionFile, type KoreaderResolvedDocument } from "../shared";
+
+export interface KoreaderProgressGetDeps {
+  auth: (event: H3Event) => Promise<KoreaderAuthResult>;
+  resolveDocument: (userId: string, document: string) => Promise<KoreaderResolvedDocument | null>;
+  findProgress: (userId: string, editionId: string) => Promise<{
+    percent: number | null;
+    locator: { koreader?: { document: string; progress: string; percentage: number; device: string; deviceId: string } };
+    updatedAt: Date;
+  } | null>;
+}
+
+export function createKoreaderProgressGetHandler(deps: KoreaderProgressGetDeps) {
+  return async (event: H3Event) => {
+    const auth = await deps.auth(event);
+    const documentParam = (event.context.params as Record<string, string> | undefined)?.document;
+    if (!documentParam) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: "Bad Request",
+        message: "Missing document",
+      });
+    }
+
+    const document = await deps.resolveDocument(auth.userId, documentParam);
+    if (!document) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: "Not Found",
+        message: "Unknown document",
+      });
+    }
+
+    const progress = await deps.findProgress(auth.userId, document.editionId);
+    if (!progress?.locator.koreader) {
+      throw createError({
+        statusCode: 404,
+        statusMessage: "Not Found",
+        message: "No KOReader progress found",
+      });
+    }
+
+    return {
+      document: progress.locator.koreader.document,
+      progress: progress.locator.koreader.progress,
+      percentage: progress.locator.koreader.percentage,
+      device: progress.locator.koreader.device,
+      device_id: progress.locator.koreader.deviceId,
+      timestamp: Math.floor(resolveKoreaderTimestamp(undefined, progress.updatedAt).getTime() / 1000),
+    };
+  };
+}
+
+export default defineEventHandler(async (event) => {
+  const { db } = await import("@bookhouse/db");
+  const { verifyPassword } = await import("@bookhouse/opds");
+  const { createKoreaderAuth } = await import("../../auth-helper");
+  const { resolveKoreaderDocument } = await import("../shared");
+
+  const handler = createKoreaderProgressGetHandler({
+    auth: createKoreaderAuth({
+      findCredentialByUsername: (username) =>
+        db.koreaderCredential.findUnique({ where: { username } }),
+      verifyPassword,
+    }),
+    resolveDocument: (_userId, document) => resolveKoreaderDocument({
+      document,
+      findExactCandidates: () =>
+        db.editionFile.findMany({
+          where: {
+            fileAsset: {
+              koreaderHash: document.toLowerCase(),
+              availabilityStatus: "PRESENT",
+              mediaKind: { in: ["EPUB", "KEPUB"] },
+            },
+          },
+          include: {
+            fileAsset: {
+              select: {
+                id: true,
+                absolutePath: true,
+                availabilityStatus: true,
+                basename: true,
+                mediaKind: true,
+                koreaderHash: true,
+              },
+            },
+          },
+        }) as Promise<CandidateEditionFile[]>,
+      findUnhashedCandidates: () =>
+        db.editionFile.findMany({
+          where: {
+            fileAsset: {
+              koreaderHash: null,
+              availabilityStatus: "PRESENT",
+              mediaKind: { in: ["EPUB", "KEPUB"] },
+            },
+          },
+          include: {
+            fileAsset: {
+              select: {
+                id: true,
+                absolutePath: true,
+                availabilityStatus: true,
+                basename: true,
+                mediaKind: true,
+                koreaderHash: true,
+              },
+            },
+          },
+        }) as Promise<CandidateEditionFile[]>,
+      updateFileAssetHash: async (fileAssetId, koreaderHash) => {
+        await db.fileAsset.update({
+          where: { id: fileAssetId },
+          data: { koreaderHash },
+        });
+      },
+    }),
+    findProgress: (userId, editionId) =>
+      db.readingProgress.findFirst({
+        where: { userId, editionId, progressKind: "EBOOK", source: "koreader" },
+        select: {
+          percent: true,
+          locator: true,
+          updatedAt: true,
+        },
+      }) as Promise<{
+        percent: number | null;
+        locator: { koreader?: { document: string; progress: string; percentage: number; device: string; deviceId: string } };
+        updatedAt: Date;
+      } | null>,
+  });
+
+  return handler(event);
+});

--- a/apps/web/server/routes/api/koreader/syncs/shared.test.ts
+++ b/apps/web/server/routes/api/koreader/syncs/shared.test.ts
@@ -1,0 +1,150 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { CandidateEditionFile } from "./shared";
+import { resolveKoreaderDocument, resolveKoreaderTimestamp } from "./shared";
+
+const { mockHashFileContents } = vi.hoisted(() => ({
+  mockHashFileContents: vi.fn(),
+}));
+
+vi.mock("@bookhouse/ingest", () => ({
+  hashFileContents: mockHashFileContents,
+}));
+
+vi.mock("@bookhouse/shared", () => ({
+  selectPreferredKoboDeliveryFile: (
+    files: Array<{ id: string; role: string }>,
+  ) => files.find((file) => file.role === "DELIVERY") ?? files[0] ?? null,
+}));
+
+function makeCandidate(
+  overrides: Partial<Omit<CandidateEditionFile, "fileAsset">> & {
+    fileAsset?: Partial<CandidateEditionFile["fileAsset"]>;
+  } = {},
+): CandidateEditionFile {
+  const { fileAsset: fileAssetOverrides, ...candidateOverrides } = overrides;
+  const fileAsset = {
+    id: "fa-1",
+    absolutePath: "/library/book.epub",
+    availabilityStatus: "PRESENT",
+    basename: "book.epub",
+    mediaKind: "EPUB",
+    koreaderHash: "abcd1234",
+    ...fileAssetOverrides,
+  };
+
+  return {
+    id: "ef-1",
+    editionId: "ed-1",
+    role: "DELIVERY",
+    ...candidateOverrides,
+    fileAsset,
+  };
+}
+
+describe("resolveKoreaderDocument", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns the preferred exact match", async () => {
+    const result = await resolveKoreaderDocument({
+      document: "ABCD1234",
+      findExactCandidates: async () => [
+        makeCandidate(),
+        makeCandidate({
+          id: "ef-2",
+          editionId: "ed-1",
+          role: "SIDECAR",
+          fileAsset: { id: "fa-2", koreaderHash: "ABCD1234" },
+        }),
+      ],
+      findUnhashedCandidates: async () => [],
+      updateFileAssetHash: vi.fn(),
+    });
+
+    expect(result).toEqual({
+      document: "ABCD1234",
+      editionId: "ed-1",
+      fileAssetId: "fa-1",
+    });
+  });
+
+  it("does not match when only a non-preferred file has the hash", async () => {
+    const result = await resolveKoreaderDocument({
+      document: "abcd1234",
+      findExactCandidates: async () => [
+        makeCandidate({
+          fileAsset: { koreaderHash: "different-hash" },
+        }),
+        makeCandidate({
+          id: "ef-2",
+          role: "SIDECAR",
+          fileAsset: { id: "fa-2", koreaderHash: "abcd1234" },
+        }),
+      ],
+      findUnhashedCandidates: async () => [],
+      updateFileAssetHash: vi.fn(),
+    });
+
+    expect(result).toBeNull();
+  });
+
+  it("lazily hashes unhashed candidates and de-duplicates file asset updates", async () => {
+    mockHashFileContents.mockResolvedValueOnce({ koreaderHash: "lazy-hash-1" });
+
+    const updateFileAssetHash = vi.fn();
+    const sharedFileAsset = {
+      id: "fa-1",
+      absolutePath: "/library/book.epub",
+      availabilityStatus: "PRESENT",
+      basename: "book.epub",
+      mediaKind: "EPUB",
+      koreaderHash: null,
+    };
+
+    const result = await resolveKoreaderDocument({
+      document: "lazy-hash-1",
+      findExactCandidates: async () => [],
+      findUnhashedCandidates: async () => [
+        {
+          id: "ef-1",
+          editionId: "ed-1",
+          role: "DELIVERY",
+          fileAsset: sharedFileAsset,
+        },
+        {
+          id: "ef-2",
+          editionId: "ed-1",
+          role: "SIDECAR",
+          fileAsset: sharedFileAsset,
+        },
+      ],
+      updateFileAssetHash,
+    });
+
+    expect(mockHashFileContents).toHaveBeenCalledTimes(1);
+    expect(mockHashFileContents).toHaveBeenCalledWith("/library/book.epub");
+    expect(updateFileAssetHash).toHaveBeenCalledTimes(1);
+    expect(updateFileAssetHash).toHaveBeenCalledWith("fa-1", "lazy-hash-1");
+    expect(result).toEqual({
+      document: "lazy-hash-1",
+      editionId: "ed-1",
+      fileAssetId: "fa-1",
+    });
+  });
+});
+
+describe("resolveKoreaderTimestamp", () => {
+  it("falls back when the timestamp is missing or invalid", () => {
+    const fallback = new Date("2024-07-01T12:00:00.000Z");
+
+    expect(resolveKoreaderTimestamp(undefined, fallback)).toBe(fallback);
+    expect(resolveKoreaderTimestamp(Number.NaN, fallback)).toBe(fallback);
+  });
+
+  it("converts epoch seconds into a Date", () => {
+    expect(resolveKoreaderTimestamp(1719835200, new Date("2020-01-01T00:00:00.000Z"))).toEqual(
+      new Date("2024-07-01T12:00:00.000Z"),
+    );
+  });
+});

--- a/apps/web/server/routes/api/koreader/syncs/shared.ts
+++ b/apps/web/server/routes/api/koreader/syncs/shared.ts
@@ -1,0 +1,93 @@
+import { hashFileContents } from "@bookhouse/ingest";
+import { selectPreferredKoboDeliveryFile } from "@bookhouse/shared";
+
+export interface KoreaderResolvedDocument {
+  document: string;
+  editionId: string;
+  fileAssetId: string;
+}
+
+export interface CandidateEditionFile {
+  id: string;
+  editionId: string;
+  role: string;
+  fileAsset: {
+    id: string;
+    absolutePath: string;
+    availabilityStatus: string;
+    basename: string;
+    mediaKind: string;
+    koreaderHash: string | null;
+  };
+}
+
+interface ResolveKoreaderDocumentDeps {
+  findExactCandidates: () => Promise<CandidateEditionFile[]>;
+  findUnhashedCandidates: () => Promise<CandidateEditionFile[]>;
+  updateFileAssetHash: (fileAssetId: string, koreaderHash: string) => Promise<void>;
+  document: string;
+}
+
+function pickMatch(document: string, editionFiles: CandidateEditionFile[]): KoreaderResolvedDocument | null {
+  const byEdition = new Map<string, CandidateEditionFile[]>();
+
+  for (const editionFile of editionFiles) {
+    const list = byEdition.get(editionFile.editionId) ?? [];
+    list.push(editionFile);
+    byEdition.set(editionFile.editionId, list);
+  }
+
+  for (const [editionId, candidates] of byEdition.entries()) {
+    const preferred = selectPreferredKoboDeliveryFile(candidates.map((editionFile) => ({
+      id: editionFile.id,
+      role: editionFile.role,
+      fileAsset: {
+        basename: editionFile.fileAsset.basename,
+        mediaKind: editionFile.fileAsset.mediaKind,
+      },
+    })));
+
+    const matched = candidates.find((candidate) => candidate.id === preferred?.id);
+    if (matched?.fileAsset.koreaderHash?.toLowerCase() === document.toLowerCase()) {
+      return {
+        document,
+        editionId,
+        fileAssetId: matched.fileAsset.id,
+      };
+    }
+  }
+
+  return null;
+}
+
+export async function resolveKoreaderDocument(
+  deps: ResolveKoreaderDocumentDeps,
+): Promise<KoreaderResolvedDocument | null> {
+  const exactCandidates = await deps.findExactCandidates();
+
+  const exactMatch = pickMatch(deps.document, exactCandidates);
+  if (exactMatch) {
+    return exactMatch;
+  }
+
+  const unhashedCandidates = await deps.findUnhashedCandidates();
+
+  const seenFileAssetIds = new Set<string>();
+  for (const candidate of unhashedCandidates) {
+    if (seenFileAssetIds.has(candidate.fileAsset.id)) continue;
+    seenFileAssetIds.add(candidate.fileAsset.id);
+    const hashes = await hashFileContents(candidate.fileAsset.absolutePath);
+    candidate.fileAsset.koreaderHash = hashes.koreaderHash;
+    await deps.updateFileAssetHash(candidate.fileAsset.id, hashes.koreaderHash);
+  }
+
+  return pickMatch(deps.document, unhashedCandidates);
+}
+
+export function resolveKoreaderTimestamp(timestamp: number | undefined, fallback: Date): Date {
+  if (typeof timestamp !== "number" || Number.isNaN(timestamp)) {
+    return fallback;
+  }
+
+  return new Date(timestamp * 1000);
+}

--- a/apps/web/server/routes/api/koreader/users/auth.default.test.ts
+++ b/apps/web/server/routes/api/koreader/users/auth.default.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+
+const { mockFindCredential, mockVerifyPassword } = vi.hoisted(() => ({
+  mockFindCredential: vi.fn(),
+  mockVerifyPassword: vi.fn(),
+}));
+
+vi.mock("h3", async () => {
+  const actual = await vi.importActual<typeof import("h3")>("h3");
+  return {
+    ...actual,
+    defineEventHandler: (handler: (event: H3Event) => unknown) => handler,
+    getRequestHeader: (event: { _headers?: Record<string, string> }, name: string) =>
+      event._headers?.[name.toLowerCase()] ?? null,
+  };
+});
+
+vi.mock("@bookhouse/db", () => ({
+  db: {
+    koreaderCredential: {
+      findUnique: mockFindCredential,
+    },
+  },
+}));
+
+vi.mock("@bookhouse/opds", () => ({
+  verifyPassword: mockVerifyPassword,
+}));
+
+const { default: handler } = await import("./auth");
+
+describe("KOReader users/auth default handler", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockFindCredential.mockResolvedValue({
+      id: "kc1",
+      userId: "u1",
+      username: "reader",
+      passwordHash: "salt:hash",
+      isEnabled: true,
+    });
+    mockVerifyPassword.mockResolvedValue(true);
+  });
+
+  it("authenticates and returns the KOReader authorization payload", async () => {
+    await expect(handler({
+      _headers: {
+        "x-auth-user": "reader",
+        "x-auth-key": "secret",
+      },
+    } as unknown as H3Event)).resolves.toEqual({ authorized: "OK" });
+
+    expect(mockFindCredential).toHaveBeenCalledWith({ where: { username: "reader" } });
+    expect(mockVerifyPassword).toHaveBeenCalledWith("secret", "salt:hash");
+  });
+});

--- a/apps/web/server/routes/api/koreader/users/auth.test.ts
+++ b/apps/web/server/routes/api/koreader/users/auth.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from "vitest";
+import type { H3Event } from "h3";
+import type { KoreaderUserAuthDeps } from "./auth";
+import { createKoreaderUserAuthHandler } from "./auth";
+
+function makeEvent(): H3Event {
+  return {} as H3Event;
+}
+
+function makeDeps(overrides: Partial<KoreaderUserAuthDeps> = {}): KoreaderUserAuthDeps {
+  return {
+    auth: vi.fn().mockResolvedValue({
+      credentialId: "kc1",
+      userId: "u1",
+      username: "reader",
+    }),
+    ...overrides,
+  };
+}
+
+describe("KOReader users/auth route", () => {
+  it("returns authorized OK for valid credentials", async () => {
+    const handler = createKoreaderUserAuthHandler(makeDeps());
+    await expect(handler(makeEvent())).resolves.toEqual({ authorized: "OK" });
+  });
+
+  it("bubbles auth errors", async () => {
+    const handler = createKoreaderUserAuthHandler(makeDeps({
+      auth: vi.fn().mockRejectedValue(Object.assign(new Error("Unauthorized"), { statusCode: 401 })),
+    }));
+
+    await expect(handler(makeEvent())).rejects.toThrow("Unauthorized");
+  });
+});

--- a/apps/web/server/routes/api/koreader/users/auth.ts
+++ b/apps/web/server/routes/api/koreader/users/auth.ts
@@ -1,0 +1,30 @@
+import { defineEventHandler } from "h3";
+import type { H3Event } from "h3";
+import type { KoreaderAuthResult } from "../auth-helper";
+
+export interface KoreaderUserAuthDeps {
+  auth: (event: H3Event) => Promise<KoreaderAuthResult>;
+}
+
+export function createKoreaderUserAuthHandler(deps: KoreaderUserAuthDeps) {
+  return async (event: H3Event) => {
+    await deps.auth(event);
+    return { authorized: "OK" };
+  };
+}
+
+export default defineEventHandler(async (event) => {
+  const { db } = await import("@bookhouse/db");
+  const { verifyPassword } = await import("@bookhouse/opds");
+  const { createKoreaderAuth } = await import("../auth-helper");
+
+  const handler = createKoreaderUserAuthHandler({
+    auth: createKoreaderAuth({
+      findCredentialByUsername: (username) =>
+        db.koreaderCredential.findUnique({ where: { username } }),
+      verifyPassword,
+    }),
+  });
+
+  return handler(event);
+});

--- a/apps/web/src/components/edition-progress.test.tsx
+++ b/apps/web/src/components/edition-progress.test.tsx
@@ -59,17 +59,17 @@ describe("EditionProgress", () => {
 
   it("renders progress bar for each edition", () => {
     render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
-    expect(screen.getByTestId("progress-bar")).toBeTruthy();
+    expect(screen.getAllByTestId("progress-bar").length).toBeGreaterThan(0);
   });
 
   it("renders format badge", () => {
     render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
-    expect(screen.getByText("EBOOK")).toBeTruthy();
+    expect(screen.getAllByText("EBOOK").length).toBeGreaterThan(0);
   });
 
   it("renders source badge", () => {
     render(<EditionProgress progress={progress} editions={editions} onUpdate={mockOnUpdate} />);
-    expect(screen.getByText("via Kobo")).toBeTruthy();
+    expect(screen.getByText(/via\s+kobo/i)).toBeTruthy();
   });
 
   it("does not render source badge when source is null", () => {
@@ -167,5 +167,19 @@ describe("EditionProgress", () => {
     }]);
     render(<EditionProgress progress={[]} editions={audioEditions} onUpdate={mockOnUpdate} />);
     expect(screen.getByText("AUDIOBOOK")).toBeTruthy();
+  });
+
+  it("renders separate rows for multiple sources on the same edition", () => {
+    const multiSourceProgress = [
+      { editionId: "e1", progressKind: "EBOOK", percent: 42, source: "manual" as string | null },
+      { editionId: "e1", progressKind: "EBOOK", percent: 65, source: "koreader" as string | null },
+    ];
+
+    render(<EditionProgress progress={multiSourceProgress} editions={editions} onUpdate={mockOnUpdate} />);
+
+    expect(screen.getByText(/via\s+manual/i)).toBeTruthy();
+    expect(screen.getByText(/via\s+koreader/i)).toBeTruthy();
+    expect(screen.getByText("42%")).toBeTruthy();
+    expect(screen.getByText("65%")).toBeTruthy();
   });
 });

--- a/apps/web/src/components/edition-progress.tsx
+++ b/apps/web/src/components/edition-progress.tsx
@@ -16,8 +16,18 @@ interface EditionProgressProps {
   onUpdate: (editionId: string, percent: number, progressKind: string) => Promise<void>;
 }
 
+function normalizeProgressSource(source: string | null | undefined): string | null {
+  if (source == null) return null;
+  return source.toLowerCase();
+}
+
 export function EditionProgress({ progress, editions, onUpdate }: EditionProgressProps) {
-  const progressMap = new Map(progress.map((p) => [p.editionId, p]));
+  const progressMap = new Map<string, typeof progress>();
+  for (const entry of progress) {
+    const existing = progressMap.get(entry.editionId) ?? [];
+    existing.push(entry);
+    progressMap.set(entry.editionId, existing);
+  }
   const [editingId, setEditingId] = useState<string | null>(null);
   const [editValue, setEditValue] = useState("");
   const [saving, setSaving] = useState(false);
@@ -37,70 +47,95 @@ export function EditionProgress({ progress, editions, onUpdate }: EditionProgres
   return (
     <div className="space-y-3">
       {editions.map((edition) => {
-        const p = progressMap.get(edition.id);
-        const percent = p?.percent ?? 0;
-        const progressKind = p?.progressKind ?? progressKindForEdition(edition.formatFamily);
+        const entries = progressMap.get(edition.id) ?? [];
+        const manualEntry = entries.find((entry) => entry.source === "manual" || entry.source === null) ?? null;
+        const sourceEntries = [
+          {
+            editionId: edition.id,
+            progressKind: manualEntry?.progressKind ?? progressKindForEdition(edition.formatFamily),
+            percent: manualEntry?.percent ?? 0,
+            source: manualEntry?.source,
+            editable: true,
+          },
+          ...entries
+            .filter((entry) => entry !== manualEntry)
+            .map((entry) => ({ ...entry, editable: false })),
+        ];
         const isEditing = editingId === edition.id;
 
         return (
           <div key={edition.id} className="space-y-1">
-            <div className="flex items-center gap-2 text-sm">
-              <Badge variant="secondary">{edition.formatFamily}</Badge>
-              {p?.source && <Badge variant="outline" className="text-xs">via {p.source}</Badge>}
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="flex-1">
-                <ProgressBar percent={percent} />
-              </div>
-              {isEditing ? (
-                <div className="flex items-center gap-1">
-                  <input
-                    data-testid={`progress-input-${edition.id}`}
-                    type="number"
-                    min={0}
-                    max={100}
-                    value={editValue}
-                    onChange={(e) => { setEditValue(e.target.value); }}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") { void handleSave(edition.id, progressKind); }
-                      if (e.key === "Escape") { setEditingId(null); }
-                    }}
-                    className="w-16 rounded border px-2 py-0.5 text-sm text-right"
-                    autoFocus
-                    disabled={saving}
-                  />
-                  <span className="text-sm">%</span>
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    disabled={saving}
-                    onClick={() => { void handleSave(edition.id, progressKind); }}
-                    data-testid={`progress-save-${edition.id}`}
-                  >
-                    {saving ? <Loader2 className="size-3 animate-spin" /> : "Save"}
-                  </Button>
-                  <Button
-                    size="sm"
-                    variant="ghost"
-                    disabled={saving}
-                    onClick={() => { setEditingId(null); }}
-                    data-testid={`progress-cancel-${edition.id}`}
-                  >
-                    ✕
-                  </Button>
+            {sourceEntries.map((entry, index) => {
+              const percent = entry.percent ?? 0;
+              const progressKind = entry.progressKind;
+              const normalizedSource = normalizeProgressSource(entry.source);
+
+              return (
+                <div key={`${edition.id}-${normalizedSource ?? "local"}-${String(index)}`} className="space-y-1">
+                  <div className="flex items-center gap-2 text-sm">
+                    <Badge variant="secondary">{edition.formatFamily}</Badge>
+                    {normalizedSource && <Badge variant="outline" className="text-xs">via {normalizedSource}</Badge>}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <div className="flex-1">
+                      <ProgressBar percent={percent} />
+                    </div>
+                    {entry.editable ? (
+                      isEditing ? (
+                        <div className="flex items-center gap-1">
+                          <input
+                            data-testid={`progress-input-${edition.id}`}
+                            type="number"
+                            min={0}
+                            max={100}
+                            value={editValue}
+                            onChange={(e) => { setEditValue(e.target.value); }}
+                            onKeyDown={(e) => {
+                              if (e.key === "Enter") { void handleSave(edition.id, progressKind); }
+                              if (e.key === "Escape") { setEditingId(null); }
+                            }}
+                            className="w-16 rounded border px-2 py-0.5 text-sm text-right"
+                            autoFocus
+                            disabled={saving}
+                          />
+                          <span className="text-sm">%</span>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            disabled={saving}
+                            onClick={() => { void handleSave(edition.id, progressKind); }}
+                            data-testid={`progress-save-${edition.id}`}
+                          >
+                            {saving ? <Loader2 className="size-3 animate-spin" /> : "Save"}
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="ghost"
+                            disabled={saving}
+                            onClick={() => { setEditingId(null); }}
+                            data-testid={`progress-cancel-${edition.id}`}
+                          >
+                            ✕
+                          </Button>
+                        </div>
+                      ) : (
+                        <button
+                          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground group"
+                          onClick={() => { setEditingId(edition.id); setEditValue(String(percent)); }}
+                          data-testid={`progress-edit-${edition.id}`}
+                          aria-label={`Edit progress for ${edition.formatFamily}`}
+                        >
+                          <span>{String(percent)}%</span>
+                          <Pencil className="size-3 opacity-0 group-hover:opacity-100 transition-opacity" />
+                        </button>
+                      )
+                    ) : (
+                      <span className="text-sm text-muted-foreground">{String(percent)}%</span>
+                    )}
+                  </div>
                 </div>
-              ) : (
-                <button
-                  className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground group"
-                  onClick={() => { setEditingId(edition.id); setEditValue(String(percent)); }}
-                  data-testid={`progress-edit-${edition.id}`}
-                  aria-label={`Edit progress for ${edition.formatFamily}`}
-                >
-                  <span>{String(percent)}%</span>
-                  <Pencil className="size-3 opacity-0 group-hover:opacity-100 transition-opacity" />
-                </button>
-              )}
-            </div>
+              );
+            })}
           </div>
         );
       })}

--- a/apps/web/src/components/work-progress.test.tsx
+++ b/apps/web/src/components/work-progress.test.tsx
@@ -27,4 +27,20 @@ describe("WorkProgress", () => {
     const bar = screen.getByTestId("progress-bar");
     expect(bar.getAttribute("data-percent")).toBe("30");
   });
+
+  it("renders separate rows when multiple sources exist", () => {
+    render(
+      <WorkProgress
+        progress={[
+          { percent: 40, source: "manual" },
+          { percent: 60, source: "koreader" },
+        ]}
+      />,
+    );
+
+    expect(screen.getByText(/via\s+manual/i)).toBeTruthy();
+    expect(screen.getByText(/via\s+koreader/i)).toBeTruthy();
+    expect(screen.getByText("40%")).toBeTruthy();
+    expect(screen.getByText("60%")).toBeTruthy();
+  });
 });

--- a/apps/web/src/components/work-progress.tsx
+++ b/apps/web/src/components/work-progress.tsx
@@ -1,19 +1,37 @@
 import { ProgressBar } from "~/components/progress-bar";
+import { Badge } from "~/components/ui/badge";
 
 interface WorkProgressProps {
-  progress: { percent: number | null }[];
+  progress: { percent: number | null; source?: string | null }[];
 }
 
 export function WorkProgress({ progress }: WorkProgressProps) {
-  const maxPercent = Math.max(...progress.map((p) => p.percent ?? 0));
+  const progressBySource = new Map<string, number>();
+
+  for (const entry of progress) {
+    const source = (entry.source ?? "manual").toLowerCase();
+    const percent = entry.percent ?? 0;
+    progressBySource.set(source, Math.max(progressBySource.get(source) ?? 0, percent));
+  }
+
+  const rows = [...progressBySource.entries()];
   return (
-    <div className="space-y-1">
-      <div className="flex items-center gap-2">
-        <div className="flex-1">
-          <ProgressBar percent={maxPercent} />
+    <div className="space-y-2">
+      {rows.map(([source, percent]) => (
+        <div key={source} className="space-y-1">
+          {rows.length > 1 && (
+            <div className="flex items-center gap-2 text-sm">
+              <Badge variant="outline" className="text-xs">via {source}</Badge>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <div className="flex-1">
+              <ProgressBar percent={percent} />
+            </div>
+            <span className="text-sm text-muted-foreground">{String(percent)}%</span>
+          </div>
         </div>
-        <span className="text-sm text-muted-foreground">{String(maxPercent)}%</span>
-      </div>
+      ))}
     </div>
   );
 }

--- a/apps/web/src/lib/server-fns/authors.test.ts
+++ b/apps/web/src/lib/server-fns/authors.test.ts
@@ -87,7 +87,7 @@ describe("getAuthorsListServerFn", () => {
           include: { edition: { select: { workId: true } } },
         },
       },
-      orderBy: { nameDisplay: "asc" },
+      orderBy: { nameSort: "asc" },
     });
     expect(result).toEqual([
       { id: "c1", nameDisplay: "Author One", workCount: 2, imagePath: null },
@@ -112,6 +112,7 @@ describe("getAuthorDetailServerFn", () => {
       id: "c1",
       nameDisplay: "Author One",
       nameCanonical: "author one",
+      nameSort: "one, author",
       imagePath: "c1",
       editions: [
         { edition: { workId: "w1" } },
@@ -135,6 +136,7 @@ describe("getAuthorDetailServerFn", () => {
         id: true,
         nameDisplay: true,
         nameCanonical: true,
+        nameSort: true,
         imagePath: true,
         editions: {
           where: { role: "AUTHOR" },
@@ -157,6 +159,7 @@ describe("getAuthorDetailServerFn", () => {
       id: "c1",
       nameDisplay: "Author One",
       nameCanonical: "author one",
+      nameSort: "one, author",
       imagePath: "c1",
       works: fakeWorks,
     });

--- a/apps/web/src/lib/server-fns/authors.ts
+++ b/apps/web/src/lib/server-fns/authors.ts
@@ -15,7 +15,7 @@ export const getAuthorsListServerFn = createServerFn({
         include: { edition: { select: { workId: true } } },
       },
     },
-    orderBy: { nameDisplay: "asc" },
+    orderBy: { nameSort: "asc" },
   });
   return contributors.map((c) => ({
     id: c.id,
@@ -46,6 +46,7 @@ export const getAuthorDetailServerFn = createServerFn({
         id: true,
         nameDisplay: true,
         nameCanonical: true,
+        nameSort: true,
         imagePath: true,
         editions: {
           where: { role: "AUTHOR" },
@@ -72,6 +73,7 @@ export const getAuthorDetailServerFn = createServerFn({
       id: contributor.id,
       nameDisplay: contributor.nameDisplay,
       nameCanonical: contributor.nameCanonical,
+      nameSort: contributor.nameSort,
       imagePath: contributor.imagePath,
       works,
     };

--- a/apps/web/src/lib/server-fns/editing.test.ts
+++ b/apps/web/src/lib/server-fns/editing.test.ts
@@ -22,6 +22,7 @@ const editionFindManyMock = vi.fn();
 const contributorFindFirstMock = vi.fn();
 const contributorCreateMock = vi.fn();
 const contributorFindManyMock = vi.fn();
+const contributorUpdateMock = vi.fn();
 const editionContributorDeleteManyMock = vi.fn();
 const editionContributorCreateManyMock = vi.fn();
 const transactionMock = vi.fn();
@@ -41,6 +42,7 @@ vi.mock("@bookhouse/db", () => ({
       findFirst: contributorFindFirstMock,
       findMany: contributorFindManyMock,
       create: contributorCreateMock,
+      update: contributorUpdateMock,
     },
     editionContributor: {
       deleteMany: editionContributorDeleteManyMock,
@@ -52,10 +54,12 @@ vi.mock("@bookhouse/db", () => ({
 
 const canonicalizeBookTitleMock = vi.fn();
 const canonicalizeContributorNameMock = vi.fn();
+const generateNameSortMock = vi.fn();
 
 vi.mock("@bookhouse/ingest", () => ({
   canonicalizeBookTitle: canonicalizeBookTitleMock,
   canonicalizeContributorName: canonicalizeContributorNameMock,
+  generateNameSort: generateNameSortMock,
 }));
 
 import {
@@ -63,6 +67,7 @@ import {
   updateEditionServerFn,
   updateWorkAuthorsServerFn,
   updateEditionNarratorsServerFn,
+  updateContributorServerFn,
   getContributorNamesServerFn,
 } from "./editing";
 
@@ -74,11 +79,13 @@ beforeEach(() => {
   editionFindManyMock.mockReset();
   contributorFindFirstMock.mockReset();
   contributorCreateMock.mockReset();
+  contributorUpdateMock.mockReset();
   editionContributorDeleteManyMock.mockReset();
   editionContributorCreateManyMock.mockReset();
   transactionMock.mockReset();
   canonicalizeBookTitleMock.mockReset();
   canonicalizeContributorNameMock.mockReset();
+  generateNameSortMock.mockReset();
 });
 
 describe("updateWorkServerFn", () => {
@@ -423,6 +430,7 @@ describe("updateWorkAuthorsServerFn", () => {
     workFindUniqueMock.mockResolvedValue({ id: "w1", editedFields: [] });
     editionFindManyMock.mockResolvedValue([{ id: "e1" }]);
     canonicalizeContributorNameMock.mockReturnValue("new author");
+    generateNameSortMock.mockReturnValue("author, new");
     contributorFindFirstMock.mockResolvedValue(null);
     contributorCreateMock.mockResolvedValue({ id: "c-new" });
     transactionMock.mockImplementation(async (fn: () => Promise<object>) => fn());
@@ -441,6 +449,7 @@ describe("updateWorkAuthorsServerFn", () => {
       data: {
         nameDisplay: "New Author",
         nameCanonical: "new author",
+        nameSort: "author, new",
       },
     });
     expect(editionContributorCreateManyMock).toHaveBeenCalledWith({
@@ -533,6 +542,7 @@ describe("updateEditionNarratorsServerFn", () => {
 
   it("creates new contributors when not found", async () => {
     canonicalizeContributorNameMock.mockReturnValue("new narrator");
+    generateNameSortMock.mockReturnValue("narrator, new");
     contributorFindFirstMock.mockResolvedValue(null);
     contributorCreateMock.mockResolvedValue({ id: "c-new" });
     editionContributorDeleteManyMock.mockResolvedValue({ count: 0 });
@@ -545,7 +555,7 @@ describe("updateEditionNarratorsServerFn", () => {
     });
 
     expect(contributorCreateMock).toHaveBeenCalledWith({
-      data: { nameDisplay: "New Narrator", nameCanonical: "new narrator" },
+      data: { nameDisplay: "New Narrator", nameCanonical: "new narrator", nameSort: "narrator, new" },
     });
   });
 
@@ -595,6 +605,22 @@ describe("updateEditionNarratorsServerFn", () => {
       where: { editionId: "e1", role: "NARRATOR" },
     });
     expect(editionContributorCreateManyMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("updateContributorServerFn", () => {
+  it("updates nameSort on a contributor", async () => {
+    contributorUpdateMock.mockResolvedValue({ id: "c1" });
+
+    const result = await updateContributorServerFn({
+      data: { contributorId: "c1", nameSort: "le guin, ursula k." },
+    });
+
+    expect(contributorUpdateMock).toHaveBeenCalledWith({
+      where: { id: "c1" },
+      data: { nameSort: "le guin, ursula k." },
+    });
+    expect(result).toEqual({ success: true });
   });
 });
 

--- a/apps/web/src/lib/server-fns/editing.ts
+++ b/apps/web/src/lib/server-fns/editing.ts
@@ -119,7 +119,7 @@ export const updateWorkAuthorsServerFn = createServerFn({
   .inputValidator(updateWorkAuthorsSchema)
   .handler(async ({ data }) => {
     const { db } = await import("@bookhouse/db");
-    const { canonicalizeContributorName } = await import("@bookhouse/ingest");
+    const { canonicalizeContributorName, generateNameSort } = await import("@bookhouse/ingest");
 
     if (data.authors.length === 0) {
       throw new Error("At least one author is required");
@@ -152,6 +152,7 @@ export const updateWorkAuthorsServerFn = createServerFn({
           data: {
             nameDisplay: authorName,
             nameCanonical: canonical,
+            nameSort: generateNameSort(authorName),
           },
         });
         contributorIds.push(created.id);
@@ -205,7 +206,7 @@ export const updateEditionNarratorsServerFn = createServerFn({
   .inputValidator(updateEditionNarratorsSchema)
   .handler(async ({ data }) => {
     const { db } = await import("@bookhouse/db");
-    const { canonicalizeContributorName } = await import("@bookhouse/ingest");
+    const { canonicalizeContributorName, generateNameSort } = await import("@bookhouse/ingest");
 
     // Resolve or create contributors
     const contributorIds: string[] = [];
@@ -222,6 +223,7 @@ export const updateEditionNarratorsServerFn = createServerFn({
           data: {
             nameDisplay: narratorName,
             nameCanonical: canonical,
+            nameSort: generateNameSort(narratorName),
           },
         });
         contributorIds.push(created.id);
@@ -255,6 +257,26 @@ export const updateEditionNarratorsServerFn = createServerFn({
     await db.edition.update({
       where: { id: data.editionId },
       data: { editedFields: mergedEdited },
+    });
+
+    return { success: true };
+  });
+
+const updateContributorSchema = z.object({
+  contributorId: z.string().min(1),
+  nameSort: z.string().min(1),
+});
+
+export const updateContributorServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(updateContributorSchema)
+  .handler(async ({ data }) => {
+    const { db } = await import("@bookhouse/db");
+
+    await db.contributor.update({
+      where: { id: data.contributorId },
+      data: { nameSort: data.nameSort },
     });
 
     return { success: true };

--- a/apps/web/src/lib/server-fns/koreader-credentials.test.ts
+++ b/apps/web/src/lib/server-fns/koreader-credentials.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@tanstack/react-start", () => ({
+  createServerFn: () => {
+    type Builder = {
+      inputValidator: (schema: object) => Builder;
+      handler: <T extends Record<string, string | number | boolean | null | string[] | Date | undefined>>(fn: (a: T) => T | Promise<T>) => (a: T) => T | Promise<T>;
+    };
+    const b: Builder = {
+      inputValidator: () => b,
+      handler: (fn) => (a) => fn(a),
+    };
+    return b;
+  },
+}));
+
+const mockFindUnique = vi.fn();
+const mockUpsert = vi.fn();
+const mockUpdate = vi.fn();
+const mockGetCurrentUser = vi.fn();
+const mockHashPassword = vi.fn().mockResolvedValue("salt:hash");
+
+vi.mock("@bookhouse/db", () => ({
+  db: {
+    koreaderCredential: {
+      findUnique: mockFindUnique,
+      upsert: mockUpsert,
+      update: mockUpdate,
+    },
+  },
+}));
+
+vi.mock("~/lib/auth-server", () => ({
+  getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("@bookhouse/opds", () => ({
+  hashPassword: mockHashPassword,
+}));
+
+import {
+  getKoreaderCredentialServerFn,
+  saveKoreaderCredentialServerFn,
+  toggleKoreaderCredentialServerFn,
+} from "./koreader-credentials";
+
+describe("koreader-credentials server functions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetCurrentUser.mockResolvedValue({ id: "u1" });
+  });
+
+  it("returns the current user's KOReader credential", async () => {
+    const credential = { id: "kc1", username: "reader", isEnabled: true, createdAt: new Date(), updatedAt: new Date() };
+    mockFindUnique.mockResolvedValue(credential);
+
+    const result = await getKoreaderCredentialServerFn({} as never);
+
+    expect(result).toEqual(credential);
+    expect(mockFindUnique).toHaveBeenCalledWith({
+      where: { userId: "u1" },
+      select: {
+        id: true,
+        username: true,
+        isEnabled: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  });
+
+  it("requires authentication to read credentials", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce(null);
+
+    await expect(getKoreaderCredentialServerFn({} as never)).rejects.toThrow("Not authenticated");
+  });
+
+  it("upserts KOReader credentials with a hashed password", async () => {
+    const saved = { id: "kc1", username: "reader", isEnabled: false, createdAt: new Date(), updatedAt: new Date() };
+    mockUpsert.mockResolvedValue(saved);
+
+    const result = await saveKoreaderCredentialServerFn({
+      data: { username: "reader", password: "supersecret" },
+    });
+
+    expect(result).toEqual(saved);
+    expect(mockHashPassword).toHaveBeenCalledWith("supersecret");
+    expect(mockUpsert).toHaveBeenCalledWith({
+      where: { userId: "u1" },
+      create: {
+        userId: "u1",
+        username: "reader",
+        passwordHash: "salt:hash",
+      },
+      update: {
+        username: "reader",
+        passwordHash: "salt:hash",
+      },
+      select: {
+        id: true,
+        username: true,
+        isEnabled: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  });
+
+  it("requires authentication to save credentials", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce(null);
+
+    await expect(saveKoreaderCredentialServerFn({
+      data: { username: "reader", password: "supersecret" },
+    })).rejects.toThrow("Not authenticated");
+  });
+
+  it("toggles the enabled state", async () => {
+    const toggled = { id: "kc1", username: "reader", isEnabled: true, createdAt: new Date(), updatedAt: new Date() };
+    mockUpdate.mockResolvedValue(toggled);
+
+    const result = await toggleKoreaderCredentialServerFn({
+      data: { isEnabled: true },
+    });
+
+    expect(result).toEqual(toggled);
+    expect(mockUpdate).toHaveBeenCalledWith({
+      where: { userId: "u1" },
+      data: { isEnabled: true },
+      select: {
+        id: true,
+        username: true,
+        isEnabled: true,
+        createdAt: true,
+        updatedAt: true,
+      },
+    });
+  });
+
+  it("requires authentication to toggle credentials", async () => {
+    mockGetCurrentUser.mockResolvedValueOnce(null);
+
+    await expect(toggleKoreaderCredentialServerFn({
+      data: { isEnabled: true },
+    })).rejects.toThrow("Not authenticated");
+  });
+});

--- a/apps/web/src/lib/server-fns/koreader-credentials.ts
+++ b/apps/web/src/lib/server-fns/koreader-credentials.ts
@@ -1,0 +1,85 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+const credentialSelection = {
+  id: true,
+  username: true,
+  isEnabled: true,
+  createdAt: true,
+  updatedAt: true,
+} as const;
+
+export const getKoreaderCredentialServerFn = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  const { db } = await import("@bookhouse/db");
+  const { getCurrentUser } = await import("~/lib/auth-server");
+
+  const user = await getCurrentUser();
+  if (!user) throw new Error("Not authenticated");
+
+  return db.koreaderCredential.findUnique({
+    where: { userId: user.id },
+    select: credentialSelection,
+  });
+});
+
+export type KoreaderCredentialRow = Awaited<
+  ReturnType<typeof getKoreaderCredentialServerFn>
+>;
+
+const saveCredentialSchema = z.object({
+  username: z.string().min(1).max(100),
+  password: z.string().min(8).max(128),
+});
+
+export const saveKoreaderCredentialServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(saveCredentialSchema)
+  .handler(async ({ data }) => {
+    const { db } = await import("@bookhouse/db");
+    const { hashPassword } = await import("@bookhouse/opds");
+    const { getCurrentUser } = await import("~/lib/auth-server");
+
+    const user = await getCurrentUser();
+    if (!user) throw new Error("Not authenticated");
+
+    const passwordHash = await hashPassword(data.password);
+
+    return db.koreaderCredential.upsert({
+      where: { userId: user.id },
+      create: {
+        userId: user.id,
+        username: data.username,
+        passwordHash,
+      },
+      update: {
+        username: data.username,
+        passwordHash,
+      },
+      select: credentialSelection,
+    });
+  });
+
+const toggleCredentialSchema = z.object({
+  isEnabled: z.boolean(),
+});
+
+export const toggleKoreaderCredentialServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(toggleCredentialSchema)
+  .handler(async ({ data }) => {
+    const { db } = await import("@bookhouse/db");
+    const { getCurrentUser } = await import("~/lib/auth-server");
+
+    const user = await getCurrentUser();
+    if (!user) throw new Error("Not authenticated");
+
+    return db.koreaderCredential.update({
+      where: { userId: user.id },
+      data: { isEnabled: data.isEnabled },
+      select: credentialSelection,
+    });
+  });

--- a/apps/web/src/lib/server-fns/library.test.ts
+++ b/apps/web/src/lib/server-fns/library.test.ts
@@ -92,7 +92,7 @@ describe("getFilteredLibraryWorksServerFn", () => {
       expect.objectContaining({
         skip: 0,
         take: 50,
-        orderBy: { titleCanonical: "asc" },
+        orderBy: { sortTitle: { sort: "asc", nulls: "last" } },
       }),
     );
     expect(countMock).toHaveBeenCalled();
@@ -140,7 +140,7 @@ describe("getFilteredLibraryWorksServerFn", () => {
 
     expect(findManyMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        orderBy: { titleCanonical: "desc" },
+        orderBy: { sortTitle: { sort: "desc", nulls: "last" } },
       }),
     );
   });
@@ -938,7 +938,7 @@ describe("getFilteredLibraryEditionsServerFn", () => {
       expect.objectContaining({
         skip: 0,
         take: 50,
-        orderBy: { work: { titleCanonical: "asc" } },
+        orderBy: { work: { sortTitle: { sort: "asc", nulls: "last" } } },
       }),
     );
     expect(result).toEqual({ editions: [], totalCount: 0 });
@@ -960,7 +960,7 @@ describe("getFilteredLibraryEditionsServerFn", () => {
     await getFilteredLibraryEditionsServerFn({ data: { sort: "title-desc" } });
 
     expect(editionFindManyMock).toHaveBeenCalledWith(
-      expect.objectContaining({ orderBy: { work: { titleCanonical: "desc" } } }),
+      expect.objectContaining({ orderBy: { work: { sortTitle: { sort: "desc", nulls: "last" } } } }),
     );
   });
 

--- a/apps/web/src/lib/server-fns/library.ts
+++ b/apps/web/src/lib/server-fns/library.ts
@@ -149,11 +149,11 @@ function buildWhere(data: z.infer<typeof filterSchema>): Prisma.WorkWhereInput {
 function buildOrderBy(sort: string): Prisma.WorkOrderByWithRelationInput {
   switch (sort) {
     case "title-desc":
-      return { titleCanonical: "desc" as const };
+      return { sortTitle: { sort: "desc" as const, nulls: "last" as const } };
     case "recent":
       return { createdAt: "desc" as const };
     default:
-      return { titleCanonical: "asc" as const };
+      return { sortTitle: { sort: "asc" as const, nulls: "last" as const } };
   }
 }
 
@@ -174,7 +174,7 @@ const EDITION_SORT_SELECT = {
       formatFamily: true,
       contributors: {
         where: { role: "AUTHOR" as const },
-        select: { contributor: { select: { nameCanonical: true } } },
+        select: { contributor: { select: { nameSort: true, nameCanonical: true } } },
       },
     },
   },
@@ -184,7 +184,7 @@ type LightweightEditionWork = {
   id: string;
   editions: {
     formatFamily: string;
-    contributors: { contributor: { nameCanonical: string } }[];
+    contributors: { contributor: { nameSort: string | null; nameCanonical: string } }[];
   }[];
 };
 
@@ -196,7 +196,7 @@ function extractSortKey(work: LightweightEditionWork, sort: EditionSortOption): 
     case "author-desc":
       return work.editions
         .flatMap((e) => e.contributors)
-        .map((c) => c.contributor.nameCanonical)
+        .map((c) => c.contributor.nameSort ?? c.contributor.nameCanonical)
         .sort()[0] ?? "\uffff";
     case "format-asc":
     case "format-desc":
@@ -461,7 +461,7 @@ type EditionOrderBy = Prisma.EditionOrderByWithRelationInput;
 function buildEditionOrderBy(sort: string): EditionOrderBy {
   switch (sort) {
     case "title-desc":
-      return { work: { titleCanonical: "desc" } };
+      return { work: { sortTitle: { sort: "desc", nulls: "last" } } };
     case "publisher-asc":
       return { publisher: "asc" };
     case "publisher-desc":
@@ -497,7 +497,7 @@ function buildEditionOrderBy(sort: string): EditionOrderBy {
     case "recent":
       return { createdAt: "desc" };
     default:
-      return { work: { titleCanonical: "asc" } };
+      return { work: { sortTitle: { sort: "asc", nulls: "last" } } };
   }
 }
 
@@ -509,20 +509,20 @@ const EDITION_CONTRIBUTOR_SORT_OPTIONS = new Set([
 const EDITION_CONTRIBUTOR_SORT_SELECT = {
   id: true,
   contributors: {
-    select: { contributor: { select: { nameCanonical: true } } },
+    select: { contributor: { select: { nameSort: true, nameCanonical: true } } },
   },
 } as const;
 
 type LightweightEditionContributor = {
   id: string;
-  contributors: { contributor: { nameCanonical: string } }[];
+  contributors: { contributor: { nameSort: string | null; nameCanonical: string } }[];
 };
 
 type EditionContributorSortOption = "author-asc" | "author-desc" | "narrator-asc" | "narrator-desc";
 
 function extractEditionContributorSortKey(edition: LightweightEditionContributor): string {
   return edition.contributors
-    .map((c) => c.contributor.nameCanonical)
+    .map((c) => c.contributor.nameSort ?? c.contributor.nameCanonical)
     .sort()[0] ?? "\uffff";
 }
 

--- a/apps/web/src/lib/server-fns/reading-progress.test.ts
+++ b/apps/web/src/lib/server-fns/reading-progress.test.ts
@@ -133,7 +133,12 @@ describe("updateReadingProgressServerFn", () => {
     });
 
     expect(readingProgressFindFirstMock).toHaveBeenCalledWith({
-      where: { userId: "user-1", editionId: "e1", progressKind: "EBOOK" },
+      where: {
+        userId: "user-1",
+        editionId: "e1",
+        progressKind: "EBOOK",
+        OR: [{ source: "manual" }, { source: null }],
+      },
     });
     expect(readingProgressUpdateMock).toHaveBeenCalledWith({
       where: { id: "rp1" },
@@ -163,6 +168,35 @@ describe("updateReadingProgressServerFn", () => {
       },
     });
     expect(result).toBe(created);
+  });
+
+  it("does not overwrite a koreader progress record when saving manual progress", async () => {
+    getCurrentUserMock.mockResolvedValue({ id: "user-1" });
+    readingProgressFindFirstMock.mockResolvedValue(null);
+    readingProgressCreateMock.mockResolvedValue({ id: "rp-manual", percent: 60 });
+
+    await updateReadingProgressServerFn({
+      data: { editionId: "e1", percent: 60, progressKind: "EBOOK" },
+    });
+
+    expect(readingProgressFindFirstMock).toHaveBeenCalledWith({
+      where: {
+        userId: "user-1",
+        editionId: "e1",
+        progressKind: "EBOOK",
+        OR: [{ source: "manual" }, { source: null }],
+      },
+    });
+    expect(readingProgressCreateMock).toHaveBeenCalledWith({
+      data: {
+        userId: "user-1",
+        editionId: "e1",
+        progressKind: "EBOOK",
+        percent: 60,
+        locator: {},
+        source: "manual",
+      },
+    });
   });
 });
 

--- a/apps/web/src/lib/server-fns/reading-progress.ts
+++ b/apps/web/src/lib/server-fns/reading-progress.ts
@@ -59,6 +59,7 @@ export const updateReadingProgressServerFn = createServerFn({
         userId: user.id,
         editionId: data.editionId,
         progressKind: data.progressKind,
+        OR: [{ source: "manual" }, { source: null }],
       },
     });
 

--- a/apps/web/src/lib/sort-filter-works.test.ts
+++ b/apps/web/src/lib/sort-filter-works.test.ts
@@ -9,7 +9,7 @@ interface MockWork {
   createdAt: Date;
   editions: {
     formatFamily: string;
-    contributors: { role: string; contributor: { nameDisplay: string } }[];
+    contributors: { role: string; contributor: { nameDisplay: string; nameSort: string | null; nameCanonical: string } }[];
   }[];
   [key: string]: string | number | boolean | null | object;
 }
@@ -29,7 +29,7 @@ const makeWork = (
       formatFamily: "EBOOK",
       contributors: authors.map((name) => ({
         role: "AUTHOR",
-        contributor: { nameDisplay: name },
+        contributor: { nameDisplay: name, nameSort: name.toLowerCase(), nameCanonical: name.toLowerCase() },
       })),
     },
   ],
@@ -103,8 +103,21 @@ describe("sortAndFilterWorks", () => {
     const noAuthor = makeWork("NoAuthor", []);
     const result = sortAndFilterWorks([noAuthor, alpha] as never[], "", "author-asc");
     const titles = result.map((w) => (w as MockWork).titleDisplay);
-    // "—" sorts before "Zara"
-    expect(titles).toEqual(["NoAuthor", "Alpha"]);
+    // Works with no authors sort last
+    expect(titles).toEqual(["Alpha", "NoAuthor"]);
+  });
+
+  it("falls back to nameCanonical when nameSort is null for author sort", () => {
+    const nullSort: MockWork = {
+      ...makeWork("FallbackAuthor", ["Zara"]),
+      editions: [{
+        formatFamily: "EBOOK",
+        contributors: [{ role: "AUTHOR", contributor: { nameDisplay: "Zara", nameSort: null, nameCanonical: "zara" } }],
+      }],
+    };
+    const result = sortAndFilterWorks([nullSort, bravo] as never[], "", "author-asc");
+    const titles = result.map((w) => (w as MockWork).titleDisplay);
+    expect(titles).toEqual(["Bravo", "FallbackAuthor"]); // alice < zara
   });
 
   it("sorts by format-asc (falls through to createdAt descending)", () => {

--- a/apps/web/src/lib/sort-filter-works.ts
+++ b/apps/web/src/lib/sort-filter-works.ts
@@ -11,6 +11,14 @@ export function getAuthors(work: LibraryWork): string {
   return [...new Set(authors)].join(", ") || "—";
 }
 
+function getAuthorSortKey(work: LibraryWork): string {
+  const keys = work.editions
+    .flatMap((e) => e.contributors)
+    .filter((c) => c.role === "AUTHOR")
+    .map((c) => c.contributor.nameSort ?? c.contributor.nameCanonical);
+  return [...new Set(keys)].sort()[0] ?? "\uffff";
+}
+
 export function sortAndFilterWorks(
   works: LibraryWork[],
   search: string,
@@ -51,9 +59,9 @@ export function sortAndFilterWorks(
       case "title-desc":
         return (b.sortTitle ?? b.titleCanonical).localeCompare(a.sortTitle ?? a.titleCanonical);
       case "author-asc":
-        return getAuthors(a).localeCompare(getAuthors(b));
+        return getAuthorSortKey(a).localeCompare(getAuthorSortKey(b));
       case "author-desc":
-        return getAuthors(b).localeCompare(getAuthors(a));
+        return getAuthorSortKey(b).localeCompare(getAuthorSortKey(a));
       case "format-asc":
       case "format-desc":
       case "recent":

--- a/apps/web/src/routes/_authenticated/-authors.$authorId.test.tsx
+++ b/apps/web/src/routes/_authenticated/-authors.$authorId.test.tsx
@@ -8,6 +8,7 @@ let mockLoaderData: {
     id: string;
     nameDisplay: string;
     nameCanonical: string;
+    nameSort: string | null;
     imagePath: string | null;
     works: {
       id: string;
@@ -23,7 +24,7 @@ let mockLoaderData: {
     }[];
   };
 } = {
-  author: { id: "a1", nameDisplay: "Patrick Rothfuss", nameCanonical: "patrick rothfuss", imagePath: null, works: [] },
+  author: { id: "a1", nameDisplay: "Patrick Rothfuss", nameCanonical: "patrick rothfuss", nameSort: "rothfuss, patrick", imagePath: null, works: [] },
 };
 
 vi.mock("sonner", () => ({
@@ -68,6 +69,11 @@ vi.mock("~/lib/server-fns/authors", () => ({
   fetchAuthorPhotoFromUrlServerFn: fetchAuthorPhotoFromUrlServerFnMock,
 }));
 
+const updateContributorServerFnMock = vi.fn().mockResolvedValue({ success: true });
+vi.mock("~/lib/server-fns/editing", () => ({
+  updateContributorServerFn: updateContributorServerFnMock,
+}));
+
 vi.mock("~/lib/mutation", () => ({
   runMutation: async (fn: () => Promise<object>) => fn(),
 }));
@@ -88,7 +94,7 @@ const makeWork = (title: string, formats: string[] = ["EBOOK"]) => ({
 describe("AuthorDetailPage", () => {
   beforeEach(() => {
     mockLoaderData = {
-      author: { id: "a1", nameDisplay: "Patrick Rothfuss", nameCanonical: "patrick rothfuss", imagePath: null, works: [] },
+      author: { id: "a1", nameDisplay: "Patrick Rothfuss", nameCanonical: "patrick rothfuss", nameSort: "rothfuss, patrick", imagePath: null, works: [] },
     };
     vi.clearAllMocks();
   });
@@ -110,6 +116,33 @@ describe("AuthorDetailPage", () => {
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
     expect(screen.getByRole("heading", { level: 1 }).textContent).toBe("Patrick Rothfuss");
+  });
+
+  it("renders nameSort editable field and saves on edit", async () => {
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    // Click the "Sort as" display text to enter edit mode
+    const sortDisplay = screen.getByText("rothfuss, patrick");
+    fireEvent.click(sortDisplay);
+    // Now an input should be visible with the current value
+    const input = screen.getByDisplayValue("rothfuss, patrick");
+    fireEvent.change(input, { target: { value: "rothfuss, patrick j." } });
+    fireEvent.blur(input);
+    await vi.waitFor(() => {
+      expect(updateContributorServerFnMock).toHaveBeenCalledWith({
+        data: { contributorId: "a1", nameSort: "rothfuss, patrick j." },
+      });
+    });
+  });
+
+  it("renders empty string when nameSort is null", async () => {
+    mockLoaderData.author.nameSort = null;
+    const { Route } = await import("./authors.$authorId");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    // When nameSort is null, the EditableField shows placeholder "auto"
+    expect(screen.getByText("auto")).toBeTruthy();
   });
 
   it("renders breadcrumb with link to authors list", async () => {

--- a/apps/web/src/routes/_authenticated/-library.$workId.test.tsx
+++ b/apps/web/src/routes/_authenticated/-library.$workId.test.tsx
@@ -572,7 +572,7 @@ describe("WorkDetailPage", () => {
     const { Route } = await import("./library.$workId");
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
-    expect(screen.getByRole("progressbar")).toBeTruthy();
+    expect(screen.getAllByRole("progressbar").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("42%").length).toBeGreaterThanOrEqual(1);
     // EBOOK appears in both editions section and progress section
     expect(screen.getAllByText("EBOOK").length).toBeGreaterThanOrEqual(2);
@@ -629,7 +629,7 @@ describe("WorkDetailPage", () => {
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
     expect(screen.getAllByText("0%").length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByRole("progressbar")).toBeTruthy();
+    expect(screen.getAllByRole("progressbar").length).toBeGreaterThanOrEqual(1);
   });
 
   it("renders BY_WORK with max percent from multiple editions", async () => {
@@ -684,7 +684,7 @@ describe("WorkDetailPage", () => {
     const Page = Route.options.component as React.ComponentType;
     render(<Page />);
     const bars = screen.getAllByRole("progressbar");
-    expect(bars).toHaveLength(2);
+    expect(bars.length).toBeGreaterThanOrEqual(2);
     expect(screen.getAllByText("30%").length).toBeGreaterThanOrEqual(1);
     expect(screen.getAllByText("75%").length).toBeGreaterThanOrEqual(1);
   });

--- a/apps/web/src/routes/_authenticated/authors.$authorId.tsx
+++ b/apps/web/src/routes/_authenticated/authors.$authorId.tsx
@@ -8,6 +8,8 @@ import { WorkCard } from "~/components/work-card";
 import { AuthorAvatar } from "~/components/author-avatar";
 import { GridPageSkeleton } from "~/components/skeletons/grid-page-skeleton";
 import { getAuthorDetailServerFn, fetchAuthorPhotoFromUrlServerFn } from "~/lib/server-fns/authors";
+import { updateContributorServerFn } from "~/lib/server-fns/editing";
+import { EditableField } from "~/components/editable-field";
 import { runMutation } from "~/lib/mutation";
 
 export const Route = createFileRoute("/_authenticated/authors/$authorId")({
@@ -125,6 +127,19 @@ function AuthorDetailPage() {
         />
         <div>
           <h1 className="text-2xl font-bold">{author.nameDisplay}</h1>
+          <div className="mt-0.5 text-xs text-muted-foreground">
+            <span className="mr-1">Sort as:</span>
+            <EditableField
+              value={author.nameSort ?? ""}
+              onSave={async (val) => {
+                await updateContributorServerFn({ data: { contributorId: author.id, nameSort: val } });
+                void router.invalidate();
+              }}
+              placeholder="auto"
+              className="text-xs"
+              required
+            />
+          </div>
           <button
             type="button"
             className="mt-1 flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground"

--- a/apps/web/src/routes/_authenticated/library.$workId.tsx
+++ b/apps/web/src/routes/_authenticated/library.$workId.tsx
@@ -285,6 +285,18 @@ function WorkDetailPage() {
                 <Trash2 className="size-4" />
               </Button>
             </div>
+            <div className="mt-0.5 text-xs text-muted-foreground">
+              <span className="mr-1">Sort as:</span>
+              <EditableField
+                value={work.sortTitle ?? ""}
+                onSave={async (val) => {
+                  await updateWorkServerFn({ data: { workId: work.id, fields: { sortTitle: val || null } } });
+                  void router.invalidate();
+                }}
+                placeholder="auto"
+                className="text-xs"
+              />
+            </div>
             <div className="mt-1 text-lg text-muted-foreground">
               <EditableTagField
                 values={authors.map((a) => a.name)}

--- a/apps/web/src/routes/_authenticated/settings/-index.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-index.test.tsx
@@ -35,7 +35,8 @@ let mockLoaderData: {
   koboDevices: { id: string; deviceId: string; status: string; lastSyncAt: string | null; createdAt: string; authToken: string; collections: { collection: { id: string; name: string } }[] }[];
   shelves: { id: string; name: string; kind: string; formatFilter: string; ownerUserId: string | null; _count: { items: number } }[];
   opdsCredentials: { id: string; username: string; isEnabled: boolean; createdAt: string }[];
-} = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [] };
+  koreaderCredential: { id: string; username: string; isEnabled: boolean; createdAt: string; updatedAt: string } | null;
+} = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [], koreaderCredential: null };
 
 const getLibraryRootsServerFnMock = vi.fn();
 const scanLibraryRootServerFnMock = vi.fn();
@@ -120,6 +121,12 @@ vi.mock("~/lib/server-fns/opds-credentials", () => ({
   createOpdsCredentialServerFn: vi.fn().mockResolvedValue({ id: "c1", username: "reader", isEnabled: true, createdAt: new Date().toISOString() }),
   toggleOpdsCredentialServerFn: vi.fn().mockResolvedValue({}),
   deleteOpdsCredentialServerFn: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("~/lib/server-fns/koreader-credentials", () => ({
+  getKoreaderCredentialServerFn: vi.fn().mockResolvedValue(null),
+  saveKoreaderCredentialServerFn: vi.fn().mockResolvedValue({ id: "kc1", username: "reader", isEnabled: false, createdAt: new Date().toISOString(), updatedAt: new Date().toISOString() }),
+  toggleKoreaderCredentialServerFn: vi.fn().mockResolvedValue({}),
 }));
 
 vi.mock("~/lib/mutation", () => ({
@@ -243,7 +250,7 @@ const makeJob = (overrides: Partial<{
 describe("SettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [] };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [], koreaderCredential: null };
     mockTheme = "system";
     mockColorMode = "book";
     mockAccentColor = null;
@@ -293,7 +300,7 @@ describe("SettingsPage", () => {
     const { Route } = await import("./index");
     const SettingsPage = (Route.options.component as React.ComponentType);
     render(<SettingsPage />);
-    expect(screen.getByText("Disabled")).toBeTruthy();
+    expect(screen.getAllByText("Disabled").length).toBeGreaterThanOrEqual(2);
   });
 
   it("does not show 'Disabled' badge when root.isEnabled is true", async () => {
@@ -301,7 +308,7 @@ describe("SettingsPage", () => {
     const { Route } = await import("./index");
     const SettingsPage = (Route.options.component as React.ComponentType);
     render(<SettingsPage />);
-    expect(screen.queryByText("Disabled")).toBeNull();
+    expect(screen.getAllByText("Disabled")).toHaveLength(1);
   });
 
   it("shows 'Never' when lastScannedAt is null", async () => {
@@ -563,6 +570,7 @@ describe("SettingsPage", () => {
       koboDevices: [],
       shelves: [],
       opdsCredentials: [],
+      koreaderCredential: null,
     });
   });
 
@@ -816,7 +824,7 @@ describe("SettingsPage", () => {
 describe("AppearanceCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [] };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [], koreaderCredential: null };
     mockTheme = "system";
     mockColorMode = "book";
     mockAccentColor = null;
@@ -885,7 +893,7 @@ describe("AppearanceCard", () => {
 describe("ColorCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [] };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [], koreaderCredential: null };
     mockTheme = "system";
     mockColorMode = "book";
     mockAccentColor = null;
@@ -1062,7 +1070,7 @@ describe("ColorCard", () => {
 describe("JobsTab", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [] };
+    mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [], koreaderCredential: null };
     mockTheme = "system";
     mockColorMode = "book";
     mockAccentColor = null;
@@ -2104,6 +2112,195 @@ describe("Kobo Devices Tab", () => {
     expect(screen.getByTestId("opds-catalog-url").textContent).toContain("/opds/catalog");
   });
 
+  it("renders KOReader sync URL on devices tab", async () => {
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
+
+    expect(screen.getByTestId("koreader-api-url").textContent).toContain("/api/koreader");
+  });
+
+  it("saves KOReader credentials", async () => {
+    const { saveKoreaderCredentialServerFn } = await import("~/lib/server-fns/koreader-credentials");
+    const saveMock = vi.mocked(saveKoreaderCredentialServerFn);
+
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
+    fireEvent.change(screen.getByTestId("koreader-username-input"), { target: { value: "koreader" } });
+    fireEvent.change(screen.getByTestId("koreader-password-input"), { target: { value: "password123" } });
+    fireEvent.click(screen.getByTestId("save-koreader-credential-btn"));
+
+    await waitFor(() => {
+      expect(saveMock).toHaveBeenCalledWith({ data: { username: "koreader", password: "password123" } });
+    });
+  });
+
+  it("toggles KOReader sync state", async () => {
+    mockLoaderData.koreaderCredential = {
+      id: "kc1",
+      username: "koreader",
+      isEnabled: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const { toggleKoreaderCredentialServerFn } = await import("~/lib/server-fns/koreader-credentials");
+    const toggleMock = vi.mocked(toggleKoreaderCredentialServerFn);
+
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
+    fireEvent.click(screen.getByTestId("toggle-koreader-credential-btn"));
+
+    await waitFor(() => {
+      expect(toggleMock).toHaveBeenCalledWith({ data: { isEnabled: true } });
+    });
+  });
+
+  it("toggles KOReader sync off when the credential is enabled", async () => {
+    mockLoaderData.koreaderCredential = {
+      id: "kc1",
+      username: "koreader",
+      isEnabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const { toggleKoreaderCredentialServerFn } = await import("~/lib/server-fns/koreader-credentials");
+    const toggleMock = vi.mocked(toggleKoreaderCredentialServerFn);
+
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
+    fireEvent.click(screen.getByTestId("toggle-koreader-credential-btn"));
+
+    await waitFor(() => {
+      expect(toggleMock).toHaveBeenCalledWith({ data: { isEnabled: false } });
+    });
+  });
+
+  it("renders enabled KOReader credential details and update actions", async () => {
+    mockLoaderData.koreaderCredential = {
+      id: "kc1",
+      username: "koreader",
+      isEnabled: true,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
+
+    expect(screen.getByText("Enabled")).toBeTruthy();
+    expect(screen.getByText("Username: koreader")).toBeTruthy();
+    expect(screen.getByText("Update Credentials")).toBeTruthy();
+    expect(screen.getByText("Disable")).toBeTruthy();
+  });
+
+  it("shows KOReader save loading state while credentials are saving", async () => {
+    let resolveSave!: (value: {
+      id: string;
+      username: string;
+      isEnabled: boolean;
+      createdAt: string;
+      updatedAt: string;
+    }) => void;
+    const { saveKoreaderCredentialServerFn } = await import("~/lib/server-fns/koreader-credentials");
+    const saveMock = vi.mocked(saveKoreaderCredentialServerFn);
+    saveMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveSave = resolve as typeof resolveSave;
+      }) as never,
+    );
+
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
+    fireEvent.change(screen.getByTestId("koreader-username-input"), { target: { value: "reader" } });
+    fireEvent.change(screen.getByTestId("koreader-password-input"), { target: { value: "password123" } });
+    fireEvent.click(screen.getByTestId("save-koreader-credential-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("save-koreader-credential-btn").textContent).toBe("");
+    });
+
+    resolveSave({
+      id: "kc1",
+      username: "reader",
+      isEnabled: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    });
+
+    await waitFor(() => {
+      expect(saveMock).toHaveBeenCalled();
+    });
+  });
+
+  it("shows KOReader toggle loading state while enablement is updating", async () => {
+    mockLoaderData.koreaderCredential = {
+      id: "kc1",
+      username: "koreader",
+      isEnabled: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+
+    let resolveToggle!: () => void;
+    const { toggleKoreaderCredentialServerFn } = await import("~/lib/server-fns/koreader-credentials");
+    const toggleMock = vi.mocked(toggleKoreaderCredentialServerFn);
+    toggleMock.mockReturnValueOnce(
+      new Promise<object>((resolve) => {
+        resolveToggle = () => {
+          resolve({});
+        };
+      }) as never,
+    );
+
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
+    fireEvent.click(screen.getByTestId("toggle-koreader-credential-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-koreader-credential-btn").textContent).toBe("");
+    });
+
+    resolveToggle();
+
+    await waitFor(() => {
+      expect(toggleMock).toHaveBeenCalled();
+    });
+  });
+
+  it("disables KOReader save button when password is too short", async () => {
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+
+    fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
+    fireEvent.change(screen.getByTestId("koreader-username-input"), { target: { value: "reader" } });
+    fireEvent.change(screen.getByTestId("koreader-password-input"), { target: { value: "short" } });
+
+    expect(screen.getByTestId("save-koreader-credential-btn").getAttribute("disabled")).not.toBeNull();
+  });
+
   it("shows empty state when no OPDS credentials exist", async () => {
     const { Route } = await import("./index");
     const SettingsPage = (Route.options.component as React.ComponentType);
@@ -2140,8 +2337,8 @@ describe("Kobo Devices Tab", () => {
 
     fireEvent.click(screen.getByRole("tab", { name: "Devices" }));
 
-    expect(screen.getByText("Disabled")).toBeTruthy();
-    expect(screen.getByText("Enable")).toBeTruthy();
+    expect(screen.getAllByText("Disabled").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getAllByText("Enable").length).toBeGreaterThanOrEqual(1);
   });
 
   it("creates a new OPDS credential", async () => {

--- a/apps/web/src/routes/_authenticated/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/settings/index.tsx
@@ -87,6 +87,12 @@ import {
   deleteOpdsCredentialServerFn,
   type OpdsCredentialRow,
 } from "~/lib/server-fns/opds-credentials";
+import {
+  getKoreaderCredentialServerFn,
+  saveKoreaderCredentialServerFn,
+  toggleKoreaderCredentialServerFn,
+  type KoreaderCredentialRow,
+} from "~/lib/server-fns/koreader-credentials";
 import { getShelvesServerFn, type ShelfRow } from "~/lib/server-fns/shelves";
 import {
   getImportJobsServerFn,
@@ -106,7 +112,7 @@ export interface LibraryRootWithExtras extends LibraryRootRow {
 
 export const Route = createFileRoute("/_authenticated/settings/")({
   loader: async () => {
-    const [roots, missingFileBehavior, jobsResult, concurrencies, integrations, backupHistory, smtpStatus, kindleStatus, koboDevices, shelves, opdsCredentials] = await Promise.all([
+    const [roots, missingFileBehavior, jobsResult, concurrencies, integrations, backupHistory, smtpStatus, kindleStatus, koboDevices, shelves, opdsCredentials, koreaderCredential] = await Promise.all([
       getLibraryRootsServerFn(),
       getMissingFileBehaviorServerFn(),
       getImportJobsServerFn({ data: { page: 1, pageSize: 100 } }),
@@ -118,6 +124,7 @@ export const Route = createFileRoute("/_authenticated/settings/")({
       getKoboDevicesServerFn(),
       getShelvesServerFn(),
       getOpdsCredentialsServerFn(),
+      getKoreaderCredentialServerFn(),
     ]);
     const rootsWithExtras: LibraryRootWithExtras[] = await Promise.all(
       roots.map(async (root) => {
@@ -141,6 +148,7 @@ export const Route = createFileRoute("/_authenticated/settings/")({
       koboDevices,
       shelves,
       opdsCredentials,
+      koreaderCredential,
     };
   },
   pendingComponent: SettingsSkeleton,
@@ -160,7 +168,7 @@ function SettingsSkeleton() {
 }
 
 function SettingsPage() {
-  const { roots, missingFileBehavior, jobs, totalCount, concurrencies, integrations, backupHistory: initialBackupHistory, smtpStatus, kindleStatus, koboDevices, shelves, opdsCredentials } = Route.useLoaderData();
+  const { roots, missingFileBehavior, jobs, totalCount, concurrencies, integrations, backupHistory: initialBackupHistory, smtpStatus, kindleStatus, koboDevices, shelves, opdsCredentials, koreaderCredential } = Route.useLoaderData();
   const [backupHistory, setBackupHistory] = useState(initialBackupHistory);
 
   const handleBackupComplete = async (manifest: BackupManifest) => {
@@ -214,11 +222,110 @@ function SettingsPage() {
         </TabsContent>
 
         <TabsContent value="devices" forceMount className="space-y-6 data-[state=inactive]:hidden">
+          <KoreaderSyncCard credential={koreaderCredential} />
           <OpdsCredentialsCard credentials={opdsCredentials} />
           <KoboDevicesTab devices={koboDevices} shelves={shelves} />
         </TabsContent>
       </Tabs>
     </div>
+  );
+}
+
+function KoreaderSyncCard({ credential }: { credential: KoreaderCredentialRow }) {
+  const router = useRouter();
+  const [saving, setSaving] = useState(false);
+  const [toggling, setToggling] = useState(false);
+  const [username, setUsername] = useState(credential?.username ?? "");
+  const [password, setPassword] = useState("");
+  const [apiUrl, setApiUrl] = useState("/api/koreader");
+
+  useEffect(() => { setApiUrl(`${window.location.origin}/api/koreader`); }, []);
+  useEffect(() => { setUsername(credential?.username ?? ""); }, [credential?.username]);
+
+  const handleSave = async () => {
+    setSaving(true);
+    try {
+      await saveKoreaderCredentialServerFn({ data: { username, password } });
+      setPassword("");
+      toast.success("KOReader credentials saved");
+      void router.invalidate();
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleToggle = async (currentCredential: NonNullable<KoreaderCredentialRow>) => {
+    setToggling(true);
+    try {
+      await toggleKoreaderCredentialServerFn({ data: { isEnabled: !currentCredential.isEnabled } });
+      toast.success(currentCredential.isEnabled ? "KOReader sync disabled" : "KOReader sync enabled");
+      void router.invalidate();
+    } finally {
+      setToggling(false);
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>KOReader Progress Sync</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 p-3 dark:border-emerald-900 dark:bg-emerald-950">
+          <p className="text-sm font-medium">Custom Sync Server URL</p>
+          <code className="mt-1 block break-all rounded bg-white p-2 text-xs dark:bg-gray-900" data-testid="koreader-api-url">
+            {apiUrl}
+          </code>
+          <p className="mt-2 text-xs text-muted-foreground">
+            In KOReader, use Progress sync, choose Custom sync server, and select Binary document matching.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2 text-sm">
+          <Badge variant={credential?.isEnabled ? "default" : "secondary"}>
+            {credential?.isEnabled ? "Enabled" : "Disabled"}
+          </Badge>
+          {credential?.username && <span className="text-muted-foreground">Username: {credential.username}</span>}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          <Input
+            placeholder="KOReader username"
+            value={username}
+            onChange={(e) => { setUsername(e.target.value); }}
+            className="max-w-xs"
+            data-testid="koreader-username-input"
+          />
+          <Input
+            type="password"
+            placeholder="Password (min 8 chars)"
+            value={password}
+            onChange={(e) => { setPassword(e.target.value); }}
+            className="max-w-xs"
+            data-testid="koreader-password-input"
+          />
+          <Button
+            onClick={() => { void handleSave(); }}
+            disabled={saving || !username.trim() || password.length < 8}
+            data-testid="save-koreader-credential-btn"
+          >
+            {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : credential ? "Update Credentials" : "Save Credentials"}
+          </Button>
+          <Button
+            variant="outline"
+            onClick={credential ? () => { void handleToggle(credential); } : undefined}
+            disabled={toggling || !credential}
+            data-testid="toggle-koreader-credential-btn"
+          >
+            {toggling ? <Loader2 className="h-4 w-4 animate-spin" /> : credential?.isEnabled ? "Disable" : "Enable"}
+          </Button>
+        </div>
+
+        {!credential && (
+          <p className="text-sm text-muted-foreground">Save KOReader credentials before enabling sync.</p>
+        )}
+      </CardContent>
+    </Card>
   );
 }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,30 +3,26 @@ services:
     image: postgres:17
     restart: unless-stopped
     environment:
-      POSTGRES_USER: bookhouse
-      POSTGRES_PASSWORD: bookhouse
-      POSTGRES_DB: bookhouse
-    ports:
-      - "5432:5432"
+      POSTGRES_USER: ${POSTGRES_USER:-bookhouse}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-bookhouse}
+      POSTGRES_DB: ${POSTGRES_DB:-bookhouse}
     volumes:
       - pgdata:/var/lib/postgresql/data
 
   queue:
     image: valkey/valkey:8
     restart: unless-stopped
-    ports:
-      - "6379:6379"
+    volumes:
+      - queuedata:/data
 
   web:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: web
+    image: ghcr.io/beforetheshoes/bookhouse-web:${BOOKHOUSE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "${WEB_PORT:-3000}:3000"
     environment:
-      DATABASE_URL: postgresql://bookhouse:bookhouse@db:5432/bookhouse
+      DATABASE_URL: postgresql://${POSTGRES_USER:-bookhouse}:${POSTGRES_PASSWORD:-bookhouse}@db:5432/${POSTGRES_DB:-bookhouse}
       QUEUE_URL: redis://queue:6379
       NODE_ENV: production
       AUTH_SECRET: ${AUTH_SECRET}
@@ -46,19 +42,17 @@ services:
       - queue
 
   worker:
-    build:
-      context: .
-      dockerfile: Dockerfile
-      target: worker
+    image: ghcr.io/beforetheshoes/bookhouse-worker:${BOOKHOUSE_TAG:-latest}
+    pull_policy: always
     restart: unless-stopped
     environment:
-      DATABASE_URL: postgresql://bookhouse:bookhouse@db:5432/bookhouse
+      DATABASE_URL: postgresql://${POSTGRES_USER:-bookhouse}:${POSTGRES_PASSWORD:-bookhouse}@db:5432/${POSTGRES_DB:-bookhouse}
       QUEUE_URL: redis://queue:6379
       NODE_ENV: production
       COVER_CACHE_DIR: /data/covers
     volumes:
-      - /Volumes/data/media/ebooks:/data/ebooks:ro
-      - /Volumes/data/media/audiobooks:/data/audiobooks:ro
+      - ${EBOOKS_PATH:?set EBOOKS_PATH in .env}:/data/ebooks:ro
+      - ${AUDIOBOOKS_PATH:?set AUDIOBOOKS_PATH in .env}:/data/audiobooks:ro
       - covers:/data/covers
     depends_on:
       - db
@@ -66,5 +60,6 @@ services:
 
 volumes:
   pgdata:
+  queuedata:
   covers:
   kepub-cache:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "bookhouse",
   "private": true,
   "type": "module",
-  "packageManager": "pnpm@10.12.1",
+  "packageManager": "pnpm@10.33.0",
   "engines": {
     "node": ">=24.0.0"
   },

--- a/packages/db/prisma/migrations/20260407120000_add_contributor_name_sort/migration.sql
+++ b/packages/db/prisma/migrations/20260407120000_add_contributor_name_sort/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Contributor" ADD COLUMN "nameSort" TEXT;

--- a/packages/db/prisma/migrations/20260415123000_add_koreader_sync/migration.sql
+++ b/packages/db/prisma/migrations/20260415123000_add_koreader_sync/migration.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "FileAsset"
+ADD COLUMN "koreaderHash" TEXT;
+
+CREATE INDEX "FileAsset_koreaderHash_idx" ON "FileAsset"("koreaderHash");
+
+CREATE TABLE "KoreaderCredential" (
+    "id" TEXT NOT NULL,
+    "userId" TEXT NOT NULL,
+    "username" TEXT NOT NULL,
+    "passwordHash" TEXT NOT NULL,
+    "isEnabled" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "KoreaderCredential_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "KoreaderCredential_userId_key" ON "KoreaderCredential"("userId");
+CREATE UNIQUE INDEX "KoreaderCredential_username_key" ON "KoreaderCredential"("username");
+
+ALTER TABLE "KoreaderCredential"
+ADD CONSTRAINT "KoreaderCredential_userId_fkey"
+FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -149,6 +149,7 @@ model User {
   readingProgress ReadingProgress[]
   workProgressPreferences WorkProgressPreference[]
   koboDevices     KoboDevice[]
+  koreaderCredential KoreaderCredential?
   opdsCredentials OpdsCredential[]
 }
 
@@ -202,6 +203,7 @@ model FileAsset {
   mtime              DateTime?
   partialHash        String?
   fullHash           String?
+  koreaderHash       String?
   metadata           Json?
   mediaKind          MediaKind
   availabilityStatus AvailabilityStatus @default(PRESENT)
@@ -219,6 +221,7 @@ model FileAsset {
   @@index([libraryRootId, availabilityStatus])
   @@index([partialHash])
   @@index([fullHash])
+  @@index([koreaderHash])
 }
 
 model Work {
@@ -300,6 +303,7 @@ model Contributor {
   id            String   @id @default(cuid())
   nameDisplay   String
   nameCanonical String
+  nameSort      String?
   imagePath     String?
   createdAt     DateTime @default(now())
 
@@ -545,4 +549,16 @@ model OpdsCredential {
   user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 
   @@index([userId])
+}
+
+model KoreaderCredential {
+  id           String   @id @default(cuid())
+  userId       String   @unique
+  username     String   @unique
+  passwordHash String
+  isEnabled    Boolean  @default(false)
+  createdAt    DateTime @default(now())
+  updatedAt    DateTime @updatedAt
+
+  user User @relation(fields: [userId], references: [id], onDelete: Cascade)
 }

--- a/packages/db/src/index.test.ts
+++ b/packages/db/src/index.test.ts
@@ -1,32 +1,93 @@
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-const prismaConstructorMock = vi.fn();
+type PrismaGlobal = {
+  prisma?: object;
+};
 
-vi.mock("@prisma/client", () => {
-  function PrismaClient() {
-    prismaConstructorMock();
+const originalDatabaseUrl = process.env.DATABASE_URL;
+const originalNodeEnv = process.env.NODE_ENV;
+const originalPrisma = (globalThis as PrismaGlobal).prisma;
+
+afterEach(() => {
+  vi.resetModules();
+  vi.doUnmock("@prisma/client");
+  vi.doUnmock("@prisma/adapter-pg");
+  process.env.DATABASE_URL = originalDatabaseUrl;
+  process.env.NODE_ENV = originalNodeEnv;
+  if (originalPrisma === undefined) {
+    delete (globalThis as PrismaGlobal).prisma;
+  } else {
+    (globalThis as PrismaGlobal).prisma = originalPrisma;
   }
-
-  return { PrismaClient };
 });
 
-describe("db package", () => {
-  it("creates and exports a prisma singleton", async () => {
-    vi.resetModules();
-    process.env.NODE_ENV = "test";
-    const { PrismaClient, db } = await import("./index");
+describe("packages/db Prisma singleton", () => {
+  it("creates and caches a client outside production, defaulting DATABASE_URL", async () => {
+    delete process.env.DATABASE_URL;
+    process.env.NODE_ENV = "development";
+    delete (globalThis as PrismaGlobal).prisma;
 
-    expect(prismaConstructorMock).toHaveBeenCalledTimes(1);
-    expect(db).toBeInstanceOf(PrismaClient);
+    const mockPrismaClient = vi.fn(function MockPrismaClient(
+      this: { kind: string; adapter: object },
+      { adapter }: { adapter: object },
+    ) {
+      this.kind = "new-client";
+      this.adapter = adapter;
+    });
+    const mockPrismaPg = vi.fn(function MockPrismaPg(
+      this: { connectionString: string },
+      { connectionString }: { connectionString: string },
+    ) {
+      this.connectionString = connectionString;
+    });
+
+    vi.doMock("@prisma/client", () => ({
+      PrismaClient: mockPrismaClient,
+    }));
+    vi.doMock("@prisma/adapter-pg", () => ({
+      PrismaPg: mockPrismaPg,
+    }));
+
+    const mod = await import("./index");
+
+    expect(mockPrismaPg).toHaveBeenCalledWith({
+      connectionString: "postgresql://bookhouse:bookhouse@localhost:5432/bookhouse",
+    });
+    expect(mockPrismaClient).toHaveBeenCalledTimes(1);
+    expect(mod.db).toEqual({
+      kind: "new-client",
+      adapter: { connectionString: "postgresql://bookhouse:bookhouse@localhost:5432/bookhouse" },
+    });
+    expect((globalThis as PrismaGlobal).prisma).toEqual(mod.db);
   });
 
-  it("does not cache the prisma client globally in production", async () => {
-    vi.resetModules();
+  it("reuses a cached client in production without mutating the global", async () => {
+    process.env.DATABASE_URL = "postgresql://example";
     process.env.NODE_ENV = "production";
-    delete (globalThis as { prisma?: object }).prisma;
+    (globalThis as PrismaGlobal).prisma = { kind: "cached-client" };
 
-    await import("./index");
+    const mockPrismaClient = vi.fn(function MockPrismaClient(this: object, _args: object) {
+      return this;
+    });
+    const mockPrismaPg = vi.fn(function MockPrismaPg(
+      this: { connectionString: string },
+      { connectionString }: { connectionString: string },
+    ) {
+      this.connectionString = connectionString;
+    });
 
-    expect((globalThis as { prisma?: object }).prisma).toBeUndefined();
+    vi.doMock("@prisma/client", () => ({
+      PrismaClient: mockPrismaClient,
+    }));
+    vi.doMock("@prisma/adapter-pg", () => ({
+      PrismaPg: mockPrismaPg,
+    }));
+
+    const mod = await import("./index");
+
+    expect(mockPrismaPg).toHaveBeenCalledWith({ connectionString: "postgresql://example" });
+    expect(mockPrismaClient).not.toHaveBeenCalled();
+    expect(mod.db).toEqual({ kind: "cached-client" });
+    expect((globalThis as PrismaGlobal).prisma).toEqual({ kind: "cached-client" });
   });
 });

--- a/packages/ingest/src/hashing.test.ts
+++ b/packages/ingest/src/hashing.test.ts
@@ -34,9 +34,11 @@ describe("hashFileContents", () => {
       .update(":")
       .update(fileContents.length.toString())
       .digest("hex");
+    const expectedKoreaderHash = createHash("md5").update(fileContents).digest("hex");
 
     expect(result.fullHash).toBe(expectedFullHash);
     expect(result.partialHash).toBe(expectedPartialHash);
+    expect(result.koreaderHash).toBe(expectedKoreaderHash);
     expect(result.sizeBytes).toBe(BigInt(fileContents.length));
     expect(result.mtime).toBeInstanceOf(Date);
   });

--- a/packages/ingest/src/hashing.ts
+++ b/packages/ingest/src/hashing.ts
@@ -6,6 +6,7 @@ export const PARTIAL_HASH_BYTES = 64 * 1024;
 
 export interface FileHashes {
   fullHash: string;
+  koreaderHash: string;
   mtime: Date;
   partialHash: string;
   sizeBytes: bigint;
@@ -15,6 +16,7 @@ export async function hashFileContents(absolutePath: string): Promise<FileHashes
   const fileStats = await stat(absolutePath);
   const sizeBytes = BigInt(fileStats.size);
   const fullHash = createHash("sha256");
+  const koreaderHash = createHash("md5");
   const partialHash = createHash("sha256");
   let partialBytesRead = 0;
 
@@ -23,6 +25,7 @@ export async function hashFileContents(absolutePath: string): Promise<FileHashes
 
     stream.on("data", (chunk: Buffer) => {
       fullHash.update(chunk);
+      koreaderHash.update(chunk);
 
       if (partialBytesRead < PARTIAL_HASH_BYTES) {
         const remainingBytes = PARTIAL_HASH_BYTES - partialBytesRead;
@@ -41,6 +44,7 @@ export async function hashFileContents(absolutePath: string): Promise<FileHashes
 
   return {
     fullHash: fullHash.digest("hex"),
+    koreaderHash: koreaderHash.digest("hex"),
     mtime: fileStats.mtime,
     partialHash: partialHash.digest("hex"),
     sizeBytes,

--- a/packages/ingest/src/index.ts
+++ b/packages/ingest/src/index.ts
@@ -100,5 +100,6 @@ export type { WDAuthor } from "./enrichment/wikidata";
 export { applyAuthorPhotoFromUrl } from "./author-photo";
 export type { AuthorPhotoDeps, AuthorPhotoDbDeps, AuthorPhotoInput, AuthorPhotoResult } from "./author-photo";
 export { levenshteinDistance, normalizedSimilarity, normalizeForTitleMatching, stripSubtitleForMatching } from "./similarity";
+export { generateSortTitle, generateNameSort } from "./sort-keys";
 export { cascadeCleanupOrphans, cleanupOrphanedFileAssets } from "./cascade-cleanup";
 export type { CascadeCleanupInput, CascadeCleanupResult } from "./cascade-cleanup";

--- a/packages/ingest/src/services.test.ts
+++ b/packages/ingest/src/services.test.ts
@@ -112,6 +112,7 @@ interface TestContributor {
   id: string;
   nameCanonical: string;
   nameDisplay: string;
+  nameSort: string | null;
 }
 
 interface TestEditionFile {
@@ -454,9 +455,11 @@ function createTestDb(state: TestState): IngestDb {
       async create({ data }) {
         await Promise.resolve();
         contributorSequence += 1;
+        const input = data as typeof data & { nameSort?: string | null };
         const created: TestContributor = {
           id: `contributor-${String(contributorSequence)}`,
-          ...data,
+          nameSort: input.nameSort ?? null,
+          ...input,
         };
         state.contributors.set(created.id, created);
         state.contributorsByCanonical.set(created.nameCanonical, created);
@@ -626,6 +629,7 @@ function addContributor(state: TestState, overrides: Partial<TestContributor> = 
     id: "contributor-1",
     nameCanonical: "n k jemisin",
     nameDisplay: "N. K. Jemisin",
+    nameSort: "jemisin, n. k.",
     ...overrides,
   };
   state.contributors.set(contributor.id, contributor);
@@ -2875,6 +2879,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "next-full",
+          koreaderHash: "next-koreader",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "next-partial",
           sizeBytes: 12n,
@@ -2891,6 +2896,7 @@ describe("ingest services", () => {
       availabilityStatus: AvailabilityStatus.PRESENT,
       fileAssetId: "file-1",
       fullHash: "next-full",
+      koreaderHash: "next-koreader",
       partialHash: "next-partial",
     });
     expect(state.fileAssetsById.get("file-1")).toMatchObject({
@@ -3051,6 +3057,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "next-full",
+          koreaderHash: "next-koreader",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "next-partial",
           sizeBytes: 12n,
@@ -3095,6 +3102,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "next-full",
+          koreaderHash: "next-koreader",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "next-partial",
           sizeBytes: 12n,
@@ -3139,6 +3147,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "next-full",
+          koreaderHash: "next-koreader",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "next-partial",
           sizeBytes: 12n,
@@ -3216,6 +3225,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "same-hash-abc",
+          koreaderHash: "same-koreader-hash-abc",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "partial-abc",
           sizeBytes: 100n,
@@ -3233,6 +3243,7 @@ describe("ingest services", () => {
       availabilityStatus: AvailabilityStatus.PRESENT,
       fileAssetId: "new-file",
       fullHash: "same-hash-abc",
+      koreaderHash: "same-koreader-hash-abc",
       movedFromFileAssetId: "old-file",
       partialHash: "partial-abc",
     });
@@ -3276,6 +3287,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "hash-abc",
+          koreaderHash: "koreader-hash-abc",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "partial-abc",
           sizeBytes: 100n,
@@ -3316,6 +3328,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "hash-abc",
+          koreaderHash: "koreader-hash-abc",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "partial-abc",
           sizeBytes: 100n,
@@ -3380,6 +3393,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "hash-xyz",
+          koreaderHash: "koreader-hash-xyz",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "partial-xyz",
           sizeBytes: 100n,
@@ -3394,6 +3408,7 @@ describe("ingest services", () => {
       availabilityStatus: AvailabilityStatus.PRESENT,
       fileAssetId: "new-file",
       fullHash: "hash-xyz",
+      koreaderHash: "koreader-hash-xyz",
       movedFromFileAssetId: "old-file",
       partialHash: "partial-xyz",
     });
@@ -3438,6 +3453,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "unique-hash",
+          koreaderHash: "koreader-unique-hash",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "partial",
           sizeBytes: 100n,
@@ -3487,6 +3503,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "same-hash",
+          koreaderHash: "koreader-same-hash",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "partial",
           sizeBytes: 100n,
@@ -5518,7 +5535,7 @@ describe("ingest services", () => {
       id: "work-1",
       seriesId: null,
       seriesPosition: null,
-      sortTitle: null,
+      sortTitle: "fifth season, the",
       titleCanonical: "the fifth season",
       titleDisplay: "The Fifth Season",
     });
@@ -5533,6 +5550,7 @@ describe("ingest services", () => {
         id: "contributor-1",
         nameCanonical: "n k jemisin",
         nameDisplay: "N. K. Jemisin",
+        nameSort: "jemisin, n. k.",
       },
     ]);
     expect([...state.editionFiles.values()]).toHaveLength(1);
@@ -6193,6 +6211,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "hash",
+          koreaderHash: "koreader-hash",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "phash",
           sizeBytes: 2n,
@@ -6237,6 +6256,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "hash",
+          koreaderHash: "koreader-hash",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "phash",
           sizeBytes: 2n,
@@ -7395,6 +7415,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "hash",
+          koreaderHash: "koreader-hash",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "phash",
           sizeBytes: 4n,
@@ -7439,6 +7460,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "hash",
+          koreaderHash: "koreader-hash",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "phash",
           sizeBytes: 2n,
@@ -7483,6 +7505,7 @@ describe("ingest services", () => {
         await Promise.resolve();
         return {
           fullHash: "hash",
+          koreaderHash: "koreader-hash",
           mtime: new Date("2025-01-01T00:00:00.000Z"),
           partialHash: "phash",
           sizeBytes: 2n,
@@ -11169,7 +11192,7 @@ describe("detectDuplicates", () => {
   }
 
   function addDetectContributor(state: TestState, id: string, name: string) {
-    const c: TestContributor = { id, nameCanonical: name.toLowerCase(), nameDisplay: name };
+    const c: TestContributor = { id, nameCanonical: name.toLowerCase(), nameDisplay: name, nameSort: name.toLowerCase() };
     state.contributors.set(id, c);
     state.contributorsByCanonical.set(c.nameCanonical, c);
     return c;
@@ -11871,7 +11894,7 @@ describe("matchSuggestions", () => {
   }
 
   function addAudioContributor(state: TestState, id: string, name: string) {
-    const c: TestContributor = { id, nameCanonical: name.toLowerCase(), nameDisplay: name };
+    const c: TestContributor = { id, nameCanonical: name.toLowerCase(), nameDisplay: name, nameSort: name.toLowerCase() };
     state.contributors.set(id, c);
     state.contributorsByCanonical.set(c.nameCanonical, c);
     return c;

--- a/packages/ingest/src/services.ts
+++ b/packages/ingest/src/services.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import { generateSortTitle, generateNameSort } from "./sort-keys";
 import type { Dirent, Stats } from "node:fs";
 import { lstat, readdir } from "node:fs/promises";
 import {
@@ -113,6 +114,7 @@ interface FileAssetCreateInput {
 
 interface FileAssetUpdateInput extends Omit<FileAssetCreateInput, "absolutePath" | "libraryRootId"> {
   fullHash?: string | null;
+  koreaderHash?: string | null;
   partialHash?: string | null;
 }
 
@@ -402,6 +404,7 @@ export interface HashFileAssetResult {
   availabilityStatus: AvailabilityStatus;
   fileAssetId: string;
   fullHash?: string;
+  koreaderHash?: string;
   movedFromFileAssetId?: string;
   partialHash?: string;
 }
@@ -1027,9 +1030,10 @@ async function ensureContributors(
     .map((nameDisplay) => ({
       nameCanonical: canonicalizeContributorName(nameDisplay),
       nameDisplay,
+      nameSort: generateNameSort(nameDisplay),
     }))
     .filter(
-      (entry): entry is { nameCanonical: string; nameDisplay: string } =>
+      (entry): entry is { nameCanonical: string; nameDisplay: string; nameSort: string } =>
         entry.nameCanonical !== undefined,
     );
 
@@ -1996,7 +2000,7 @@ export function createIngestServices(
                 const stubWork = await ingestDb.work.create({
                   data: {
                     enrichmentStatus: "STUB",
-                    sortTitle: null,
+                    sortTitle: generateSortTitle(title),
                     titleCanonical,
                     titleDisplay: title,
                   },
@@ -2054,7 +2058,7 @@ export function createIngestServices(
                 const stubWork = await ingestDb.work.create({
                   data: {
                     enrichmentStatus: "STUB",
-                    sortTitle: null,
+                    sortTitle: generateSortTitle(title),
                     titleCanonical,
                     titleDisplay: title,
                   },
@@ -2163,6 +2167,7 @@ export function createIngestServices(
         data: {
           availabilityStatus: AvailabilityStatus.PRESENT,
           fullHash: hashes.fullHash,
+          koreaderHash: hashes.koreaderHash,
           lastSeenAt: now,
           mtime: hashes.mtime,
           partialHash: hashes.partialHash,
@@ -2209,6 +2214,7 @@ export function createIngestServices(
                   availabilityStatus: AvailabilityStatus.PRESENT,
                   fileAssetId: fileAsset.id,
                   fullHash: hashes.fullHash,
+                  koreaderHash: hashes.koreaderHash,
                   movedFromFileAssetId: missingMatch.id,
                   partialHash: hashes.partialHash,
                 };
@@ -2235,6 +2241,7 @@ export function createIngestServices(
         availabilityStatus: AvailabilityStatus.PRESENT,
         fileAssetId: fileAsset.id,
         fullHash: hashes.fullHash,
+        koreaderHash: hashes.koreaderHash,
         partialHash: hashes.partialHash,
       };
     } catch (error) {
@@ -2928,7 +2935,7 @@ export function createIngestServices(
                 data: {
                   description: storedMeta.normalized?.description ?? null,
                   enrichmentStatus: "ENRICHED",
-                  sortTitle: null,
+                  sortTitle: generateSortTitle(matchableMeta.title),
                   titleCanonical: matchableMeta.titleCanonical,
                   titleDisplay: matchableMeta.title,
                 },
@@ -3076,7 +3083,7 @@ export function createIngestServices(
           data: {
             description: ctx.storedMetadata.normalized?.description ?? null,
             enrichmentStatus: "ENRICHED",
-            sortTitle: null,
+            sortTitle: generateSortTitle(ctx.matchableMetadata.title),
             titleCanonical: ctx.matchableMetadata.titleCanonical,
             titleDisplay: ctx.matchableMetadata.title,
           },
@@ -3308,7 +3315,7 @@ export function createIngestServices(
     if (matchingWork === undefined) {
       const createdWorkRecord = await ingestDb.work.create({
         data: {
-          sortTitle: null,
+          sortTitle: generateSortTitle(ctx.matchableMetadata.title),
           titleCanonical: ctx.matchableMetadata.titleCanonical,
           titleDisplay: ctx.matchableMetadata.title,
         },
@@ -3354,7 +3361,7 @@ export function createIngestServices(
         data: {
           description: ctx.storedMetadata.normalized?.description ?? null,
           enrichmentStatus: "ENRICHED",
-          sortTitle: null,
+          sortTitle: generateSortTitle(ctx.matchableMetadata.title),
           titleCanonical: ctx.matchableMetadata.titleCanonical,
           titleDisplay: ctx.matchableMetadata.title,
         },

--- a/packages/ingest/src/sort-keys.test.ts
+++ b/packages/ingest/src/sort-keys.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from "vitest";
+import { generateSortTitle, generateNameSort } from "./sort-keys";
+
+describe("generateSortTitle", () => {
+  it("strips leading 'The' and appends after comma", () => {
+    expect(generateSortTitle("The Alchemist")).toBe("alchemist, the");
+  });
+
+  it("strips leading 'A' and appends after comma", () => {
+    expect(generateSortTitle("A Game of Thrones")).toBe("game of thrones, a");
+  });
+
+  it("strips leading 'An' and appends after comma", () => {
+    expect(generateSortTitle("An Artist of the Floating World")).toBe(
+      "artist of the floating world, an",
+    );
+  });
+
+  it("does not strip 'The' when not followed by a word boundary", () => {
+    expect(generateSortTitle("There Will Come Soft Rains")).toBe(
+      "there will come soft rains",
+    );
+  });
+
+  it("does not strip 'A' when not followed by a word boundary", () => {
+    expect(generateSortTitle("Another Country")).toBe("another country");
+  });
+
+  it("does not strip 'An' when not followed by a word boundary", () => {
+    expect(generateSortTitle("Anthem")).toBe("anthem");
+  });
+
+  it("lowercases the result", () => {
+    expect(generateSortTitle("THE GREAT GATSBY")).toBe("great gatsby, the");
+  });
+
+  it("passes through titles without articles unchanged (lowercased)", () => {
+    expect(generateSortTitle("1984")).toBe("1984");
+  });
+
+  it("handles single-word title", () => {
+    expect(generateSortTitle("Dune")).toBe("dune");
+  });
+
+  it("trims whitespace", () => {
+    expect(generateSortTitle("  The Hobbit  ")).toBe("hobbit, the");
+  });
+
+  it("handles empty string", () => {
+    expect(generateSortTitle("")).toBe("");
+  });
+
+  it("handles case-insensitive article matching", () => {
+    expect(generateSortTitle("the catcher in the rye")).toBe(
+      "catcher in the rye, the",
+    );
+  });
+});
+
+describe("generateNameSort", () => {
+  it("moves last word to front for multi-word name", () => {
+    expect(generateNameSort("Ursula K. Le Guin")).toBe(
+      "guin, ursula k. le",
+    );
+  });
+
+  it("handles simple two-part name", () => {
+    expect(generateNameSort("J.R.R. Tolkien")).toBe("tolkien, j.r.r.");
+  });
+
+  it("returns single name lowercased", () => {
+    expect(generateNameSort("Plato")).toBe("plato");
+  });
+
+  it("lowercases the result", () => {
+    expect(generateNameSort("STEPHEN KING")).toBe("king, stephen");
+  });
+
+  it("trims whitespace", () => {
+    expect(generateNameSort("  Neil Gaiman  ")).toBe("gaiman, neil");
+  });
+
+  it("handles empty string", () => {
+    expect(generateNameSort("")).toBe("");
+  });
+
+  it("handles name with multiple spaces between words", () => {
+    expect(generateNameSort("Gabriel  García  Márquez")).toBe(
+      "márquez, gabriel garcía",
+    );
+  });
+});

--- a/packages/ingest/src/sort-keys.ts
+++ b/packages/ingest/src/sort-keys.ts
@@ -1,0 +1,26 @@
+const LEADING_ARTICLE = /^(the|a|an)\s+/i;
+
+export function generateSortTitle(titleDisplay: string): string {
+  const trimmed = titleDisplay.trim();
+  if (trimmed === "") return "";
+
+  const match = LEADING_ARTICLE.exec(trimmed);
+  if (match) {
+    const article = match[1] as string;
+    const rest = trimmed.slice(match[0].length);
+    return `${rest.toLowerCase()}, ${article.toLowerCase()}`;
+  }
+
+  return trimmed.toLowerCase();
+}
+
+export function generateNameSort(nameDisplay: string): string {
+  const trimmed = nameDisplay.trim();
+  if (trimmed === "") return "";
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length === 1) return trimmed.toLowerCase();
+
+  const last = parts.pop() as string;
+  return `${last.toLowerCase()}, ${parts.join(" ").toLowerCase()}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,37 @@ importers:
         specifier: ^9.0.4
         version: 9.0.4
 
+  apps/guide:
+    dependencies:
+      '@tanstack/react-router':
+        specifier: ^1.167.4
+        version: 1.167.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      react:
+        specifier: ^19.2.4
+        version: 19.2.4
+      react-dom:
+        specifier: ^19.2.4
+        version: 19.2.4(react@19.2.4)
+    devDependencies:
+      '@types/node':
+        specifier: ^25.5.0
+        version: 25.5.0
+      '@types/react':
+        specifier: ^19.2.14
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: ^19.2.3
+        version: 19.2.3(@types/react@19.2.14)
+      '@vitejs/plugin-react':
+        specifier: ^4.6.0
+        version: 4.7.0(vite@7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0))
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vite:
+        specifier: ^7.3.1
+        version: 7.3.1(@types/node@25.5.0)(jiti@2.6.1)(lightningcss@1.31.1)(tsx@4.21.0)
+
   apps/web:
     dependencies:
       '@bookhouse/auth':
@@ -822,67 +853,79 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -1079,24 +1122,28 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/crc32-linux-arm64-musl@1.10.6':
     resolution: {integrity: sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/crc32-linux-x64-gnu@1.10.6':
     resolution: {integrity: sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@node-rs/crc32-linux-x64-musl@1.10.6':
     resolution: {integrity: sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@node-rs/crc32-wasm32-wasi@1.10.6':
     resolution: {integrity: sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==}
@@ -1961,36 +2008,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
     resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
     resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
     resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
@@ -2058,66 +2111,79 @@ packages:
     resolution: {integrity: sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.59.0':
     resolution: {integrity: sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.59.0':
     resolution: {integrity: sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.59.0':
     resolution: {integrity: sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.59.0':
     resolution: {integrity: sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.59.0':
     resolution: {integrity: sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.59.0':
     resolution: {integrity: sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.59.0':
     resolution: {integrity: sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.59.0':
     resolution: {integrity: sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.59.0':
     resolution: {integrity: sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.59.0':
     resolution: {integrity: sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.59.0':
     resolution: {integrity: sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.59.0':
     resolution: {integrity: sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.59.0':
     resolution: {integrity: sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==}
@@ -2197,24 +2263,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.2.1':
     resolution: {integrity: sha512-WZA0CHRL/SP1TRbA5mp9htsppSEkWuQ4KsSUumYQnyl8ZdT39ntwqmz4IUHGN6p4XdSlYfJwM4rRzZLShHsGAQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.2.1':
     resolution: {integrity: sha512-qMFzxI2YlBOLW5PhblzuSWlWfwLHaneBE0xHzLrBgNtqN6mWfs+qYbhryGSXQjFYB1Dzf5w+LN5qbUTPhW7Y5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.2.1':
     resolution: {integrity: sha512-5r1X2FKnCMUPlXTWRYpHdPYUY6a1Ar/t7P24OuiEdEOmms5lyqjDRvVY1yy9Rmioh+AunQ0rWiOTPE8F9A3v5g==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.2.1':
     resolution: {integrity: sha512-MGFB5cVPvshR85MTJkEvqDUnuNoysrsRxd6vnk1Lf2tbiqNlXpHYZqkqOQalydienEWOHHFyyuTSYRsLfxFJ2Q==}
@@ -4033,24 +4103,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.31.1:
     resolution: {integrity: sha512-mVZ7Pg2zIbe3XlNbZJdjs86YViQFoJSpc41CbVmKBPiGmC4YrfeOyz65ms2qpAobVd7WQsbW4PdsSJEMymyIMg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.31.1:
     resolution: {integrity: sha512-xGlFWRMl+0KvUhgySdIaReQdB4FNudfUTARn7q0hh/V67PVGCs3ADFjw+6++kG1RNd0zdGRlEKa+T13/tQjPMA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.31.1:
     resolution: {integrity: sha512-eowF8PrKHw9LpoZii5tdZwnBcYDxRw2rRCyvAXLi34iyeYfqCQNA9rmUM0ce62NlPhCvof1+9ivRaTY6pSKDaA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.31.1:
     resolution: {integrity: sha512-aJReEbSEQzx1uBlQizAOBSjcmr9dCdL3XuC/6HLXAxmtErsj2ICo5yYggg1qOODQMtnjNQv2UHb9NpOuFtYe4w==}

--- a/scripts/backfill-sort-keys.ts
+++ b/scripts/backfill-sort-keys.ts
@@ -1,0 +1,65 @@
+/**
+ * One-time backfill script: Populate sortTitle on works and nameSort on contributors.
+ *
+ * - Sets Work.sortTitle using generateSortTitle(titleDisplay) where sortTitle IS NULL
+ *   and "sortTitle" is not in editedFields (user hasn't manually set it).
+ * - Sets Contributor.nameSort using generateNameSort(nameDisplay) where nameSort IS NULL.
+ *
+ * Usage: npx tsx scripts/backfill-sort-keys.ts
+ */
+
+import { db } from "@bookhouse/db";
+import { generateSortTitle, generateNameSort } from "@bookhouse/ingest";
+
+async function main() {
+  // Backfill Work.sortTitle
+  const works = await db.work.findMany({
+    where: { sortTitle: null },
+    select: { id: true, titleDisplay: true, editedFields: true },
+  });
+
+  const worksToUpdate = works.filter(
+    (w) => !w.editedFields.includes("sortTitle"),
+  );
+
+  console.log(
+    `Found ${String(works.length)} works with null sortTitle (${String(worksToUpdate.length)} eligible for backfill)`,
+  );
+
+  let workUpdated = 0;
+  for (const work of worksToUpdate) {
+    await db.work.update({
+      where: { id: work.id },
+      data: { sortTitle: generateSortTitle(work.titleDisplay) },
+    });
+    workUpdated++;
+  }
+
+  console.log(`Updated ${String(workUpdated)} works`);
+
+  // Backfill Contributor.nameSort
+  const contributors = await db.contributor.findMany({
+    where: { nameSort: null },
+    select: { id: true, nameDisplay: true },
+  });
+
+  console.log(`Found ${String(contributors.length)} contributors with null nameSort`);
+
+  let contribUpdated = 0;
+  for (const contrib of contributors) {
+    await db.contributor.update({
+      where: { id: contrib.id },
+      data: { nameSort: generateNameSort(contrib.nameDisplay) },
+    });
+    contribUpdated++;
+  }
+
+  console.log(`Updated ${String(contribUpdated)} contributors`);
+  console.log("Backfill complete");
+}
+
+main()
+  .catch(console.error)
+  .finally(() => {
+    void db.$disconnect();
+  });

--- a/scripts/web-entrypoint.sh
+++ b/scripts/web-entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -e
+
+PRISMA_CLI=$(ls /app/node_modules/.pnpm/prisma@*/node_modules/prisma/build/index.js 2>/dev/null | head -n1)
+if [ -z "$PRISMA_CLI" ]; then
+  echo "web-entrypoint: prisma CLI not found in /app/node_modules/.pnpm" >&2
+  exit 1
+fi
+
+echo "web-entrypoint: applying database migrations"
+node "$PRISMA_CLI" migrate deploy --schema=/app/packages/db/prisma/schema.prisma
+
+echo "web-entrypoint: starting server"
+exec node /app/.output/server/index.mjs


### PR DESCRIPTION
## Summary
- KOReader progress-sync API (`users/auth`, `syncs/progress`, `syncs/progress/[document]`) with per-user credential management
- Contributor `nameSort` field populated at ingest time via a new `sort-keys` helper; includes a backfill script for existing rows
- GHCR publish workflow builds `web` and `worker` images on push to `main` and `v*` tags
- Web image now runs `prisma migrate deploy` via an entrypoint before starting the server
- `docker-compose.yml` switched from local `build:` to pulling published images with env-var-driven paths and credentials
- Bump pnpm to 10.33.0; add `apps/guide` to `.gitignore`

## Deploy notes
- First successful run of the Publish workflow creates the GHCR packages as private — make them public or configure the host to `docker login ghcr.io` with a PAT that has `read:packages`.
- Hosts must set `EBOOKS_PATH`, `AUDIOBOOKS_PATH`, `AUTH_SECRET`, and the OIDC vars in `.env` before `docker compose up`. See `.env.example`.