### PR TITLE
Install ca-certificates in web image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN DATABASE_URL="postgresql://build:build@localhost:5432/build" pnpm db:generat
 RUN pnpm build
 
 FROM base AS web
-RUN apt-get update && apt-get install -y --no-install-recommends curl \
+RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
   && ARCH=$(dpkg --print-architecture) \
   && curl -fsSL "https://github.com/pgaskin/kepubify/releases/latest/download/kepubify-linux-${ARCH}" -o /usr/local/bin/kepubify \
   && chmod +x /usr/local/bin/kepubify \


### PR DESCRIPTION
## Summary
The web image's kepubify download step failed in the Publish workflow with `curl: (77) error setting certificate file: /etc/ssl/certs/ca-certificates.crt`. `node:24-slim` does not include a CA bundle, and `apt-get install --no-install-recommends curl` does not pull one in. Install `ca-certificates` alongside `curl`.

Failure run: https://github.com/beforetheshoes/Bookhouse/actions/runs/24884269543