### PR TITLE
Map dpkg arch to kepubify release asset names

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,14 @@ RUN pnpm build
 
 FROM base AS web
 RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates \
-  && ARCH=$(dpkg --print-architecture) \
-  && curl -fsSL "https://github.com/pgaskin/kepubify/releases/latest/download/kepubify-linux-${ARCH}" -o /usr/local/bin/kepubify \
+  && case "$(dpkg --print-architecture)" in \
+       amd64) KEPUBIFY_ARCH=64bit ;; \
+       arm64) KEPUBIFY_ARCH=arm64 ;; \
+       armhf) KEPUBIFY_ARCH=armv6 ;; \
+       i386)  KEPUBIFY_ARCH=32bit ;; \
+       *) echo "unsupported arch: $(dpkg --print-architecture)" >&2; exit 1 ;; \
+     esac \
+  && curl -fsSL "https://github.com/pgaskin/kepubify/releases/latest/download/kepubify-linux-${KEPUBIFY_ARCH}" -o /usr/local/bin/kepubify \
   && chmod +x /usr/local/bin/kepubify \
   && apt-get purge -y curl && apt-get autoremove -y && rm -rf /var/lib/apt/lists/*
 COPY --from=build /app/node_modules node_modules


### PR DESCRIPTION
## Summary
The web image's kepubify download step failed in Publish with `curl: (22) The requested URL returned error: 404`. pgaskin/kepubify publishes binaries as `kepubify-linux-64bit`, `kepubify-linux-arm64`, etc., not the `amd64`/`armhf` names that `dpkg --print-architecture` returns. Add a mapping.

Failure run: https://github.com/beforetheshoes/Bookhouse/actions/runs/24884610971