### PR TITLE
Fix worker module resolution and web prisma migrate

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,10 +36,15 @@ RUN PRISMA_DIR="$(find /app/node_modules/.pnpm -path '*/node_modules/@prisma' | 
   && ln -s "$PRISMA_DIR" /app/node_modules/@prisma
 COPY --from=build /app/apps/web/.output .output
 COPY --from=build /app/packages/db/prisma packages/db/prisma
+COPY --from=build /app/packages/db/prisma.config.ts packages/db/prisma.config.ts
+COPY --from=build /app/packages/db/package.json packages/db/package.json
 COPY scripts/web-entrypoint.sh /usr/local/bin/web-entrypoint.sh
 RUN chmod +x /usr/local/bin/web-entrypoint.sh
 CMD ["/usr/local/bin/web-entrypoint.sh"]
 
 FROM base AS worker
+WORKDIR /app/workers/library-worker
+COPY --from=build /app/node_modules /app/node_modules
+COPY --from=build /app/workers/library-worker/node_modules node_modules
 COPY --from=build /app/workers/library-worker/dist dist
 CMD ["node", "dist/index.js"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -352,12 +352,33 @@ importers:
       '@bookhouse/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      '@prisma/adapter-pg':
+        specifier: ^7.5.0
+        version: 7.5.0
+      '@prisma/client':
+        specifier: ^7.5.0
+        version: 7.5.0(prisma@7.5.0(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(typescript@5.9.3)
       bullmq:
         specifier: ^5.71.0
         version: 5.71.0
+      fast-xml-parser:
+        specifier: ^5.5.6
+        version: 5.5.6
       ioredis:
         specifier: 5.9.3
         version: 5.9.3
+      music-metadata:
+        specifier: ^11.12.3
+        version: 11.12.3
+      pino:
+        specifier: ^10.3.1
+        version: 10.3.1
+      sharp:
+        specifier: ^0.33.0
+        version: 0.33.5
+      yauzl-promise:
+        specifier: ^4.0.0
+        version: 4.0.0
     devDependencies:
       '@types/node':
         specifier: ^25.5.0

--- a/scripts/web-entrypoint.sh
+++ b/scripts/web-entrypoint.sh
@@ -8,7 +8,7 @@ if [ -z "$PRISMA_CLI" ]; then
 fi
 
 echo "web-entrypoint: applying database migrations"
-node "$PRISMA_CLI" migrate deploy --schema=/app/packages/db/prisma/schema.prisma
+(cd /app/packages/db && node "$PRISMA_CLI" migrate deploy)
 
 echo "web-entrypoint: starting server"
 exec node /app/.output/server/index.mjs

--- a/workers/library-worker/package.json
+++ b/workers/library-worker/package.json
@@ -18,8 +18,15 @@
     "@bookhouse/domain": "workspace:*",
     "@bookhouse/ingest": "workspace:*",
     "@bookhouse/shared": "workspace:*",
+    "@prisma/adapter-pg": "^7.5.0",
+    "@prisma/client": "^7.5.0",
     "bullmq": "^5.71.0",
-    "ioredis": "5.9.3"
+    "fast-xml-parser": "^5.5.6",
+    "ioredis": "5.9.3",
+    "music-metadata": "^11.12.3",
+    "pino": "^10.3.1",
+    "sharp": "^0.33.0",
+    "yauzl-promise": "^4.0.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/workers/library-worker/tsup.config.test.ts
+++ b/workers/library-worker/tsup.config.test.ts
@@ -7,7 +7,7 @@ describe("library worker tsup config", () => {
 
     expect(config.entry).toEqual(["src/index.ts"]);
     expect(config.format).toBe("esm");
-    expect(config.noExternal).toEqual([/.*/]);
+    expect(config.noExternal).toEqual([/^@bookhouse\//]);
     expect(config.external).toContain("node:fs");
     expect(config.banner?.js).toContain("__bundleCreateRequire");
   });

--- a/workers/library-worker/tsup.config.ts
+++ b/workers/library-worker/tsup.config.ts
@@ -4,7 +4,7 @@ import { builtinModules } from "node:module";
 export default defineConfig({
   entry: ["src/index.ts"],
   format: "esm",
-  noExternal: [/.*/],
+  noExternal: [/^@bookhouse\//],
   external: builtinModules.flatMap((m) => [m, `node:${m}`]),
   banner: {
     js: "import { createRequire as __bundleCreateRequire } from 'node:module'; const require = __bundleCreateRequire(import.meta.url);",


### PR DESCRIPTION
## Summary

Two separate issues surfaced when the published images were run on the NAS — the web container crash-looped on `prisma migrate deploy`, and the worker crash-looped on `Cannot find module 'yauzl-promise'`.

### Worker — module resolution
The bundle left several runtime `require()` calls unresolved:
- `yauzl-promise` (via `createRequire` in `epub.ts`)
- `@img/sharp-*` (template-literal requires inside sharp's source)
- `@prisma/client` (CJS/ESM interop + generated `.prisma/client`)

`tsup noExternal: [/.*/]` was forcing bundling of everything it could see, but the leftover runtime lookups couldn't resolve from the bundle's location because those packages were only transitive deps of `@bookhouse/ingest`/`@bookhouse/db`.

Fix:
- `tsup` now only bundles workspace code (`noExternal: [/^@bookhouse\//]`) and leaves npm deps external.
- Promote the runtime deps to direct worker deps (`sharp`, `yauzl-promise`, `music-metadata`, `fast-xml-parser`, `pino`, `@prisma/client`, `@prisma/adapter-pg`) so pnpm links them into `workers/library-worker/node_modules`.
- Worker Docker stage ships the full workspace install tree (`node_modules` at root + worker).
- Bundle size drops from ~6 MB / ~100 chunks to ~200 KB / 3 files.

### Web — Prisma config discovery
Prisma 7 resolves `DATABASE_URL` via `packages/db/prisma.config.ts`. The image never copied the config and ran prisma from `/app`, so it errored with "The datasource.url property is required in your Prisma config file when using prisma migrate deploy."

Fix:
- Copy `prisma.config.ts` and `packages/db/package.json` into the web image.
- Entrypoint `cd`s into `/app/packages/db` before invoking prisma so the config auto-discovers.