### PR TITLE
Copy packages/db/node_modules into web image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY --from=build /app/apps/web/.output .output
 COPY --from=build /app/packages/db/prisma packages/db/prisma
 COPY --from=build /app/packages/db/prisma.config.ts packages/db/prisma.config.ts
 COPY --from=build /app/packages/db/package.json packages/db/package.json
+COPY --from=build /app/packages/db/node_modules packages/db/node_modules
 COPY scripts/web-entrypoint.sh /usr/local/bin/web-entrypoint.sh
 RUN chmod +x /usr/local/bin/web-entrypoint.sh
 CMD ["/usr/local/bin/web-entrypoint.sh"]


### PR DESCRIPTION
## Summary
`packages/db/prisma.config.ts` imports from `"prisma/config"`. pnpm links the prisma CLI at `packages/db/node_modules/prisma` (it's a devDep of the db package, not hoisted to the workspace root). The web image previously only copied `prisma/`, `prisma.config.ts`, and `package.json`, so at startup prisma CLI failed with `Cannot find module 'prisma/config'`.

Also copy `packages/db/node_modules` so the symlink resolves. It references `../../../node_modules/.pnpm/...`, which is already present in the image.