### PR TITLE
Add multi-user accounts with owner + viewer roles

### DIFF
--- a/apps/web/server/middleware/auth.test.ts
+++ b/apps/web/server/middleware/auth.test.ts
@@ -1,7 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AuthSessionData, AuthenticatedUser } from "@bookhouse/auth";
 import type { H3Event } from "h3";
-import { createAuthMiddleware, type AuthMiddlewareDeps } from "./auth";
+import { createAuthMiddleware, requireOwnerFromEvent, type AuthMiddlewareDeps } from "./auth";
 
 function createMockDeps(
   overrides: Partial<AuthMiddlewareDeps> = {},
@@ -16,7 +16,8 @@ function createMockDeps(
 function createMockEvent(pathname: string): H3Event {
   return {
     path: pathname,
-  } as H3Event;
+    context: {},
+  } as unknown as H3Event;
 }
 
 const validUser: AuthenticatedUser = {
@@ -26,6 +27,7 @@ const validUser: AuthenticatedUser = {
   image: null,
   issuer: "https://issuer.example.com",
   subject: "sub-123",
+  roles: ["OWNER"],
 };
 
 const validSessionData: Partial<AuthSessionData> = {
@@ -99,6 +101,31 @@ describe("createAuthMiddleware", () => {
     expect(deps.resolveUser).not.toHaveBeenCalled();
   });
 
+  it("requires auth for /_serverFn/ paths", async () => {
+    const deps = createMockDeps();
+    const middleware = createAuthMiddleware(deps);
+
+    await expect(
+      middleware(createMockEvent("/_serverFn/getLibraryWorks")),
+    ).rejects.toMatchObject({
+      statusCode: 401,
+      statusMessage: "Unauthorized",
+    });
+  });
+
+  it("attaches user to event.context for /_serverFn/ paths when authenticated", async () => {
+    const deps = createMockDeps({
+      getSession: vi.fn().mockResolvedValue({ data: validSessionData }),
+      resolveUser: vi.fn().mockResolvedValue(validUser),
+    });
+    const middleware = createAuthMiddleware(deps);
+    const event = createMockEvent("/_serverFn/getLibraryWorks");
+
+    await middleware(event);
+
+    expect((event.context as { user?: AuthenticatedUser }).user).toBe(validUser);
+  });
+
   it("skips auth for root path", async () => {
     const deps = createMockDeps();
     const middleware = createAuthMiddleware(deps);
@@ -122,5 +149,44 @@ describe("createAuthMiddleware", () => {
     await middleware(event);
 
     expect(getSession).toHaveBeenCalledWith(event);
+  });
+
+  it("attaches the user to event.context after successful auth", async () => {
+    const deps = createMockDeps({
+      getSession: vi.fn().mockResolvedValue({ data: validSessionData }),
+      resolveUser: vi.fn().mockResolvedValue(validUser),
+    });
+    const middleware = createAuthMiddleware(deps);
+    const event = createMockEvent("/api/events");
+
+    await middleware(event);
+
+    expect((event.context as { user?: AuthenticatedUser }).user).toBe(validUser);
+  });
+});
+
+describe("requireOwnerFromEvent", () => {
+  it("returns the user when they are an owner", () => {
+    const event = {
+      context: { user: { id: "u1", roles: ["OWNER"] } },
+    } as unknown as H3Event;
+    const user = requireOwnerFromEvent(event);
+    expect(user.id).toBe("u1");
+  });
+
+  it("throws 403 when the user is not an owner", () => {
+    const event = {
+      context: { user: { id: "u1", roles: ["VIEWER"] } },
+    } as unknown as H3Event;
+    expect(() => requireOwnerFromEvent(event)).toThrowError(
+      expect.objectContaining({ statusCode: 403 }),
+    );
+  });
+
+  it("throws 401 when no user is attached", () => {
+    const event = { context: {} } as unknown as H3Event;
+    expect(() => requireOwnerFromEvent(event)).toThrowError(
+      expect.objectContaining({ statusCode: 401 }),
+    );
   });
 });

--- a/apps/web/server/middleware/auth.ts
+++ b/apps/web/server/middleware/auth.ts
@@ -11,9 +11,13 @@ export interface AuthMiddlewareDeps {
   ) => Promise<AuthenticatedUser | null>;
 }
 
+function requiresSessionAuth(path: string): boolean {
+  return path.startsWith("/api/") || path.startsWith("/_serverFn/");
+}
+
 export function createAuthMiddleware(deps: AuthMiddlewareDeps) {
   return async (event: H3Event) => {
-    if (!event.path.startsWith("/api/")) {
+    if (!requiresSessionAuth(event.path)) {
       return;
     }
 
@@ -23,7 +27,20 @@ export function createAuthMiddleware(deps: AuthMiddlewareDeps) {
     if (!user) {
       throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
     }
+
+    (event.context as { user?: AuthenticatedUser }).user = user;
   };
+}
+
+export function requireOwnerFromEvent(event: H3Event): AuthenticatedUser {
+  const user = (event.context as { user?: AuthenticatedUser }).user;
+  if (!user) {
+    throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
+  }
+  if (!user.roles.includes("OWNER")) {
+    throw createError({ statusCode: 403, statusMessage: "Forbidden" });
+  }
+  return user;
 }
 
 /* c8 ignore start — runtime wiring, tested via unit tests on createAuthMiddleware */
@@ -46,7 +63,7 @@ export default defineEventHandler(async (event) => {
     },
   });
 
-  if (!event.path.startsWith("/api/")) {
+  if (!requiresSessionAuth(event.path)) {
     return;
   }
 
@@ -55,5 +72,7 @@ export default defineEventHandler(async (event) => {
   if (!user) {
     throw createError({ statusCode: 401, statusMessage: "Unauthorized" });
   }
+
+  (event.context as { user?: typeof user }).user = user;
 });
 /* c8 ignore stop */

--- a/apps/web/server/routes/api/backup/download.test.ts
+++ b/apps/web/server/routes/api/backup/download.test.ts
@@ -19,6 +19,7 @@ function createMockDeps(overrides: Partial<DownloadHandlerDeps> = {}): DownloadH
     }) as DownloadHandlerDeps["createBackup"],
     setResponseHeader: vi.fn(),
     sendStream: vi.fn().mockReturnValue(undefined),
+    requireOwner: vi.fn(),
     ...overrides,
   };
 }
@@ -102,5 +103,17 @@ describe("backup download handler", () => {
     const handler = createDownloadHandler(deps);
 
     await expect(handler(createMockEvent() as never)).rejects.toThrow("pg_dump failed");
+  });
+
+  it("calls requireOwner before doing any backup work", async () => {
+    const requireOwner = vi.fn().mockImplementation(() => {
+      throw new Error("Forbidden");
+    });
+    const createBackup = vi.fn();
+    const deps = createMockDeps({ requireOwner, createBackup });
+    const handler = createDownloadHandler(deps);
+
+    await expect(handler(createMockEvent() as never)).rejects.toThrow("Forbidden");
+    expect(createBackup).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/routes/api/backup/download.ts
+++ b/apps/web/server/routes/api/backup/download.ts
@@ -9,10 +9,12 @@ export interface DownloadHandlerDeps {
   createBackup: () => Promise<{ stream: Readable; manifest: BackupManifest }>;
   setResponseHeader: (event: H3Event, name: string, value: string) => void;
   sendStream: (event: H3Event, stream: Readable) => unknown;
+  requireOwner: (event: H3Event) => void;
 }
 
 export function createDownloadHandler(deps: DownloadHandlerDeps) {
   return async (event: H3Event) => {
+    deps.requireOwner(event);
     const { stream, manifest } = await deps.createBackup();
 
     const filename = `bookhouse-backup-${manifest.timestamp}.tar.gz`;
@@ -34,6 +36,7 @@ export default defineEventHandler(async (event) => {
   const { execFile: execFileCallback } = await import("node:child_process");
   const { promisify } = await import("node:util");
   const execFile = promisify(execFileCallback);
+  const { requireOwnerFromEvent } = await import("../../../middleware/auth");
 
   const handler = createDownloadHandler({
     createBackup: () =>
@@ -48,6 +51,7 @@ export default defineEventHandler(async (event) => {
       }),
     setResponseHeader,
     sendStream: sendStream as unknown as DownloadHandlerDeps["sendStream"],
+    requireOwner: (e) => { requireOwnerFromEvent(e); },
   });
   return handler(event);
 });

--- a/apps/web/server/routes/api/backup/upload.test.ts
+++ b/apps/web/server/routes/api/backup/upload.test.ts
@@ -17,6 +17,7 @@ function createMockDeps(overrides: Partial<UploadRestoreHandlerDeps> = {}): Uplo
     ]),
     restoreBackup: vi.fn().mockResolvedValue({ manifest: MOCK_MANIFEST }),
     maxFileSize: 2 * 1024 * 1024 * 1024,
+    requireOwner: vi.fn(),
     ...overrides,
   };
 }
@@ -104,5 +105,18 @@ describe("backup upload/restore handler", () => {
     const handler = createUploadRestoreHandler(deps);
 
     await expect(handler(createMockEvent() as never)).rejects.toThrow("invalid archive");
+  });
+
+  it("calls requireOwner before reading or restoring", async () => {
+    const requireOwner = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error("Forbidden"), { statusCode: 403 });
+    });
+    const deps = createMockDeps({ requireOwner });
+    const handler = createUploadRestoreHandler(deps);
+    await expect(handler(createMockEvent() as never)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+    expect(deps.readFormData).not.toHaveBeenCalled();
+    expect(deps.restoreBackup).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/routes/api/backup/upload.ts
+++ b/apps/web/server/routes/api/backup/upload.ts
@@ -10,10 +10,12 @@ export interface UploadRestoreHandlerDeps {
   readFormData: (event: H3Event) => Promise<{ name?: string; data: Uint8Array; type?: string }[] | undefined>;
   restoreBackup: (archiveBuffer: Buffer) => Promise<{ manifest: BackupManifest }>;
   maxFileSize: number;
+  requireOwner: (event: H3Event) => void;
 }
 
 export function createUploadRestoreHandler(deps: UploadRestoreHandlerDeps) {
   return async (event: H3Event) => {
+    deps.requireOwner(event);
     const formData = await deps.readFormData(event);
     const fileField = formData?.find((f) => f.name === "file");
 
@@ -54,10 +56,13 @@ export default defineEventHandler(async (event) => {
     psqlBin,
   };
 
+  const { requireOwnerFromEvent } = await import("../../../middleware/auth");
+
   const handler = createUploadRestoreHandler({
     readFormData: readMultipartFormData as unknown as UploadRestoreHandlerDeps["readFormData"],
     restoreBackup: (buf) => restoreBackupImpl(restoreDeps, buf),
     maxFileSize: MAX_FILE_SIZE,
+    requireOwner: (e) => { requireOwnerFromEvent(e); },
   });
 
   return handler(event);

--- a/apps/web/server/routes/api/upload-author-photo/[contributorId].test.ts
+++ b/apps/web/server/routes/api/upload-author-photo/[contributorId].test.ts
@@ -14,6 +14,7 @@ function createMockDeps(overrides: Partial<AuthorPhotoUploadDeps> = {}): AuthorP
       findContributor: vi.fn().mockResolvedValue({ id: "c1" }),
       updateContributor: vi.fn().mockResolvedValue(undefined),
     },
+    requireOwner: vi.fn(),
     ...overrides,
   };
 }
@@ -120,5 +121,18 @@ describe("author photo upload handler", () => {
     const handler = createAuthorPhotoUploadHandler(deps);
     const result = await handler(createMockEvent("c1") as never);
     expect(result).toEqual({ success: true });
+  });
+
+  it("calls requireOwner before doing any upload work", async () => {
+    const requireOwner = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error("Forbidden"), { statusCode: 403 });
+    });
+    deps = createMockDeps({ requireOwner });
+    const handler = createAuthorPhotoUploadHandler(deps);
+    await expect(handler(createMockEvent("c1") as never)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+    expect(deps.resizeAndSave).not.toHaveBeenCalled();
+    expect(deps.db.updateContributor).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/routes/api/upload-author-photo/[contributorId].ts
+++ b/apps/web/server/routes/api/upload-author-photo/[contributorId].ts
@@ -14,10 +14,12 @@ export interface AuthorPhotoUploadDeps {
     findContributor: (id: string) => Promise<{ id: string } | null>;
     updateContributor: (id: string, data: { imagePath: string }) => Promise<void>;
   };
+  requireOwner: (event: H3Event) => void;
 }
 
 export function createAuthorPhotoUploadHandler(deps: AuthorPhotoUploadDeps) {
   return async (event: H3Event) => {
+    deps.requireOwner(event);
     const params = event.context.params as { contributorId: string };
     const { contributorId } = params;
 
@@ -65,6 +67,8 @@ export default defineEventHandler(async (event) => {
   const { resizeCoverImage } = await import("@bookhouse/ingest");
   const sharpModule = await import("sharp");
 
+  const { requireOwnerFromEvent } = await import("../../../middleware/auth");
+
   const handler = createAuthorPhotoUploadHandler({
     coverCacheDir: COVER_CACHE_DIR,
     readFormData: readMultipartFormData,
@@ -79,6 +83,7 @@ export default defineEventHandler(async (event) => {
       findContributor: (id) => db.contributor.findUnique({ where: { id }, select: { id: true } }),
       updateContributor: async (id, data) => { await db.contributor.update({ where: { id }, data }); },
     },
+    requireOwner: (e) => { requireOwnerFromEvent(e); },
   });
   return handler(event);
 });

--- a/apps/web/server/routes/api/upload-cover/[workId].test.ts
+++ b/apps/web/server/routes/api/upload-cover/[workId].test.ts
@@ -17,6 +17,7 @@ function createMockDeps(overrides: Partial<UploadHandlerDeps> = {}): UploadHandl
       findWork: vi.fn().mockResolvedValue({ editedFields: [] }),
       updateWork: vi.fn().mockResolvedValue(undefined),
     },
+    requireOwner: vi.fn(),
     ...overrides,
   };
 }
@@ -199,5 +200,18 @@ describe("cover upload handler", () => {
       statusCode: 404,
       statusMessage: "Work not found",
     });
+  });
+
+  it("calls requireOwner before doing any upload work", async () => {
+    const requireOwner = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error("Forbidden"), { statusCode: 403 });
+    });
+    deps = createMockDeps({ requireOwner });
+    const handler = createUploadHandler(deps);
+    await expect(handler(createMockEvent("work-1") as never)).rejects.toMatchObject({
+      statusCode: 403,
+    });
+    expect(deps.resizeAndSave).not.toHaveBeenCalled();
+    expect(deps.db.updateWork).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/server/routes/api/upload-cover/[workId].ts
+++ b/apps/web/server/routes/api/upload-cover/[workId].ts
@@ -15,10 +15,12 @@ export interface UploadHandlerDeps {
     findWork: (id: string) => Promise<{ editedFields: string[] } | null>;
     updateWork: (id: string, data: { coverPath: string; editedFields: string[]; coverColors?: string[] }) => Promise<void>;
   };
+  requireOwner: (event: H3Event) => void;
 }
 
 export function createUploadHandler(deps: UploadHandlerDeps) {
   return async (event: H3Event) => {
+    deps.requireOwner(event);
     const params = event.context.params as { workId: string };
     const { workId } = params;
 
@@ -75,6 +77,8 @@ export default defineEventHandler(async (event) => {
   const { resizeCoverImage, extractDominantColors } = await import("@bookhouse/ingest");
   const sharpModule = await import("sharp");
 
+  const { requireOwnerFromEvent } = await import("../../../middleware/auth");
+
   const handler = createUploadHandler({
     coverCacheDir: COVER_CACHE_DIR,
     readFormData: readMultipartFormData,
@@ -90,6 +94,7 @@ export default defineEventHandler(async (event) => {
       findWork: (id) => db.work.findUnique({ where: { id }, select: { editedFields: true } }),
       updateWork: async (id, data) => { await db.work.update({ where: { id }, data }); },
     },
+    requireOwner: (e) => { requireOwnerFromEvent(e); },
   });
   return handler(event);
 });

--- a/apps/web/src/components/app-sidebar.test.tsx
+++ b/apps/web/src/components/app-sidebar.test.tsx
@@ -22,18 +22,32 @@ vi.mock("~/hooks/use-app-color", () => ({
   useAppColor: () => ({ brandPalette: mockBrandPalette }),
 }));
 
-const mockUser = { name: "John Doe", email: "john@example.com", image: null };
+const mockUser = {
+  name: "John Doe",
+  email: "john@example.com",
+  image: null,
+  roles: ["OWNER"],
+};
 
-function renderSidebar(user: { name: string | null; email: string | null; image: string | null } = mockUser) {
+function renderSidebar(
+  user: {
+    name: string | null;
+    email: string | null;
+    image: string | null;
+    roles?: string[];
+  } = mockUser,
+) {
   return render(
     <SidebarProvider>
-      <AppSidebar user={user as Parameters<typeof AppSidebar>[0]["user"]} />
+      <AppSidebar
+        user={{ ...user, roles: user.roles ?? ["OWNER"] } as Parameters<typeof AppSidebar>[0]["user"]}
+      />
     </SidebarProvider>
   );
 }
 
 describe("AppSidebar", () => {
-  it("renders navigation items", () => {
+  it("renders all navigation items for owners", () => {
     renderSidebar();
     expect(screen.getByText("Library")).toBeTruthy();
     expect(screen.getByText("Series")).toBeTruthy();
@@ -43,6 +57,24 @@ describe("AppSidebar", () => {
     expect(screen.getByText("Match Suggestions")).toBeTruthy();
     expect(screen.getByText("Library Health")).toBeTruthy();
     expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("hides owner-only nav items for viewers", () => {
+    renderSidebar({
+      name: "Viewer",
+      email: "v@example.com",
+      image: null,
+      roles: ["VIEWER"],
+    });
+    expect(screen.getByText("Library")).toBeTruthy();
+    expect(screen.getByText("Series")).toBeTruthy();
+    expect(screen.getByText("Authors")).toBeTruthy();
+    expect(screen.getByText("Shelves")).toBeTruthy();
+    // Settings remains visible — viewers need it to manage their own devices.
+    expect(screen.getByText("Settings")).toBeTruthy();
+    expect(screen.queryByText("Duplicates")).toBeNull();
+    expect(screen.queryByText("Match Suggestions")).toBeNull();
+    expect(screen.queryByText("Library Health")).toBeNull();
   });
 
   it("shows user name and email", () => {

--- a/apps/web/src/components/app-sidebar.tsx
+++ b/apps/web/src/components/app-sidebar.tsx
@@ -34,14 +34,14 @@ import {
 import { Avatar, AvatarFallback, AvatarImage } from "~/components/ui/avatar";
 
 const navItems = [
-  { title: "Library", href: "/library", icon: BookOpen },
-  { title: "Series", href: "/series", icon: BookCopy },
-  { title: "Authors", href: "/authors", icon: Users },
-  { title: "Shelves", href: "/shelves", icon: FolderOpen },
-  { title: "Duplicates", href: "/duplicates", icon: Copy },
-  { title: "Match Suggestions", href: "/match-suggestions", icon: Headphones },
-  { title: "Library Health", href: "/health", icon: Activity },
-  { title: "Settings", href: "/settings", icon: Settings },
+  { title: "Library", href: "/library", icon: BookOpen, ownerOnly: false },
+  { title: "Series", href: "/series", icon: BookCopy, ownerOnly: false },
+  { title: "Authors", href: "/authors", icon: Users, ownerOnly: false },
+  { title: "Shelves", href: "/shelves", icon: FolderOpen, ownerOnly: false },
+  { title: "Duplicates", href: "/duplicates", icon: Copy, ownerOnly: true },
+  { title: "Match Suggestions", href: "/match-suggestions", icon: Headphones, ownerOnly: true },
+  { title: "Library Health", href: "/health", icon: Activity, ownerOnly: true },
+  { title: "Settings", href: "/settings", icon: Settings, ownerOnly: false },
 ] as const;
 
 function getInitials(name: string | null, email: string | null): string {
@@ -63,6 +63,8 @@ export function AppSidebar({ user }: { user: AuthenticatedUser }) {
   const routerState = useRouterState();
   const currentPath = routerState.location.pathname;
   const { brandPalette } = useAppColor();
+  const isOwner = user.roles.includes("OWNER");
+  const visibleNavItems = navItems.filter((item) => !item.ownerOnly || isOwner);
 
   return (
     <Sidebar>
@@ -87,7 +89,7 @@ export function AppSidebar({ user }: { user: AuthenticatedUser }) {
           <SidebarGroupLabel>Navigation</SidebarGroupLabel>
           <SidebarGroupContent>
             <SidebarMenu>
-              {navItems.map((item) => (
+              {visibleNavItems.map((item) => (
                 <SidebarMenuItem key={item.href}>
                   <SidebarMenuButton
                     asChild

--- a/apps/web/src/lib/auth-server.test.ts
+++ b/apps/web/src/lib/auth-server.test.ts
@@ -12,7 +12,18 @@ const getRequestMock = vi.fn();
 const getRequestUrlMock = vi.fn();
 const useSessionMock = vi.fn();
 
+class MockAuthAccessDeniedError extends Error {
+  constructor(message = "denied") {
+    super(message);
+    this.name = "AuthAccessDeniedError";
+  }
+}
+
 vi.mock("@bookhouse/auth", () => ({
+  AuthAccessDeniedError: MockAuthAccessDeniedError,
+  OWNER_ROLE: "OWNER",
+  VIEWER_ROLE: "VIEWER",
+  isOwner: (roles: string[]) => roles.includes("OWNER"),
   createAuthenticatedSession: createAuthenticatedSessionMock,
   createAuthorizationRequest: createAuthorizationRequestMock,
   clearSession: clearSessionMock,
@@ -252,5 +263,111 @@ describe("auth server helpers", () => {
     await expect(getCurrentUser()).resolves.toEqual({
       id: "user-1",
     });
+  });
+
+  it("redirects to /auth/denied when upsertOidcUser throws AuthAccessDeniedError", async () => {
+    const update = vi.fn();
+    useSessionMock.mockResolvedValue({
+      data: {
+        login: {
+          state: "state",
+          nonce: "nonce",
+          codeVerifier: "verifier",
+          returnTo: "/books",
+        },
+      },
+      update,
+    });
+    getRequestMock.mockReturnValue({
+      url: "http://localhost:3000/auth/callback?code=abc&state=state",
+    });
+    exchangeAuthorizationCodeMock.mockResolvedValue({
+      claims: { sub: "subject-x", email: "noone@example.com" },
+    });
+    clearSessionMock.mockReturnValue({ cleared: true });
+    upsertOidcUserMock.mockRejectedValue(new MockAuthAccessDeniedError("nope"));
+
+    const { handleCallbackRequest } = await import("./auth-server");
+    const response = await handleCallbackRequest();
+
+    expect(response.headers.get("location")).toBe(
+      "http://localhost:3000/auth/denied",
+    );
+    expect(update).toHaveBeenCalledWith({ cleared: true });
+    expect(createAuthenticatedSessionMock).not.toHaveBeenCalled();
+  });
+
+  it("propagates non-AuthAccessDeniedError failures from upsertOidcUser", async () => {
+    useSessionMock.mockResolvedValue({
+      data: {
+        login: {
+          state: "state",
+          nonce: "nonce",
+          codeVerifier: "verifier",
+          returnTo: "/",
+        },
+      },
+      update: vi.fn(),
+    });
+    getRequestMock.mockReturnValue({
+      url: "http://localhost:3000/auth/callback?code=abc&state=state",
+    });
+    exchangeAuthorizationCodeMock.mockResolvedValue({
+      claims: { sub: "subject-x" },
+    });
+    upsertOidcUserMock.mockRejectedValue(new Error("db down"));
+
+    const { handleCallbackRequest } = await import("./auth-server");
+    await expect(handleCallbackRequest()).rejects.toThrow("db down");
+  });
+
+  it("requireAuthenticated returns the current user or throws", async () => {
+    useSessionMock.mockResolvedValue({
+      data: {
+        userId: "user-1",
+        issuer: "https://issuer.example.com",
+        subject: "subject-1",
+      },
+    });
+    resolveAuthenticatedUserMock.mockResolvedValueOnce({
+      id: "user-1",
+      roles: ["VIEWER"],
+    });
+    const { requireAuthenticated, UnauthorizedError } = await import(
+      "./auth-server"
+    );
+    await expect(requireAuthenticated()).resolves.toMatchObject({
+      id: "user-1",
+    });
+
+    resolveAuthenticatedUserMock.mockResolvedValueOnce(null);
+    await expect(requireAuthenticated()).rejects.toBeInstanceOf(
+      UnauthorizedError,
+    );
+  });
+
+  it("requireOwner returns the owner user or throws ForbiddenError for non-owners", async () => {
+    useSessionMock.mockResolvedValue({
+      data: {
+        userId: "user-1",
+        issuer: "https://issuer.example.com",
+        subject: "subject-1",
+      },
+    });
+    resolveAuthenticatedUserMock.mockResolvedValueOnce({
+      id: "user-1",
+      roles: ["OWNER"],
+    });
+    const { requireOwner, ForbiddenError } = await import("./auth-server");
+    await expect(requireOwner()).resolves.toMatchObject({
+      id: "user-1",
+      roles: ["OWNER"],
+    });
+
+    resolveAuthenticatedUserMock.mockResolvedValueOnce({
+      id: "user-2",
+      roles: ["VIEWER"],
+    });
+    await expect(requireOwner()).rejects.toBeInstanceOf(ForbiddenError);
   });
 });

--- a/apps/web/src/lib/auth-server.ts
+++ b/apps/web/src/lib/auth-server.ts
@@ -1,8 +1,11 @@
 import {
+  AuthAccessDeniedError,
+  OWNER_ROLE,
   createAuthenticatedSession,
   createAuthorizationRequest,
   clearSession,
   exchangeAuthorizationCode,
+  isOwner,
   loadAuthConfig,
   resolveAuthenticatedUser,
   upsertOidcUser,
@@ -64,6 +67,40 @@ export const getCurrentUserServerFn = createServerFn({ method: "GET" }).handler(
   async () => getCurrentUser(),
 );
 
+export class UnauthorizedError extends Error {
+  readonly statusCode = 401;
+  constructor(message = "Unauthorized") {
+    super(message);
+    this.name = "UnauthorizedError";
+  }
+}
+
+export class ForbiddenError extends Error {
+  readonly statusCode = 403;
+  constructor(message = "Forbidden") {
+    super(message);
+    this.name = "ForbiddenError";
+  }
+}
+
+export async function requireAuthenticated(): Promise<AuthenticatedUser> {
+  const user = await getCurrentUser();
+  if (!user) {
+    throw new UnauthorizedError();
+  }
+  return user;
+}
+
+export async function requireOwner(): Promise<AuthenticatedUser> {
+  const user = await requireAuthenticated();
+  if (!isOwner(user.roles)) {
+    throw new ForbiddenError("Owner role required");
+  }
+  return user;
+}
+
+export { OWNER_ROLE };
+
 function normalizeReturnTo(input: string | null | undefined): string {
   if (!input) {
     return "/";
@@ -109,11 +146,20 @@ export async function handleCallbackRequest(): Promise<Response> {
     expectedNonce: login.nonce,
   });
 
-  const user = await upsertOidcUser({
-    db,
-    config: authConfig,
-    claims,
-  });
+  let user: AuthenticatedUser;
+  try {
+    user = await upsertOidcUser({
+      db,
+      config: authConfig,
+      claims,
+    });
+  } catch (error) {
+    if (error instanceof AuthAccessDeniedError) {
+      await session.update(clearSession());
+      return redirectResponse(appUrl("/auth/denied"));
+    }
+    throw error;
+  }
 
   await session.update(
     createAuthenticatedSession({

--- a/apps/web/src/lib/server-fns/_guards.test.ts
+++ b/apps/web/src/lib/server-fns/_guards.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+const requireOwnerMock = vi.fn();
+const requireAuthenticatedMock = vi.fn();
+
+vi.mock("../auth-server", () => ({
+  requireOwner: requireOwnerMock,
+  requireAuthenticated: requireAuthenticatedMock,
+}));
+
+describe("server-fn guards", () => {
+  it("ownerOnly delegates to requireOwner and returns the user", async () => {
+    requireOwnerMock.mockResolvedValueOnce({ id: "owner-1", roles: ["OWNER"] });
+    const { ownerOnly } = await import("./_guards");
+    await expect(ownerOnly()).resolves.toMatchObject({ id: "owner-1" });
+    expect(requireOwnerMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("authenticatedOnly delegates to requireAuthenticated and returns the user", async () => {
+    requireAuthenticatedMock.mockResolvedValueOnce({
+      id: "viewer-1",
+      roles: ["VIEWER"],
+    });
+    const { authenticatedOnly } = await import("./_guards");
+    await expect(authenticatedOnly()).resolves.toMatchObject({
+      id: "viewer-1",
+    });
+  });
+});

--- a/apps/web/src/lib/server-fns/_guards.ts
+++ b/apps/web/src/lib/server-fns/_guards.ts
@@ -1,0 +1,9 @@
+export async function ownerOnly() {
+  const { requireOwner } = await import("../auth-server");
+  return requireOwner();
+}
+
+export async function authenticatedOnly() {
+  const { requireAuthenticated } = await import("../auth-server");
+  return requireAuthenticated();
+}

--- a/apps/web/src/lib/server-fns/app-settings.test.ts
+++ b/apps/web/src/lib/server-fns/app-settings.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/app-settings.ts
+++ b/apps/web/src/lib/server-fns/app-settings.ts
@@ -42,6 +42,7 @@ export const setScanConcurrencyServerFn = createServerFn({
     concurrency: z.number().int().min(1).max(20),
   }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const key = SCAN_CONCURRENCY_KEYS[data.scanType as ScanType];
 
@@ -70,6 +71,7 @@ export const setMissingFileBehaviorServerFn = createServerFn({
 })
   .inputValidator(z.object({ behavior: z.enum(["auto-cleanup", "manual"]) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     await db.appSetting.upsert({
@@ -97,6 +99,7 @@ export const setThemeServerFn = createServerFn({
 })
   .inputValidator(z.object({ theme: z.enum(["light", "dark", "system"]) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     await db.appSetting.upsert({
@@ -124,6 +127,7 @@ export const setColorModeServerFn = createServerFn({
 })
   .inputValidator(z.object({ mode: z.enum(["off", "book", "page", "accent"]) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     await db.appSetting.upsert({
@@ -149,6 +153,7 @@ export const setAccentColorServerFn = createServerFn({
 })
   .inputValidator(z.object({ color: z.string().regex(/^#[0-9a-fA-F]{6}$/).nullable() }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     if (data.color === null) {
@@ -189,6 +194,7 @@ export const setBrandPaletteServerFn = createServerFn({
 })
   .inputValidator(z.object({ palette: paletteSchema }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     await db.appSetting.upsert({

--- a/apps/web/src/lib/server-fns/authors.test.ts
+++ b/apps/web/src/lib/server-fns/authors.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/authors.ts
+++ b/apps/web/src/lib/server-fns/authors.ts
@@ -94,6 +94,7 @@ export const getEnrichAuthorPhotosProgressServerFn = createServerFn({
 export const enrichAuthorPhotosServerFn = createServerFn({
   method: "POST",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
   const { enqueueEnrichmentJob } = await import("@bookhouse/shared");
 
@@ -136,6 +137,7 @@ export const fetchAuthorPhotoFromUrlServerFn = createServerFn({
 })
   .inputValidator(fetchAuthorPhotoSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { applyAuthorPhotoFromUrl, resizeAndSaveCover } = await import("@bookhouse/ingest");
     const { db } = await import("@bookhouse/db");
 

--- a/apps/web/src/lib/server-fns/backup.test.ts
+++ b/apps/web/src/lib/server-fns/backup.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/backup.ts
+++ b/apps/web/src/lib/server-fns/backup.ts
@@ -7,6 +7,7 @@ const MAX_HISTORY = 20;
 export const getBackupHistoryServerFn = createServerFn({
   method: "GET",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
 
   const setting = await db.appSetting.findUnique({
@@ -28,6 +29,7 @@ export const recordBackupServerFn = createServerFn({
 })
   .inputValidator(backupManifestSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const setting = await db.appSetting.findUnique({

--- a/apps/web/src/lib/server-fns/bulk-enrich.test.ts
+++ b/apps/web/src/lib/server-fns/bulk-enrich.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/bulk-enrich.ts
+++ b/apps/web/src/lib/server-fns/bulk-enrich.ts
@@ -12,6 +12,7 @@ export const bulkEnrichServerFn = createServerFn({
 })
   .inputValidator(bulkEnrichSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { enqueueEnrichmentJob } = await import("@bookhouse/shared");
 

--- a/apps/web/src/lib/server-fns/deletion.test.ts
+++ b/apps/web/src/lib/server-fns/deletion.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/deletion.ts
+++ b/apps/web/src/lib/server-fns/deletion.ts
@@ -27,6 +27,7 @@ export const deleteWorkServerFn = createServerFn({
 })
   .inputValidator(z.object({ workId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const fileAssetIds = await collectFileAssetIds(db, { edition: { workId: data.workId } });
     await db.work.delete({ where: { id: data.workId } });
@@ -39,6 +40,7 @@ export const deleteEditionServerFn = createServerFn({
 })
   .inputValidator(z.object({ editionId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const edition = await db.edition.findUnique({ where: { id: data.editionId } });
@@ -64,6 +66,7 @@ export const bulkDeleteWorksServerFn = createServerFn({
 })
   .inputValidator(z.object({ workIds: z.array(z.string().min(1)).max(100) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     if (data.workIds.length === 0) {
       return { deletedWorkIds: [] as string[] };
     }
@@ -80,6 +83,7 @@ export const bulkDeleteEditionsServerFn = createServerFn({
 })
   .inputValidator(z.object({ editionIds: z.array(z.string().min(1)).max(100) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     if (data.editionIds.length === 0) {
       return { deletedEditionIds: [] as string[], deletedWorkIds: [] as string[] };
     }
@@ -119,6 +123,7 @@ export const bulkDeleteEditionsByFormatForWorksServerFn = createServerFn({
     format: z.enum(["EBOOK", "AUDIOBOOK"]),
   }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     if (data.workIds.length === 0) {
       return { deletedEditionIds: [] as string[], deletedWorkIds: [] as string[] };
     }
@@ -163,6 +168,7 @@ export const deleteAllEditionsByFormatServerFn = createServerFn({
     format: z.enum(["EBOOK", "AUDIOBOOK"]),
   }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const editions = await db.edition.findMany({
@@ -245,6 +251,7 @@ export const cleanupMissingFilesServerFn = createServerFn({
 })
   .inputValidator(z.object({ fileAssetIds: z.array(z.string().min(1)) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { cascadeCleanupOrphans } = await import("@bookhouse/ingest");
 

--- a/apps/web/src/lib/server-fns/duplicates.test.ts
+++ b/apps/web/src/lib/server-fns/duplicates.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/duplicates.ts
+++ b/apps/web/src/lib/server-fns/duplicates.ts
@@ -56,6 +56,7 @@ export const ignoreDuplicateServerFn = createServerFn({
 })
   .inputValidator(idSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     await db.duplicateCandidate.update({
       where: { id: data.id },
@@ -69,6 +70,7 @@ export const confirmDuplicateServerFn = createServerFn({
 })
   .inputValidator(idSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     await db.duplicateCandidate.update({
       where: { id: data.id },
@@ -87,6 +89,7 @@ export const mergeDuplicateServerFn = createServerFn({
 })
   .inputValidator(mergeSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const candidate = await db.duplicateCandidate.findUnique({

--- a/apps/web/src/lib/server-fns/editing.test.ts
+++ b/apps/web/src/lib/server-fns/editing.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/editing.ts
+++ b/apps/web/src/lib/server-fns/editing.ts
@@ -16,6 +16,7 @@ export const updateWorkServerFn = createServerFn({
 })
   .inputValidator(updateWorkSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { canonicalizeBookTitle } = await import("@bookhouse/ingest");
 
@@ -71,6 +72,7 @@ export const updateEditionServerFn = createServerFn({
 })
   .inputValidator(updateEditionSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const edition = await db.edition.findUnique({
@@ -118,6 +120,7 @@ export const updateWorkAuthorsServerFn = createServerFn({
 })
   .inputValidator(updateWorkAuthorsSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { canonicalizeContributorName, generateNameSort } = await import("@bookhouse/ingest");
 
@@ -205,6 +208,7 @@ export const updateEditionNarratorsServerFn = createServerFn({
 })
   .inputValidator(updateEditionNarratorsSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { canonicalizeContributorName, generateNameSort } = await import("@bookhouse/ingest");
 
@@ -272,6 +276,7 @@ export const updateContributorServerFn = createServerFn({
 })
   .inputValidator(updateContributorSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     await db.contributor.update({

--- a/apps/web/src/lib/server-fns/enrichment.test.ts
+++ b/apps/web/src/lib/server-fns/enrichment.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/enrichment.ts
+++ b/apps/web/src/lib/server-fns/enrichment.ts
@@ -45,6 +45,7 @@ export const searchEnrichmentServerFn = createServerFn({
 })
   .inputValidator(searchSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const {
       searchAllSources,
@@ -159,6 +160,7 @@ export const applyEnrichmentServerFn = createServerFn({
 })
   .inputValidator(applySchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     let appliedAnyFields = false;
@@ -387,6 +389,7 @@ export const applyCoverFromUrlServerFn = createServerFn({
 })
   .inputValidator(coverUrlSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { applyCoverFromUrl } = await import("@bookhouse/ingest");
     const { mkdir, writeFile } = await import("node:fs/promises");

--- a/apps/web/src/lib/server-fns/import-jobs.test.ts
+++ b/apps/web/src/lib/server-fns/import-jobs.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/import-jobs.ts
+++ b/apps/web/src/lib/server-fns/import-jobs.ts
@@ -228,6 +228,7 @@ export const getActiveJobCountServerFn = createServerFn({
 export const stopAllJobsServerFn = createServerFn({
   method: "POST",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
   const { obliterateLibraryQueue } = await import("@bookhouse/shared");
 

--- a/apps/web/src/lib/server-fns/integrations.test.ts
+++ b/apps/web/src/lib/server-fns/integrations.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/integrations.ts
+++ b/apps/web/src/lib/server-fns/integrations.ts
@@ -71,6 +71,7 @@ export const setApiKeyServerFn = createServerFn({
 })
   .inputValidator(setApiKeySchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const secret = await getSecret();
 
@@ -95,6 +96,7 @@ export const removeApiKeyServerFn = createServerFn({
 })
   .inputValidator(removeApiKeySchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const key = `apiKey:${data.provider}`;
 
@@ -121,6 +123,7 @@ export const validateApiKeyServerFn = createServerFn({
 })
   .inputValidator(validateApiKeySchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { searchGoogleBooks, searchHardcover } = await import("@bookhouse/ingest");
 
     try {

--- a/apps/web/src/lib/server-fns/kindle.test.ts
+++ b/apps/web/src/lib/server-fns/kindle.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/kindle.ts
+++ b/apps/web/src/lib/server-fns/kindle.ts
@@ -15,6 +15,7 @@ export const getKindleStatusServerFn = createServerFn({
 export const getKindleConfigServerFn = createServerFn({
   method: "GET",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
   const setting = await db.appSetting.findUnique({ where: { key: "kindle:email" } });
   if (!setting) return { configured: false as const };
@@ -34,6 +35,7 @@ export const saveKindleConfigServerFn = createServerFn({
 })
   .inputValidator(saveKindleConfigSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     await db.appSetting.upsert({
@@ -48,6 +50,7 @@ export const saveKindleConfigServerFn = createServerFn({
 export const removeKindleConfigServerFn = createServerFn({
   method: "POST",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
   await db.appSetting.deleteMany({
     where: { key: { in: ["kindle:email"] } },
@@ -64,6 +67,7 @@ export const sendToKindleServerFn = createServerFn({
 })
   .inputValidator(sendToKindleSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const editionFile = await db.editionFile.findUnique({

--- a/apps/web/src/lib/server-fns/kobo-devices.test.ts
+++ b/apps/web/src/lib/server-fns/kobo-devices.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue({ id: "u1", roles: ["OWNER"] }),
+  authenticatedOnly: vi.fn().mockResolvedValue({ id: "u1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {
@@ -15,18 +20,20 @@ vi.mock("@tanstack/react-start", () => ({
 }));
 
 const mockFindMany = vi.fn();
+const mockFindUnique = vi.fn();
 const mockCreate = vi.fn();
 const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
 const mockDeviceCollectionDeleteMany = vi.fn();
 const mockDeviceCollectionCreateMany = vi.fn();
 const mockDeviceCollectionFindMany = vi.fn();
-const mockGetCurrentUser = vi.fn();
+const mockCollectionFindMany = vi.fn();
 
 vi.mock("@bookhouse/db", () => ({
   db: {
     koboDevice: {
       findMany: mockFindMany,
+      findUnique: mockFindUnique,
       create: mockCreate,
       update: mockUpdate,
       delete: mockDelete,
@@ -36,11 +43,10 @@ vi.mock("@bookhouse/db", () => ({
       createMany: mockDeviceCollectionCreateMany,
       findMany: mockDeviceCollectionFindMany,
     },
+    collection: {
+      findMany: mockCollectionFindMany,
+    },
   },
-}));
-
-vi.mock("~/lib/auth-server", () => ({
-  getCurrentUser: mockGetCurrentUser,
 }));
 
 const mockGenerateAuthToken = vi.fn().mockReturnValue("a".repeat(64));
@@ -62,11 +68,10 @@ import {
 describe("kobo-devices server functions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetCurrentUser.mockResolvedValue({ id: "u1" });
   });
 
   describe("getKoboDevicesServerFn", () => {
-    it("returns all devices with collections", async () => {
+    it("returns only devices owned by the current user", async () => {
       const devices = [
         { id: "d1", deviceId: "Kobo Clara", status: "ACTIVE", collections: [] },
       ];
@@ -76,6 +81,7 @@ describe("kobo-devices server functions", () => {
 
       expect(result).toEqual(devices);
       expect(mockFindMany).toHaveBeenCalledWith({
+        where: { userId: "u1" },
         include: {
           collections: {
             include: { collection: { select: { id: true, name: true } } },
@@ -113,20 +119,11 @@ describe("kobo-devices server functions", () => {
       expect(mockGenerateAuthToken).toHaveBeenCalled();
       expect(mockGenerateUserKey).toHaveBeenCalledWith("u1", "My Kobo");
     });
-
-    it("throws when user is not authenticated", async () => {
-      mockGetCurrentUser.mockResolvedValue(null);
-
-      await expect(
-        addKoboDeviceServerFn({ data: { deviceName: "My Kobo" } }),
-      ).rejects.toThrow("Not authenticated");
-
-      expect(mockCreate).not.toHaveBeenCalled();
-    });
   });
 
   describe("revokeKoboDeviceServerFn", () => {
-    it("sets device status to REVOKED", async () => {
+    it("sets device status to REVOKED when current user owns it", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "u1" });
       mockUpdate.mockResolvedValue({ id: "d1", status: "REVOKED" });
 
       const result = await revokeKoboDeviceServerFn({
@@ -139,10 +136,28 @@ describe("kobo-devices server functions", () => {
         data: { status: "REVOKED" },
       });
     });
+
+    it("rejects when another user tries to revoke", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "other-user" });
+
+      await expect(
+        revokeKoboDeviceServerFn({ data: { deviceId: "d1" } }),
+      ).rejects.toThrow("Device not found");
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("rejects when the device does not exist", async () => {
+      mockFindUnique.mockResolvedValue(null);
+
+      await expect(
+        revokeKoboDeviceServerFn({ data: { deviceId: "missing" } }),
+      ).rejects.toThrow("Device not found");
+    });
   });
 
   describe("removeKoboDeviceServerFn", () => {
-    it("deletes the device", async () => {
+    it("deletes the device when current user owns it", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "u1" });
       mockDelete.mockResolvedValue({ id: "d1" });
 
       const result = await removeKoboDeviceServerFn({
@@ -152,10 +167,20 @@ describe("kobo-devices server functions", () => {
       expect(result).toEqual({ id: "d1" });
       expect(mockDelete).toHaveBeenCalledWith({ where: { id: "d1" } });
     });
+
+    it("rejects when current user does not own the device", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "other" });
+      await expect(
+        removeKoboDeviceServerFn({ data: { deviceId: "d1" } }),
+      ).rejects.toThrow("Device not found");
+      expect(mockDelete).not.toHaveBeenCalled();
+    });
   });
 
   describe("updateDeviceCollectionsServerFn", () => {
-    it("replaces device collections", async () => {
+    it("replaces device collections when user owns the device and shelves", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "u1" });
+      mockCollectionFindMany.mockResolvedValue([{ id: "c1" }]);
       const collections = [
         { id: "dc1", koboDeviceId: "d1", collectionId: "c1", collection: { id: "c1", name: "Fiction" } },
       ];
@@ -166,6 +191,10 @@ describe("kobo-devices server functions", () => {
       });
 
       expect(result).toEqual(collections);
+      expect(mockCollectionFindMany).toHaveBeenCalledWith({
+        where: { id: { in: ["c1"] }, ownerUserId: "u1" },
+        select: { id: true },
+      });
       expect(mockDeviceCollectionDeleteMany).toHaveBeenCalledWith({
         where: { koboDeviceId: "d1" },
       });
@@ -175,16 +204,40 @@ describe("kobo-devices server functions", () => {
     });
 
     it("only deletes when collectionIds is empty", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "u1" });
       mockDeviceCollectionFindMany.mockResolvedValue([]);
 
       await updateDeviceCollectionsServerFn({
         data: { deviceId: "d1", collectionIds: [] },
       });
 
+      expect(mockCollectionFindMany).not.toHaveBeenCalled();
       expect(mockDeviceCollectionDeleteMany).toHaveBeenCalledWith({
         where: { koboDeviceId: "d1" },
       });
       expect(mockDeviceCollectionCreateMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects when current user does not own the device", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "other" });
+      await expect(
+        updateDeviceCollectionsServerFn({
+          data: { deviceId: "d1", collectionIds: [] },
+        }),
+      ).rejects.toThrow("Device not found");
+      expect(mockDeviceCollectionDeleteMany).not.toHaveBeenCalled();
+    });
+
+    it("rejects when one or more shelves are not owned by current user", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "u1" });
+      mockCollectionFindMany.mockResolvedValue([{ id: "c1" }]); // requested 2, found 1
+
+      await expect(
+        updateDeviceCollectionsServerFn({
+          data: { deviceId: "d1", collectionIds: ["c1", "c2"] },
+        }),
+      ).rejects.toThrow("One or more shelves not found");
+      expect(mockDeviceCollectionDeleteMany).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/lib/server-fns/kobo-devices.ts
+++ b/apps/web/src/lib/server-fns/kobo-devices.ts
@@ -4,8 +4,10 @@ import { z } from "zod";
 export const getKoboDevicesServerFn = createServerFn({
   method: "GET",
 }).handler(async () => {
+  const user = await (await import("./_guards")).authenticatedOnly();
   const { db } = await import("@bookhouse/db");
   return db.koboDevice.findMany({
+    where: { userId: user.id },
     include: {
       collections: {
         include: { collection: { select: { id: true, name: true } } },
@@ -28,12 +30,9 @@ export const addKoboDeviceServerFn = createServerFn({
 })
   .inputValidator(addDeviceSchema)
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
     const { generateAuthToken, generateUserKey } = await import("@bookhouse/kobo");
-    const { getCurrentUser } = await import("~/lib/auth-server");
-
-    const user = await getCurrentUser();
-    if (!user) throw new Error("Not authenticated");
 
     const authToken = generateAuthToken();
     const userKey = generateUserKey(user.id, data.deviceName);
@@ -52,12 +51,28 @@ const revokeDeviceSchema = z.object({
   deviceId: z.string().min(1),
 });
 
+async function requireOwnedKoboDevice(
+  db: { koboDevice: { findUnique: (args: { where: { id: string }; select: { userId: true } }) => Promise<{ userId: string } | null> } },
+  deviceId: string,
+  userId: string,
+): Promise<void> {
+  const device = await db.koboDevice.findUnique({
+    where: { id: deviceId },
+    select: { userId: true },
+  });
+  if (!device || device.userId !== userId) {
+    throw new Error("Device not found");
+  }
+}
+
 export const revokeKoboDeviceServerFn = createServerFn({
   method: "POST",
 })
   .inputValidator(revokeDeviceSchema)
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+    await requireOwnedKoboDevice(db, data.deviceId, user.id);
     return db.koboDevice.update({
       where: { id: data.deviceId },
       data: { status: "REVOKED" },
@@ -73,7 +88,9 @@ export const removeKoboDeviceServerFn = createServerFn({
 })
   .inputValidator(removeDeviceSchema)
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+    await requireOwnedKoboDevice(db, data.deviceId, user.id);
     return db.koboDevice.delete({
       where: { id: data.deviceId },
     });
@@ -89,7 +106,20 @@ export const updateDeviceCollectionsServerFn = createServerFn({
 })
   .inputValidator(updateDeviceCollectionsSchema)
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+    await requireOwnedKoboDevice(db, data.deviceId, user.id);
+
+    // Verify all referenced collections are owned by the user.
+    if (data.collectionIds.length > 0) {
+      const owned = await db.collection.findMany({
+        where: { id: { in: data.collectionIds }, ownerUserId: user.id },
+        select: { id: true },
+      });
+      if (owned.length !== data.collectionIds.length) {
+        throw new Error("One or more shelves not found");
+      }
+    }
 
     await db.koboDeviceCollection.deleteMany({
       where: { koboDeviceId: data.deviceId },
@@ -109,4 +139,3 @@ export const updateDeviceCollectionsServerFn = createServerFn({
       include: { collection: { select: { id: true, name: true } } },
     });
   });
-

--- a/apps/web/src/lib/server-fns/library-health.test.ts
+++ b/apps/web/src/lib/server-fns/library-health.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 const cleanupOrphanedFileAssetsMock = vi.fn();
 
 vi.mock("@bookhouse/ingest", () => ({

--- a/apps/web/src/lib/server-fns/library-health.ts
+++ b/apps/web/src/lib/server-fns/library-health.ts
@@ -106,6 +106,7 @@ export const deleteOrphanedFileServerFn = createServerFn({
 })
   .inputValidator(z.object({ fileAssetId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const fileAsset = await db.fileAsset.findUnique({
       where: { id: data.fileAssetId },
@@ -137,6 +138,7 @@ export type EmptyWork = Awaited<
 export const deleteEmptyWorksServerFn = createServerFn({
   method: "POST",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
   const { cleanupOrphanedFileAssets } = await import("@bookhouse/ingest");
   const emptyWorks = await db.work.findMany({

--- a/apps/web/src/lib/server-fns/library-roots.test.ts
+++ b/apps/web/src/lib/server-fns/library-roots.test.ts
@@ -2,6 +2,13 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import type * as SharedModule from "@bookhouse/shared";
 import type { ZodType } from "zod";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type ServerFnInput = Record<string, string | number | boolean | null | string[] | Date | undefined | object>;

--- a/apps/web/src/lib/server-fns/library-roots.ts
+++ b/apps/web/src/lib/server-fns/library-roots.ts
@@ -68,6 +68,7 @@ export const addLibraryRootServerFn = createServerFn({
 })
   .inputValidator(addLibraryRootSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     return db.libraryRoot.create({
       data: {
@@ -88,6 +89,7 @@ export const removeLibraryRootServerFn = createServerFn({
 })
   .inputValidator(removeLibraryRootSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { cascadeCleanupOrphans } = await import("@bookhouse/ingest");
 
@@ -297,6 +299,7 @@ export const scanLibraryRootServerFn = createServerFn({
 })
   .inputValidator(scanLibraryRootSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { enqueueLibraryJob, LIBRARY_JOB_NAMES } = await import(
       "@bookhouse/shared"
@@ -334,6 +337,7 @@ export const retryLibraryIssuesServerFn = createServerFn({
 })
   .inputValidator(libraryRootIdSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { createIngestServices } = await import("@bookhouse/ingest");
     const { enqueueLibraryJob } = await import("@bookhouse/shared");

--- a/apps/web/src/lib/server-fns/match-suggestions.test.ts
+++ b/apps/web/src/lib/server-fns/match-suggestions.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/match-suggestions.ts
+++ b/apps/web/src/lib/server-fns/match-suggestions.ts
@@ -65,6 +65,7 @@ export const acceptMatchSuggestionServerFn = createServerFn({
 })
   .inputValidator(acceptSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const link = await db.matchSuggestion.findUniqueOrThrow({
@@ -126,6 +127,7 @@ export const declineMatchSuggestionServerFn = createServerFn({
 })
   .inputValidator(idSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     await db.matchSuggestion.update({
       where: { id: data.id },
@@ -137,6 +139,7 @@ export const declineMatchSuggestionServerFn = createServerFn({
 export const rematchAllServerFn = createServerFn({
   method: "POST",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
   const { enqueueLibraryJob, LIBRARY_JOB_NAMES } = await import(
     "@bookhouse/shared"

--- a/apps/web/src/lib/server-fns/opds-credentials.test.ts
+++ b/apps/web/src/lib/server-fns/opds-credentials.test.ts
@@ -15,16 +15,19 @@ vi.mock("@tanstack/react-start", () => ({
 }));
 
 const mockFindMany = vi.fn();
+const mockFindUnique = vi.fn();
 const mockCreate = vi.fn();
 const mockUpdate = vi.fn();
 const mockDelete = vi.fn();
 const mockGetCurrentUser = vi.fn();
+const mockAuthenticatedOnly = vi.fn();
 const mockHashPassword = vi.fn().mockResolvedValue("salt:hash");
 
 vi.mock("@bookhouse/db", () => ({
   db: {
     opdsCredential: {
       findMany: mockFindMany,
+      findUnique: mockFindUnique,
       create: mockCreate,
       update: mockUpdate,
       delete: mockDelete,
@@ -34,6 +37,11 @@ vi.mock("@bookhouse/db", () => ({
 
 vi.mock("~/lib/auth-server", () => ({
   getCurrentUser: mockGetCurrentUser,
+}));
+
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue({ id: "u1", roles: ["OWNER"] }),
+  authenticatedOnly: mockAuthenticatedOnly,
 }));
 
 vi.mock("@bookhouse/opds", () => ({
@@ -51,6 +59,7 @@ describe("opds-credentials server functions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetCurrentUser.mockResolvedValue({ id: "u1" });
+    mockAuthenticatedOnly.mockResolvedValue({ id: "u1", roles: ["VIEWER"] });
   });
 
   describe("getOpdsCredentialsServerFn", () => {
@@ -129,7 +138,8 @@ describe("opds-credentials server functions", () => {
   });
 
   describe("toggleOpdsCredentialServerFn", () => {
-    it("updates the isEnabled flag", async () => {
+    it("updates the isEnabled flag when current user owns the credential", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "u1" });
       mockUpdate.mockResolvedValue({
         id: "c1",
         username: "reader",
@@ -153,10 +163,30 @@ describe("opds-credentials server functions", () => {
         },
       });
     });
+
+    it("rejects when current user does not own the credential", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "other" });
+      await expect(
+        toggleOpdsCredentialServerFn({
+          data: { credentialId: "c1", isEnabled: false },
+        }),
+      ).rejects.toThrow("Credential not found");
+      expect(mockUpdate).not.toHaveBeenCalled();
+    });
+
+    it("rejects when the credential does not exist", async () => {
+      mockFindUnique.mockResolvedValue(null);
+      await expect(
+        toggleOpdsCredentialServerFn({
+          data: { credentialId: "c1", isEnabled: false },
+        }),
+      ).rejects.toThrow("Credential not found");
+    });
   });
 
   describe("deleteOpdsCredentialServerFn", () => {
-    it("deletes the credential", async () => {
+    it("deletes the credential when current user owns it", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "u1" });
       mockDelete.mockResolvedValue({ id: "c1" });
 
       const result = await deleteOpdsCredentialServerFn({
@@ -167,6 +197,14 @@ describe("opds-credentials server functions", () => {
       expect(mockDelete).toHaveBeenCalledWith({
         where: { id: "c1" },
       });
+    });
+
+    it("rejects when current user does not own the credential", async () => {
+      mockFindUnique.mockResolvedValue({ userId: "other" });
+      await expect(
+        deleteOpdsCredentialServerFn({ data: { credentialId: "c1" } }),
+      ).rejects.toThrow("Credential not found");
+      expect(mockDelete).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/lib/server-fns/opds-credentials.ts
+++ b/apps/web/src/lib/server-fns/opds-credentials.ts
@@ -70,7 +70,16 @@ export const toggleOpdsCredentialServerFn = createServerFn({
 })
   .inputValidator(toggleCredentialSchema)
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+
+    const existing = await db.opdsCredential.findUnique({
+      where: { id: data.credentialId },
+      select: { userId: true },
+    });
+    if (!existing || existing.userId !== user.id) {
+      throw new Error("Credential not found");
+    }
 
     return db.opdsCredential.update({
       where: { id: data.credentialId },
@@ -93,7 +102,16 @@ export const deleteOpdsCredentialServerFn = createServerFn({
 })
   .inputValidator(deleteCredentialSchema)
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+
+    const existing = await db.opdsCredential.findUnique({
+      where: { id: data.credentialId },
+      select: { userId: true },
+    });
+    if (!existing || existing.userId !== user.id) {
+      throw new Error("Credential not found");
+    }
 
     return db.opdsCredential.delete({
       where: { id: data.credentialId },

--- a/apps/web/src/lib/server-fns/shelves.test.ts
+++ b/apps/web/src/lib/server-fns/shelves.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "user-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {
@@ -15,7 +22,8 @@ vi.mock("@tanstack/react-start", () => ({
 }));
 
 const collectionFindManyMock = vi.fn();
-const collectionFindUniqueOrThrowMock = vi.fn();
+const collectionFindUniqueMock = vi.fn();
+const collectionFindFirstOrThrowMock = vi.fn();
 const collectionCreateMock = vi.fn();
 const collectionUpdateMock = vi.fn();
 const collectionDeleteMock = vi.fn();
@@ -30,7 +38,8 @@ vi.mock("@bookhouse/db", () => ({
   db: {
     collection: {
       findMany: collectionFindManyMock,
-      findUniqueOrThrow: collectionFindUniqueOrThrowMock,
+      findUnique: collectionFindUniqueMock,
+      findFirstOrThrow: collectionFindFirstOrThrowMock,
       create: collectionCreateMock,
       update: collectionUpdateMock,
       delete: collectionDeleteMock,
@@ -70,11 +79,12 @@ describe("shelves server functions", () => {
   });
 
   describe("getShelvesServerFn", () => {
-    it("returns all shelves with item counts", async () => {
+    it("returns only shelves owned by the current user", async () => {
       const shelves = [{ id: "1", name: "Fiction", _count: { items: 5 } }];
       collectionFindManyMock.mockResolvedValue(shelves);
       const result = await getShelvesServerFn();
       expect(collectionFindManyMock).toHaveBeenCalledWith({
+        where: { ownerUserId: "user-1" },
         include: { _count: { select: { items: true } } },
         orderBy: { name: "asc" },
       });
@@ -83,24 +93,26 @@ describe("shelves server functions", () => {
   });
 
   describe("getShelfDetailServerFn", () => {
-    it("returns shelf with edition-based items", async () => {
+    it("returns shelf scoped to current user", async () => {
       const detail = {
         id: "s1",
         name: "Fiction",
         formatFilter: "ALL",
         items: [{ edition: { id: "e1", work: { id: "w1", titleDisplay: "Book" } } }],
       };
-      collectionFindUniqueOrThrowMock.mockResolvedValue(detail);
+      collectionFindFirstOrThrowMock.mockResolvedValue(detail);
       const result = await getShelfDetailServerFn({ data: { shelfId: "s1" } } as never);
-      expect(collectionFindUniqueOrThrowMock).toHaveBeenCalledWith(
-        expect.objectContaining({ where: { id: "s1" } }),
+      expect(collectionFindFirstOrThrowMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: { id: "s1", ownerUserId: "user-1" },
+        }),
       );
       expect(result).toBe(detail);
     });
   });
 
   describe("getShelvesForEditionServerFn", () => {
-    it("returns collection IDs for an edition", async () => {
+    it("returns collection IDs for an edition scoped to current user", async () => {
       collectionItemFindManyMock.mockResolvedValue([
         { collectionId: "s1" },
         { collectionId: "s2" },
@@ -109,7 +121,10 @@ describe("shelves server functions", () => {
         data: { editionId: "e1" },
       } as never);
       expect(collectionItemFindManyMock).toHaveBeenCalledWith({
-        where: { editionId: "e1" },
+        where: {
+          editionId: "e1",
+          collection: { ownerUserId: "user-1" },
+        },
         select: { collectionId: true },
       });
       expect(result).toEqual(["s1", "s2"]);
@@ -125,7 +140,7 @@ describe("shelves server functions", () => {
   });
 
   describe("getShelvesForWorkServerFn", () => {
-    it("returns all shelves annotated with membership via editions", async () => {
+    it("returns user shelves annotated with membership via editions", async () => {
       editionFindManyMock.mockResolvedValue([{ id: "e1" }, { id: "e2" }]);
       collectionFindManyMock.mockResolvedValue([
         { id: "s1", name: "Fiction" },
@@ -142,6 +157,10 @@ describe("shelves server functions", () => {
       expect(editionFindManyMock).toHaveBeenCalledWith({
         where: { workId: "w1" },
         select: { id: true },
+      });
+      expect(collectionFindManyMock).toHaveBeenCalledWith({
+        where: { ownerUserId: "user-1" },
+        orderBy: { name: "asc" },
       });
       expect(result).toEqual([
         { id: "s1", name: "Fiction", isMember: true },
@@ -167,7 +186,7 @@ describe("shelves server functions", () => {
   });
 
   describe("createShelfServerFn", () => {
-    it("creates a shelf with MANUAL kind and ALL format filter", async () => {
+    it("creates a shelf with ownerUserId set to current user", async () => {
       const created = { id: "s1", name: "New Shelf", kind: "MANUAL", formatFilter: "ALL" };
       collectionCreateMock.mockResolvedValue(created);
 
@@ -176,7 +195,12 @@ describe("shelves server functions", () => {
       } as never);
 
       expect(collectionCreateMock).toHaveBeenCalledWith({
-        data: { name: "New Shelf", kind: "MANUAL", formatFilter: "ALL" },
+        data: {
+          name: "New Shelf",
+          kind: "MANUAL",
+          formatFilter: "ALL",
+          ownerUserId: "user-1",
+        },
       });
       expect(result).toBe(created);
     });
@@ -190,14 +214,20 @@ describe("shelves server functions", () => {
       } as never);
 
       expect(collectionCreateMock).toHaveBeenCalledWith({
-        data: { name: "Ebooks", kind: "MANUAL", formatFilter: "EBOOK" },
+        data: {
+          name: "Ebooks",
+          kind: "MANUAL",
+          formatFilter: "EBOOK",
+          ownerUserId: "user-1",
+        },
       });
       expect(result).toBe(created);
     });
   });
 
   describe("renameShelfServerFn", () => {
-    it("updates the shelf name", async () => {
+    it("updates the shelf name when current user owns it", async () => {
+      collectionFindUniqueMock.mockResolvedValue({ ownerUserId: "user-1" });
       const updated = { id: "s1", name: "Renamed" };
       collectionUpdateMock.mockResolvedValue(updated);
 
@@ -211,10 +241,32 @@ describe("shelves server functions", () => {
       });
       expect(result).toBe(updated);
     });
+
+    it("rejects when the shelf is owned by another user", async () => {
+      collectionFindUniqueMock.mockResolvedValue({ ownerUserId: "other-user" });
+
+      await expect(
+        renameShelfServerFn({
+          data: { shelfId: "s1", name: "Renamed" },
+        } as never),
+      ).rejects.toThrow("Shelf not found");
+      expect(collectionUpdateMock).not.toHaveBeenCalled();
+    });
+
+    it("rejects when the shelf does not exist", async () => {
+      collectionFindUniqueMock.mockResolvedValue(null);
+
+      await expect(
+        renameShelfServerFn({
+          data: { shelfId: "s1", name: "Renamed" },
+        } as never),
+      ).rejects.toThrow("Shelf not found");
+    });
   });
 
   describe("deleteShelfServerFn", () => {
-    it("deletes the shelf", async () => {
+    it("deletes the shelf when current user owns it", async () => {
+      collectionFindUniqueMock.mockResolvedValue({ ownerUserId: "user-1" });
       collectionDeleteMock.mockResolvedValue({ id: "s1" });
 
       await deleteShelfServerFn({
@@ -229,6 +281,7 @@ describe("shelves server functions", () => {
 
   describe("addEditionToShelfServerFn", () => {
     it("creates a collection item with editionId", async () => {
+      collectionFindUniqueMock.mockResolvedValue({ ownerUserId: "user-1" });
       const item = { id: "ci1", collectionId: "s1", editionId: "e1" };
       collectionItemCreateMock.mockResolvedValue(item);
 
@@ -245,7 +298,7 @@ describe("shelves server functions", () => {
 
   describe("addEditionsForWorkToShelfServerFn", () => {
     it("adds matching editions for a work to a shelf with ALL format filter", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
       editionFindManyMock.mockResolvedValue([{ id: "e1" }, { id: "e2" }]);
       collectionItemFindManyMock.mockResolvedValue([]);
       collectionItemCreateManyMock.mockResolvedValue({ count: 2 });
@@ -254,8 +307,8 @@ describe("shelves server functions", () => {
         data: { shelfId: "s1", workId: "w1" },
       } as never);
 
-      expect(collectionFindUniqueOrThrowMock).toHaveBeenCalledWith({
-        where: { id: "s1" },
+      expect(collectionFindFirstOrThrowMock).toHaveBeenCalledWith({
+        where: { id: "s1", ownerUserId: "user-1" },
         select: { formatFilter: true },
       });
       expect(editionFindManyMock).toHaveBeenCalledWith({
@@ -272,7 +325,7 @@ describe("shelves server functions", () => {
     });
 
     it("filters editions by EBOOK format when shelf has EBOOK filter", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "EBOOK" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "EBOOK" });
       editionFindManyMock.mockResolvedValue([{ id: "e1" }]);
       collectionItemFindManyMock.mockResolvedValue([]);
       collectionItemCreateManyMock.mockResolvedValue({ count: 1 });
@@ -289,7 +342,7 @@ describe("shelves server functions", () => {
     });
 
     it("skips existing editions", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
       editionFindManyMock.mockResolvedValue([{ id: "e1" }, { id: "e2" }]);
       collectionItemFindManyMock.mockResolvedValue([{ editionId: "e1" }]);
       collectionItemCreateManyMock.mockResolvedValue({ count: 1 });
@@ -305,7 +358,7 @@ describe("shelves server functions", () => {
     });
 
     it("returns zero when no matching editions exist", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "AUDIOBOOK" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "AUDIOBOOK" });
       editionFindManyMock.mockResolvedValue([]);
 
       const result = await addEditionsForWorkToShelfServerFn({
@@ -317,7 +370,7 @@ describe("shelves server functions", () => {
     });
 
     it("returns zero when all editions already exist on shelf", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
       editionFindManyMock.mockResolvedValue([{ id: "e1" }]);
       collectionItemFindManyMock.mockResolvedValue([{ editionId: "e1" }]);
 
@@ -332,7 +385,7 @@ describe("shelves server functions", () => {
 
   describe("bulkAddToShelfServerFn", () => {
     it("adds editions for multiple works respecting format filter", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
       editionFindManyMock.mockResolvedValue([{ id: "e1" }, { id: "e2" }]);
       collectionItemFindManyMock.mockResolvedValue([{ editionId: "e1" }]);
       collectionItemCreateManyMock.mockResolvedValue({ count: 1 });
@@ -341,8 +394,8 @@ describe("shelves server functions", () => {
         data: { shelfId: "s1", workIds: ["w1", "w2"] },
       } as never);
 
-      expect(collectionFindUniqueOrThrowMock).toHaveBeenCalledWith({
-        where: { id: "s1" },
+      expect(collectionFindFirstOrThrowMock).toHaveBeenCalledWith({
+        where: { id: "s1", ownerUserId: "user-1" },
         select: { formatFilter: true },
       });
       expect(editionFindManyMock).toHaveBeenCalledWith({
@@ -356,7 +409,7 @@ describe("shelves server functions", () => {
     });
 
     it("skips createMany when all editions already exist", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
       editionFindManyMock.mockResolvedValue([{ id: "e1" }]);
       collectionItemFindManyMock.mockResolvedValue([{ editionId: "e1" }]);
 
@@ -369,7 +422,7 @@ describe("shelves server functions", () => {
     });
 
     it("returns zero when no editions match format filter", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "EBOOK" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "EBOOK" });
       editionFindManyMock.mockResolvedValue([]);
 
       const result = await bulkAddToShelfServerFn({
@@ -381,7 +434,7 @@ describe("shelves server functions", () => {
     });
 
     it("applies AUDIOBOOK format filter when shelf has AUDIOBOOK filter", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "AUDIOBOOK" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "AUDIOBOOK" });
       editionFindManyMock.mockResolvedValue([{ id: "e3" }]);
       collectionItemFindManyMock.mockResolvedValue([]);
       collectionItemCreateManyMock.mockResolvedValue({ count: 1 });
@@ -400,6 +453,7 @@ describe("shelves server functions", () => {
 
   describe("removeEditionFromShelfServerFn", () => {
     it("deletes the collection item by compound key", async () => {
+      collectionFindUniqueMock.mockResolvedValue({ ownerUserId: "user-1" });
       collectionItemDeleteMock.mockResolvedValue({ id: "ci1" });
 
       await removeEditionFromShelfServerFn({
@@ -419,6 +473,7 @@ describe("shelves server functions", () => {
 
   describe("removeWorkEditionsFromShelfServerFn", () => {
     it("removes all editions of a work from a shelf", async () => {
+      collectionFindUniqueMock.mockResolvedValue({ ownerUserId: "user-1" });
       editionFindManyMock.mockResolvedValue([{ id: "e1" }, { id: "e2" }]);
       collectionItemDeleteManyMock.mockResolvedValue({ count: 2 });
 
@@ -437,6 +492,7 @@ describe("shelves server functions", () => {
     });
 
     it("returns zero when work has no editions", async () => {
+      collectionFindUniqueMock.mockResolvedValue({ ownerUserId: "user-1" });
       editionFindManyMock.mockResolvedValue([]);
 
       const result = await removeWorkEditionsFromShelfServerFn({
@@ -450,15 +506,15 @@ describe("shelves server functions", () => {
 
   describe("getAvailableEditionsServerFn", () => {
     it("returns editions not already on the shelf matching format filter", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "EBOOK" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "EBOOK" });
       collectionItemFindManyMock.mockResolvedValue([{ editionId: "e1" }]);
       const available = [{ id: "e2", formatFamily: "EBOOK", work: { titleDisplay: "Book" } }];
       editionFindManyMock.mockResolvedValue(available);
 
       const result = await getAvailableEditionsServerFn({ data: { shelfId: "s1" } } as never);
 
-      expect(collectionFindUniqueOrThrowMock).toHaveBeenCalledWith({
-        where: { id: "s1" },
+      expect(collectionFindFirstOrThrowMock).toHaveBeenCalledWith({
+        where: { id: "s1", ownerUserId: "user-1" },
         select: { formatFilter: true },
       });
       expect(editionFindManyMock).toHaveBeenCalledWith(
@@ -472,7 +528,7 @@ describe("shelves server functions", () => {
     });
 
     it("returns all formats when shelf filter is ALL", async () => {
-      collectionFindUniqueOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
+      collectionFindFirstOrThrowMock.mockResolvedValue({ formatFilter: "ALL" });
       collectionItemFindManyMock.mockResolvedValue([]);
       editionFindManyMock.mockResolvedValue([]);
 

--- a/apps/web/src/lib/server-fns/shelves.ts
+++ b/apps/web/src/lib/server-fns/shelves.ts
@@ -1,11 +1,36 @@
 import { createServerFn } from "@tanstack/react-start";
 import { z } from "zod";
 
+type ShelfOwnershipDb = {
+  collection: {
+    findUnique: (args: {
+      where: { id: string };
+      select: { ownerUserId: true };
+    }) => Promise<{ ownerUserId: string | null } | null>;
+  };
+};
+
+async function requireOwnedShelf(
+  db: ShelfOwnershipDb,
+  shelfId: string,
+  userId: string,
+): Promise<void> {
+  const shelf = await db.collection.findUnique({
+    where: { id: shelfId },
+    select: { ownerUserId: true },
+  });
+  if (!shelf || shelf.ownerUserId !== userId) {
+    throw new Error("Shelf not found");
+  }
+}
+
 export const getShelvesServerFn = createServerFn({
   method: "GET",
 }).handler(async () => {
+  const user = await (await import("./_guards")).authenticatedOnly();
   const { db } = await import("@bookhouse/db");
   return db.collection.findMany({
+    where: { ownerUserId: user.id },
     include: {
       _count: {
         select: { items: true },
@@ -24,9 +49,10 @@ export const getShelfDetailServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
-    return db.collection.findUniqueOrThrow({
-      where: { id: data.shelfId },
+    return db.collection.findFirstOrThrow({
+      where: { id: data.shelfId, ownerUserId: user.id },
       include: {
         items: {
           include: {
@@ -59,9 +85,13 @@ export const getShelvesForEditionServerFn = createServerFn({
 })
   .inputValidator(z.object({ editionId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
     const memberships = await db.collectionItem.findMany({
-      where: { editionId: data.editionId },
+      where: {
+        editionId: data.editionId,
+        collection: { ownerUserId: user.id },
+      },
       select: { collectionId: true },
     });
     return memberships.map((m) => m.collectionId);
@@ -72,6 +102,7 @@ export const getShelvesForWorkServerFn = createServerFn({
 })
   .inputValidator(z.object({ workId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
     const editions = await db.edition.findMany({
       where: { workId: data.workId },
@@ -79,9 +110,15 @@ export const getShelvesForWorkServerFn = createServerFn({
     });
     const editionIds = editions.map((e) => e.id);
     const [shelves, memberships] = await Promise.all([
-      db.collection.findMany({ orderBy: { name: "asc" } }),
+      db.collection.findMany({
+        where: { ownerUserId: user.id },
+        orderBy: { name: "asc" },
+      }),
       db.collectionItem.findMany({
-        where: { editionId: { in: editionIds } },
+        where: {
+          editionId: { in: editionIds },
+          collection: { ownerUserId: user.id },
+        },
         select: { collectionId: true },
       }),
     ]);
@@ -101,9 +138,15 @@ export const createShelfServerFn = createServerFn({
     formatFilter: z.enum(["ALL", "EBOOK", "AUDIOBOOK"]).default("ALL"),
   }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
     return db.collection.create({
-      data: { name: data.name, kind: "MANUAL", formatFilter: data.formatFilter },
+      data: {
+        name: data.name,
+        kind: "MANUAL",
+        formatFilter: data.formatFilter,
+        ownerUserId: user.id,
+      },
     });
   });
 
@@ -112,9 +155,10 @@ export const getAvailableEditionsServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
-    const shelf = await db.collection.findUniqueOrThrow({
-      where: { id: data.shelfId },
+    const shelf = await db.collection.findFirstOrThrow({
+      where: { id: data.shelfId, ownerUserId: user.id },
       select: { formatFilter: true },
     });
     const existing = await db.collectionItem.findMany({
@@ -151,7 +195,9 @@ export const renameShelfServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1), name: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+    await requireOwnedShelf(db, data.shelfId, user.id);
     return db.collection.update({
       where: { id: data.shelfId },
       data: { name: data.name },
@@ -163,7 +209,9 @@ export const deleteShelfServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+    await requireOwnedShelf(db, data.shelfId, user.id);
     return db.collection.delete({
       where: { id: data.shelfId },
     });
@@ -174,7 +222,9 @@ export const addEditionToShelfServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1), editionId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+    await requireOwnedShelf(db, data.shelfId, user.id);
     return db.collectionItem.create({
       data: { collectionId: data.shelfId, editionId: data.editionId },
     });
@@ -185,9 +235,10 @@ export const addEditionsForWorkToShelfServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1), workId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
-    const shelf = await db.collection.findUniqueOrThrow({
-      where: { id: data.shelfId },
+    const shelf = await db.collection.findFirstOrThrow({
+      where: { id: data.shelfId, ownerUserId: user.id },
       select: { formatFilter: true },
     });
     const formatWhere = shelf.formatFilter === "ALL"
@@ -218,9 +269,10 @@ export const bulkAddToShelfServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1), workIds: z.array(z.string().min(1)).min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
-    const shelf = await db.collection.findUniqueOrThrow({
-      where: { id: data.shelfId },
+    const shelf = await db.collection.findFirstOrThrow({
+      where: { id: data.shelfId, ownerUserId: user.id },
       select: { formatFilter: true },
     });
     const formatWhere = shelf.formatFilter === "ALL"
@@ -251,7 +303,9 @@ export const removeEditionFromShelfServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1), editionId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+    await requireOwnedShelf(db, data.shelfId, user.id);
     return db.collectionItem.delete({
       where: {
         collectionId_editionId: {
@@ -267,7 +321,9 @@ export const removeWorkEditionsFromShelfServerFn = createServerFn({
 })
   .inputValidator(z.object({ shelfId: z.string().min(1), workId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    const user = await (await import("./_guards")).authenticatedOnly();
     const { db } = await import("@bookhouse/db");
+    await requireOwnedShelf(db, data.shelfId, user.id);
     const editions = await db.edition.findMany({
       where: { workId: data.workId },
       select: { id: true },

--- a/apps/web/src/lib/server-fns/smtp.test.ts
+++ b/apps/web/src/lib/server-fns/smtp.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/smtp.ts
+++ b/apps/web/src/lib/server-fns/smtp.ts
@@ -41,6 +41,7 @@ export const getSmtpStatusServerFn = createServerFn({
 export const getSmtpConfigServerFn = createServerFn({
   method: "GET",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
   const settings = await db.appSetting.findMany({
     where: { key: { in: [...SMTP_KEYS] } },
@@ -74,6 +75,7 @@ export const saveSmtpConfigServerFn = createServerFn({
 })
   .inputValidator(saveSmtpConfigSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
     const { encryptValue } = await import("./integrations");
     const secret = await getSecret();
@@ -105,6 +107,7 @@ export const saveSmtpConfigServerFn = createServerFn({
 export const removeSmtpConfigServerFn = createServerFn({
   method: "POST",
 }).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
   const { db } = await import("@bookhouse/db");
   await db.appSetting.deleteMany({
     where: { key: { in: [...SMTP_KEYS] } },
@@ -121,6 +124,7 @@ export const testSmtpConnectionServerFn = createServerFn({
 })
   .inputValidator(testSmtpConnectionSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const config = await getDecryptedSmtpConfig();
     if (!config) return { success: false, error: "SMTP is not configured" };
 

--- a/apps/web/src/lib/server-fns/tags.test.ts
+++ b/apps/web/src/lib/server-fns/tags.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/tags.ts
+++ b/apps/web/src/lib/server-fns/tags.ts
@@ -11,6 +11,7 @@ export const updateWorkTagsServerFn = createServerFn({
 })
   .inputValidator(updateWorkTagsSchema)
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const work = await db.work.findUnique({

--- a/apps/web/src/lib/server-fns/users.test.ts
+++ b/apps/web/src/lib/server-fns/users.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("./_guards", () => ({
+  ownerOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
+vi.mock("@tanstack/react-start", () => ({
+  createServerFn: () => {
+    type Builder = {
+      inputValidator: () => Builder;
+      handler: <T>(fn: (a: T) => T | Promise<T>) => (a: T) => T | Promise<T>;
+    };
+    const b: Builder = {
+      inputValidator: () => b,
+      handler: (fn) => (a) => fn(a),
+    };
+    return b;
+  },
+}));
+
+const userFindManyMock = vi.fn();
+const userDeleteMock = vi.fn();
+const allowedEmailFindManyMock = vi.fn();
+const allowedEmailUpsertMock = vi.fn();
+const allowedEmailDeleteMock = vi.fn();
+
+vi.mock("@bookhouse/db", () => ({
+  db: {
+    user: {
+      findMany: userFindManyMock,
+      delete: userDeleteMock,
+    },
+    allowedEmail: {
+      findMany: allowedEmailFindManyMock,
+      upsert: allowedEmailUpsertMock,
+      delete: allowedEmailDeleteMock,
+    },
+  },
+}));
+
+import {
+  listUsersServerFn,
+  listAllowedEmailsServerFn,
+  addAllowedEmailServerFn,
+  removeAllowedEmailServerFn,
+  removeUserServerFn,
+} from "./users";
+
+describe("user management server functions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("lists users with roles flattened to string arrays", async () => {
+    userFindManyMock.mockResolvedValue([
+      {
+        id: "u1",
+        email: "a@example.com",
+        name: "A",
+        image: null,
+        createdAt: new Date("2026-05-01"),
+        roles: [{ role: "OWNER" }],
+      },
+      {
+        id: "u2",
+        email: "b@example.com",
+        name: "B",
+        image: null,
+        createdAt: new Date("2026-05-02"),
+        roles: [{ role: "VIEWER" }],
+      },
+    ]);
+
+    const result = await listUsersServerFn();
+    expect(result[0]?.roles).toEqual(["OWNER"]);
+    expect(result[1]?.roles).toEqual(["VIEWER"]);
+  });
+
+  it("lists allowed emails ordered by recency", async () => {
+    const entries = [{ id: "ae-1", email: "viewer@example.com" }];
+    allowedEmailFindManyMock.mockResolvedValue(entries);
+    const result = await listAllowedEmailsServerFn();
+    expect(allowedEmailFindManyMock).toHaveBeenCalledWith({
+      orderBy: { createdAt: "desc" },
+    });
+    expect(result).toBe(entries);
+  });
+
+  it("adds an allowed email (lowercased) and records the owner who added it", async () => {
+    allowedEmailUpsertMock.mockResolvedValue({
+      id: "ae-1",
+      email: "viewer@example.com",
+    });
+
+    await addAllowedEmailServerFn({
+      data: { email: "  Viewer@Example.com  " },
+    } as never);
+
+    expect(allowedEmailUpsertMock).toHaveBeenCalledWith({
+      where: { email: "viewer@example.com" },
+      create: { email: "viewer@example.com", createdBy: "owner-1" },
+      update: {},
+    });
+  });
+
+  it("removes an allowed email and tolerates a missing record", async () => {
+    allowedEmailDeleteMock.mockResolvedValueOnce({ id: "ae-1" });
+    await expect(
+      removeAllowedEmailServerFn({ data: { id: "ae-1" } } as never),
+    ).resolves.toEqual({ success: true });
+
+    const notFoundError = Object.assign(new Error("not found"), { code: "P2025" });
+    allowedEmailDeleteMock.mockRejectedValueOnce(notFoundError);
+    await expect(
+      removeAllowedEmailServerFn({ data: { id: "ae-missing" } } as never),
+    ).resolves.toEqual({ success: true });
+  });
+
+  it("rethrows non-P2025 errors when removing an allowed email", async () => {
+    allowedEmailDeleteMock.mockRejectedValueOnce(new Error("db down"));
+    await expect(
+      removeAllowedEmailServerFn({ data: { id: "ae-1" } } as never),
+    ).rejects.toThrow("db down");
+  });
+
+  it("removes a non-owner user", async () => {
+    userDeleteMock.mockResolvedValue({ id: "u2" });
+    await expect(
+      removeUserServerFn({ data: { userId: "u2" } } as never),
+    ).resolves.toEqual({ success: true });
+    expect(userDeleteMock).toHaveBeenCalledWith({ where: { id: "u2" } });
+  });
+
+  it("refuses to remove the current owner", async () => {
+    await expect(
+      removeUserServerFn({ data: { userId: "owner-1" } } as never),
+    ).rejects.toThrow("Cannot remove yourself");
+    expect(userDeleteMock).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/server-fns/users.ts
+++ b/apps/web/src/lib/server-fns/users.ts
@@ -1,0 +1,93 @@
+import { createServerFn } from "@tanstack/react-start";
+import { z } from "zod";
+
+function normalizeEmail(email: string): string {
+  return email.trim().toLowerCase();
+}
+
+export const listUsersServerFn = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
+  const { db } = await import("@bookhouse/db");
+  const users = await db.user.findMany({
+    select: {
+      id: true,
+      email: true,
+      name: true,
+      image: true,
+      createdAt: true,
+      roles: { select: { role: true } },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+  return users.map((u) => ({
+    id: u.id,
+    email: u.email,
+    name: u.name,
+    image: u.image,
+    createdAt: u.createdAt,
+    roles: u.roles.map((r) => r.role),
+  }));
+});
+
+export const listAllowedEmailsServerFn = createServerFn({
+  method: "GET",
+}).handler(async () => {
+  await (await import("./_guards")).ownerOnly();
+  const { db } = await import("@bookhouse/db");
+  return db.allowedEmail.findMany({
+    orderBy: { createdAt: "desc" },
+  });
+});
+
+export const addAllowedEmailServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(z.object({ email: z.string().email() }))
+  .handler(async ({ data }) => {
+    const owner = await (await import("./_guards")).ownerOnly();
+    const { db } = await import("@bookhouse/db");
+    const email = normalizeEmail(data.email);
+    return db.allowedEmail.upsert({
+      where: { email },
+      create: { email, createdBy: owner.id },
+      update: {},
+    });
+  });
+
+export const removeAllowedEmailServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(z.object({ id: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
+    const { db } = await import("@bookhouse/db");
+    try {
+      await db.allowedEmail.delete({ where: { id: data.id } });
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        "code" in error &&
+        (error as { code: string }).code === "P2025"
+      ) {
+        return { success: true };
+      }
+      throw error;
+    }
+    return { success: true };
+  });
+
+export const removeUserServerFn = createServerFn({
+  method: "POST",
+})
+  .inputValidator(z.object({ userId: z.string().min(1) }))
+  .handler(async ({ data }) => {
+    const owner = await (await import("./_guards")).ownerOnly();
+    if (data.userId === owner.id) {
+      throw new Error("Cannot remove yourself");
+    }
+    const { db } = await import("@bookhouse/db");
+    await db.user.delete({ where: { id: data.userId } });
+    return { success: true };
+  });

--- a/apps/web/src/lib/server-fns/work-management.test.ts
+++ b/apps/web/src/lib/server-fns/work-management.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+vi.mock("./_guards", () => ({
+  ownerOnly: vi.fn().mockResolvedValue(undefined),
+  authenticatedOnly: vi
+    .fn()
+    .mockResolvedValue({ id: "owner-1", roles: ["OWNER"] }),
+}));
+
 vi.mock("@tanstack/react-start", () => ({
   createServerFn: () => {
     type Builder = {

--- a/apps/web/src/lib/server-fns/work-management.ts
+++ b/apps/web/src/lib/server-fns/work-management.ts
@@ -11,6 +11,7 @@ export const mergeWorksServerFn = createServerFn({
     }),
   )
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     if (data.sourceWorkIds.includes(data.targetWorkId)) {
       throw new Error("Target work cannot be in source works");
     }
@@ -26,6 +27,7 @@ export const splitEditionToWorkServerFn = createServerFn({
 })
   .inputValidator(z.object({ editionId: z.string().min(1) }))
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const edition = await db.edition.findUnique({
@@ -69,6 +71,7 @@ export const splitEditionFilesServerFn = createServerFn({
     }),
   )
   .handler(async ({ data }) => {
+    await (await import("./_guards")).ownerOnly();
     const { db } = await import("@bookhouse/db");
 
     const edition = await db.edition.findUnique({

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -14,6 +14,7 @@ import { Route as AuthenticatedRouteImport } from './routes/_authenticated'
 import { Route as AuthenticatedIndexRouteImport } from './routes/_authenticated/index'
 import { Route as AuthLogoutRouteImport } from './routes/auth/logout'
 import { Route as AuthLoginRouteImport } from './routes/auth/login'
+import { Route as AuthDeniedRouteImport } from './routes/auth/denied'
 import { Route as AuthCallbackRouteImport } from './routes/auth/callback'
 import { Route as AuthenticatedShelvesRouteImport } from './routes/_authenticated/shelves'
 import { Route as AuthenticatedSettingsRouteImport } from './routes/_authenticated/settings'
@@ -29,6 +30,7 @@ import { Route as AuthenticatedSeriesIndexRouteImport } from './routes/_authenti
 import { Route as AuthenticatedLibraryIndexRouteImport } from './routes/_authenticated/library.index'
 import { Route as AuthenticatedAuthorsIndexRouteImport } from './routes/_authenticated/authors.index'
 import { Route as AuthenticatedShelvesShelfIdRouteImport } from './routes/_authenticated/shelves.$shelfId'
+import { Route as AuthenticatedSettingsUsersRouteImport } from './routes/_authenticated/settings/users'
 import { Route as AuthenticatedSettingsMissingFilesRouteImport } from './routes/_authenticated/settings/missing-files'
 import { Route as AuthenticatedSettingsLibrariesRouteImport } from './routes/_authenticated/settings/libraries'
 import { Route as AuthenticatedSettingsJobsRouteImport } from './routes/_authenticated/settings/jobs'
@@ -61,6 +63,11 @@ const AuthLogoutRoute = AuthLogoutRouteImport.update({
 const AuthLoginRoute = AuthLoginRouteImport.update({
   id: '/auth/login',
   path: '/auth/login',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const AuthDeniedRoute = AuthDeniedRouteImport.update({
+  id: '/auth/denied',
+  path: '/auth/denied',
   getParentRoute: () => rootRouteImport,
 } as any)
 const AuthCallbackRoute = AuthCallbackRouteImport.update({
@@ -145,6 +152,12 @@ const AuthenticatedShelvesShelfIdRoute =
     path: '/$shelfId',
     getParentRoute: () => AuthenticatedShelvesRoute,
   } as any)
+const AuthenticatedSettingsUsersRoute =
+  AuthenticatedSettingsUsersRouteImport.update({
+    id: '/users',
+    path: '/users',
+    getParentRoute: () => AuthenticatedSettingsRoute,
+  } as any)
 const AuthenticatedSettingsMissingFilesRoute =
   AuthenticatedSettingsMissingFilesRouteImport.update({
     id: '/missing-files',
@@ -212,6 +225,7 @@ export interface FileRoutesByFullPath {
   '/settings': typeof AuthenticatedSettingsRouteWithChildren
   '/shelves': typeof AuthenticatedShelvesRouteWithChildren
   '/auth/callback': typeof AuthCallbackRoute
+  '/auth/denied': typeof AuthDeniedRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/authors/$authorId': typeof AuthenticatedAuthorsAuthorIdRoute
@@ -220,6 +234,7 @@ export interface FileRoutesByFullPath {
   '/settings/jobs': typeof AuthenticatedSettingsJobsRouteWithChildren
   '/settings/libraries': typeof AuthenticatedSettingsLibrariesRoute
   '/settings/missing-files': typeof AuthenticatedSettingsMissingFilesRoute
+  '/settings/users': typeof AuthenticatedSettingsUsersRoute
   '/shelves/$shelfId': typeof AuthenticatedShelvesShelfIdRoute
   '/authors/': typeof AuthenticatedAuthorsIndexRoute
   '/library/': typeof AuthenticatedLibraryIndexRoute
@@ -236,6 +251,7 @@ export interface FileRoutesByTo {
   '/health': typeof AuthenticatedHealthRoute
   '/match-suggestions': typeof AuthenticatedMatchSuggestionsRoute
   '/auth/callback': typeof AuthCallbackRoute
+  '/auth/denied': typeof AuthDeniedRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/': typeof AuthenticatedIndexRoute
@@ -244,6 +260,7 @@ export interface FileRoutesByTo {
   '/series/$seriesId': typeof AuthenticatedSeriesSeriesIdRoute
   '/settings/libraries': typeof AuthenticatedSettingsLibrariesRoute
   '/settings/missing-files': typeof AuthenticatedSettingsMissingFilesRoute
+  '/settings/users': typeof AuthenticatedSettingsUsersRoute
   '/shelves/$shelfId': typeof AuthenticatedShelvesShelfIdRoute
   '/authors': typeof AuthenticatedAuthorsIndexRoute
   '/library': typeof AuthenticatedLibraryIndexRoute
@@ -267,6 +284,7 @@ export interface FileRoutesById {
   '/_authenticated/settings': typeof AuthenticatedSettingsRouteWithChildren
   '/_authenticated/shelves': typeof AuthenticatedShelvesRouteWithChildren
   '/auth/callback': typeof AuthCallbackRoute
+  '/auth/denied': typeof AuthDeniedRoute
   '/auth/login': typeof AuthLoginRoute
   '/auth/logout': typeof AuthLogoutRoute
   '/_authenticated/': typeof AuthenticatedIndexRoute
@@ -276,6 +294,7 @@ export interface FileRoutesById {
   '/_authenticated/settings/jobs': typeof AuthenticatedSettingsJobsRouteWithChildren
   '/_authenticated/settings/libraries': typeof AuthenticatedSettingsLibrariesRoute
   '/_authenticated/settings/missing-files': typeof AuthenticatedSettingsMissingFilesRoute
+  '/_authenticated/settings/users': typeof AuthenticatedSettingsUsersRoute
   '/_authenticated/shelves/$shelfId': typeof AuthenticatedShelvesShelfIdRoute
   '/_authenticated/authors/': typeof AuthenticatedAuthorsIndexRoute
   '/_authenticated/library/': typeof AuthenticatedLibraryIndexRoute
@@ -300,6 +319,7 @@ export interface FileRouteTypes {
     | '/settings'
     | '/shelves'
     | '/auth/callback'
+    | '/auth/denied'
     | '/auth/login'
     | '/auth/logout'
     | '/authors/$authorId'
@@ -308,6 +328,7 @@ export interface FileRouteTypes {
     | '/settings/jobs'
     | '/settings/libraries'
     | '/settings/missing-files'
+    | '/settings/users'
     | '/shelves/$shelfId'
     | '/authors/'
     | '/library/'
@@ -324,6 +345,7 @@ export interface FileRouteTypes {
     | '/health'
     | '/match-suggestions'
     | '/auth/callback'
+    | '/auth/denied'
     | '/auth/login'
     | '/auth/logout'
     | '/'
@@ -332,6 +354,7 @@ export interface FileRouteTypes {
     | '/series/$seriesId'
     | '/settings/libraries'
     | '/settings/missing-files'
+    | '/settings/users'
     | '/shelves/$shelfId'
     | '/authors'
     | '/library'
@@ -354,6 +377,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings'
     | '/_authenticated/shelves'
     | '/auth/callback'
+    | '/auth/denied'
     | '/auth/login'
     | '/auth/logout'
     | '/_authenticated/'
@@ -363,6 +387,7 @@ export interface FileRouteTypes {
     | '/_authenticated/settings/jobs'
     | '/_authenticated/settings/libraries'
     | '/_authenticated/settings/missing-files'
+    | '/_authenticated/settings/users'
     | '/_authenticated/shelves/$shelfId'
     | '/_authenticated/authors/'
     | '/_authenticated/library/'
@@ -378,6 +403,7 @@ export interface RootRouteChildren {
   AuthenticatedRoute: typeof AuthenticatedRouteWithChildren
   LoggedOutRoute: typeof LoggedOutRoute
   AuthCallbackRoute: typeof AuthCallbackRoute
+  AuthDeniedRoute: typeof AuthDeniedRoute
   AuthLoginRoute: typeof AuthLoginRoute
   AuthLogoutRoute: typeof AuthLogoutRoute
 }
@@ -417,6 +443,13 @@ declare module '@tanstack/react-router' {
       path: '/auth/login'
       fullPath: '/auth/login'
       preLoaderRoute: typeof AuthLoginRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/denied': {
+      id: '/auth/denied'
+      path: '/auth/denied'
+      fullPath: '/auth/denied'
+      preLoaderRoute: typeof AuthDeniedRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/auth/callback': {
@@ -523,6 +556,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/shelves/$shelfId'
       preLoaderRoute: typeof AuthenticatedShelvesShelfIdRouteImport
       parentRoute: typeof AuthenticatedShelvesRoute
+    }
+    '/_authenticated/settings/users': {
+      id: '/_authenticated/settings/users'
+      path: '/users'
+      fullPath: '/settings/users'
+      preLoaderRoute: typeof AuthenticatedSettingsUsersRouteImport
+      parentRoute: typeof AuthenticatedSettingsRoute
     }
     '/_authenticated/settings/missing-files': {
       id: '/_authenticated/settings/missing-files'
@@ -649,6 +689,7 @@ interface AuthenticatedSettingsRouteChildren {
   AuthenticatedSettingsJobsRoute: typeof AuthenticatedSettingsJobsRouteWithChildren
   AuthenticatedSettingsLibrariesRoute: typeof AuthenticatedSettingsLibrariesRoute
   AuthenticatedSettingsMissingFilesRoute: typeof AuthenticatedSettingsMissingFilesRoute
+  AuthenticatedSettingsUsersRoute: typeof AuthenticatedSettingsUsersRoute
   AuthenticatedSettingsIndexRoute: typeof AuthenticatedSettingsIndexRoute
   AuthenticatedSettingsLibraryIssuesLibraryRootIdRoute: typeof AuthenticatedSettingsLibraryIssuesLibraryRootIdRoute
 }
@@ -658,6 +699,7 @@ const AuthenticatedSettingsRouteChildren: AuthenticatedSettingsRouteChildren = {
   AuthenticatedSettingsLibrariesRoute: AuthenticatedSettingsLibrariesRoute,
   AuthenticatedSettingsMissingFilesRoute:
     AuthenticatedSettingsMissingFilesRoute,
+  AuthenticatedSettingsUsersRoute: AuthenticatedSettingsUsersRoute,
   AuthenticatedSettingsIndexRoute: AuthenticatedSettingsIndexRoute,
   AuthenticatedSettingsLibraryIssuesLibraryRootIdRoute:
     AuthenticatedSettingsLibraryIssuesLibraryRootIdRoute,
@@ -713,6 +755,7 @@ const rootRouteChildren: RootRouteChildren = {
   AuthenticatedRoute: AuthenticatedRouteWithChildren,
   LoggedOutRoute: LoggedOutRoute,
   AuthCallbackRoute: AuthCallbackRoute,
+  AuthDeniedRoute: AuthDeniedRoute,
   AuthLoginRoute: AuthLoginRoute,
   AuthLogoutRoute: AuthLogoutRoute,
 }

--- a/apps/web/src/routes/-_authenticated-component.test.tsx
+++ b/apps/web/src/routes/-_authenticated-component.test.tsx
@@ -86,7 +86,7 @@ describe("_authenticated route", () => {
 
   it("beforeLoad returns user when authenticated", async () => {
     const { getCurrentUserServerFn } = await import("~/lib/auth-client");
-    const user = { id: "u1", name: "Test", email: "t@t.com", image: null, issuer: "test", subject: "s1" };
+    const user = { id: "u1", name: "Test", email: "t@t.com", image: null, issuer: "test", subject: "s1", roles: ["OWNER"] };
     (vi.mocked(getCurrentUserServerFn)).mockResolvedValue(user);
 
     const { Route } = await import("./_authenticated");

--- a/apps/web/src/routes/_authenticated/settings/-index.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-index.test.tsx
@@ -164,6 +164,9 @@ vi.mock("~/hooks/use-app-color", () => ({
 
 const mockNavigate = vi.fn();
 const mockInvalidate = vi.fn();
+let mockRouteContext: { user?: { id: string; roles?: string[] } } = {
+  user: { id: "owner-1", roles: ["OWNER"] },
+};
 
 vi.mock("@tanstack/react-router", async () => {
   const actual = await vi.importActual<typeof TanstackRouter>("@tanstack/react-router");
@@ -183,7 +186,7 @@ vi.mock("@tanstack/react-router", async () => {
       ...opts,
       options: opts,
       useLoaderData: () => mockLoaderData,
-      useRouteContext: () => ({}),
+      useRouteContext: () => mockRouteContext,
     }),
   };
 });
@@ -254,6 +257,7 @@ const makeJob = (overrides: Partial<{
 describe("SettingsPage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockRouteContext = { user: { id: "owner-1", roles: ["OWNER"] } };
     mockLoaderData = { roots: [], missingFileBehavior: "manual", jobs: [], totalCount: 0, concurrencies: { full: 8, onDemand: 5, incremental: 3 }, integrations: { openlibrary: { configured: true, label: "Open Library" }, googlebooks: { configured: false, label: "Google Books" }, hardcover: { configured: false, label: "Hardcover" } }, backupHistory: [], smtpStatus: { configured: false }, kindleStatus: { configured: false }, koboDevices: [], shelves: [], opdsCredentials: [], koreaderCredential: null };
     mockTheme = "system";
     mockColorMode = "book";
@@ -265,6 +269,31 @@ describe("SettingsPage", () => {
     const SettingsPage = (Route.options.component as React.ComponentType);
     render(<SettingsPage />);
     expect(screen.getByText("Settings")).toBeTruthy();
+  });
+
+  it("shows only the Devices tab for viewers", async () => {
+    mockRouteContext = { user: { id: "viewer-1", roles: ["VIEWER"] } };
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    expect(screen.getByRole("tab", { name: "Devices" })).toBeTruthy();
+    expect(screen.queryByRole("tab", { name: "Library" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Appearance" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Jobs" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Integrations" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Backup" })).toBeNull();
+    expect(screen.queryByRole("tab", { name: "Users" })).toBeNull();
+    // The Devices tab is the default for viewers.
+    expect(screen.getByRole("tab", { name: "Devices" }).getAttribute("data-state")).toBe("active");
+  });
+
+  it("treats a user with no roles array as a viewer", async () => {
+    mockRouteContext = {};
+    const { Route } = await import("./index");
+    const SettingsPage = (Route.options.component as React.ComponentType);
+    render(<SettingsPage />);
+    expect(screen.queryByRole("tab", { name: "Library" })).toBeNull();
+    expect(screen.getByRole("tab", { name: "Devices" })).toBeTruthy();
   });
 
   it("renders three tabs: Library, Appearance, Jobs", async () => {
@@ -542,6 +571,40 @@ describe("SettingsPage", () => {
     });
   });
 
+  it("loader skips owner-only fetches when the user is not an owner", async () => {
+    getLibraryRootsServerFnMock.mockClear();
+
+    const { Route } = await import("./index");
+    const loader = Route.options.loader as (args: {
+      context: { user?: { id: string; roles?: string[] } };
+    }) => Promise<{
+      roots: object[];
+      smtpStatus: { configured: boolean };
+      backupHistory: object[];
+      jobs: object[];
+    }>;
+    const result = await loader({
+      context: { user: { id: "viewer-1", roles: ["VIEWER"] } },
+    });
+
+    expect(getLibraryRootsServerFnMock).not.toHaveBeenCalled();
+    expect(result.roots).toEqual([]);
+    expect(result.smtpStatus).toEqual({ configured: false });
+    expect(result.backupHistory).toEqual([]);
+    expect(result.jobs).toEqual([]);
+  });
+
+  it("loader falls back to no-OWNER role gracefully when context has no user", async () => {
+    getLibraryRootsServerFnMock.mockClear();
+    const { Route } = await import("./index");
+    const loader = Route.options.loader as (args: {
+      context: object;
+    }) => Promise<{ roots: object[] }>;
+    const result = await loader({ context: {} });
+    expect(getLibraryRootsServerFnMock).not.toHaveBeenCalled();
+    expect(result.roots).toEqual([]);
+  });
+
   it("loader calls all server functions including jobs and concurrency", async () => {
     const mockRoots = [{ id: "root-1", name: "Loader Root", path: "/books", kind: "EBOOKS", scanMode: "INCREMENTAL", isEnabled: true, lastScannedAt: null }];
     getLibraryRootsServerFnMock.mockResolvedValueOnce(mockRoots);
@@ -551,7 +614,12 @@ describe("SettingsPage", () => {
     getScanProgressServerFnMock.mockResolvedValueOnce(null);
     getLibraryIssueCountServerFnMock.mockResolvedValueOnce(0);
     const { Route } = await import("./index");
-    const result = await (Route.options.loader as (args: Record<string, string | object>) => Promise<object>)({});
+    type LoaderArgs = { context: { user?: { id: string; roles?: string[] } } };
+    const loaderUntyped = Route.options.loader as object;
+    const loader = loaderUntyped as (args: LoaderArgs) => Promise<object>;
+    const result = await loader({
+      context: { user: { id: "owner-1", roles: ["OWNER"] } },
+    });
     expect(getLibraryRootsServerFnMock).toHaveBeenCalled();
     expect(getImportJobsServerFnMock).toHaveBeenCalledWith({ data: { page: 1, pageSize: 100 } });
     expect(getAllScanConcurrenciesServerFnMock).toHaveBeenCalled();

--- a/apps/web/src/routes/_authenticated/settings/-users.test.tsx
+++ b/apps/web/src/routes/_authenticated/settings/-users.test.tsx
@@ -1,0 +1,383 @@
+// @vitest-environment happy-dom
+import type * as TanstackRouter from "@tanstack/react-router";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const listUsersServerFnMock = vi.fn();
+const listAllowedEmailsServerFnMock = vi.fn();
+const addAllowedEmailServerFnMock = vi.fn();
+const removeAllowedEmailServerFnMock = vi.fn();
+const removeUserServerFnMock = vi.fn();
+
+vi.mock("~/lib/server-fns/users", () => ({
+  listUsersServerFn: listUsersServerFnMock,
+  listAllowedEmailsServerFn: listAllowedEmailsServerFnMock,
+  addAllowedEmailServerFn: addAllowedEmailServerFnMock,
+  removeAllowedEmailServerFn: removeAllowedEmailServerFnMock,
+  removeUserServerFn: removeUserServerFnMock,
+}));
+
+const mockInvalidate = vi.fn();
+const mockToast = { success: vi.fn(), error: vi.fn() };
+vi.mock("sonner", () => ({ toast: mockToast }));
+
+interface MockLoaderData {
+  users: Array<{
+    id: string;
+    email: string | null;
+    name: string | null;
+    image: string | null;
+    createdAt: Date;
+    roles: string[];
+  }>;
+  allowedEmails: Array<{
+    id: string;
+    email: string;
+    createdAt: Date;
+    createdBy: string | null;
+  }>;
+  currentUserId: string;
+}
+
+let mockLoaderData: MockLoaderData = {
+  users: [],
+  allowedEmails: [],
+  currentUserId: "owner-1",
+};
+
+vi.mock("@tanstack/react-router", async () => {
+  const actual = await vi.importActual<typeof TanstackRouter>(
+    "@tanstack/react-router",
+  );
+  return {
+    ...actual,
+    useRouter: () => ({ invalidate: mockInvalidate }),
+    createFileRoute: () => (opts: Record<string, object | ((...a: object[]) => object)>) => ({
+      ...opts,
+      options: opts,
+      useLoaderData: () => mockLoaderData,
+    }),
+  };
+});
+
+describe("UsersPage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockLoaderData = {
+      users: [
+        {
+          id: "owner-1",
+          email: "owner@example.com",
+          name: "Owner",
+          image: null,
+          createdAt: new Date("2026-05-01"),
+          roles: ["OWNER"],
+        },
+        {
+          id: "viewer-1",
+          email: "viewer@example.com",
+          name: null,
+          image: null,
+          createdAt: new Date("2026-05-02"),
+          roles: ["VIEWER"],
+        },
+      ],
+      allowedEmails: [
+        {
+          id: "ae-1",
+          email: "pending@example.com",
+          createdAt: new Date("2026-05-02"),
+          createdBy: "owner-1",
+        },
+      ],
+      currentUserId: "owner-1",
+    };
+  });
+
+  it("renders the users table and allowlist", async () => {
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getByText("Users")).toBeTruthy();
+    expect(screen.getByText("owner@example.com")).toBeTruthy();
+    expect(screen.getByText("viewer@example.com")).toBeTruthy();
+    expect(screen.getByText("pending@example.com")).toBeTruthy();
+    expect(screen.getByText("OWNER")).toBeTruthy();
+    expect(screen.getByText("VIEWER")).toBeTruthy();
+  });
+
+  it("does not show a remove button for the current user", async () => {
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.queryByLabelText("Remove owner@example.com")).toBeNull();
+    expect(screen.getByLabelText("Remove viewer@example.com")).toBeTruthy();
+    expect(screen.getByLabelText("Remove pending@example.com")).toBeTruthy();
+  });
+
+  it("renders fallback dashes for missing email and name", async () => {
+    mockLoaderData = {
+      users: [
+        {
+          id: "u-x",
+          email: null,
+          name: null,
+          image: null,
+          createdAt: new Date("2026-05-03"),
+          roles: ["VIEWER"],
+        },
+      ],
+      allowedEmails: [],
+      currentUserId: "owner-1",
+    };
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    expect(screen.getAllByText("—").length).toBeGreaterThanOrEqual(2);
+    expect(screen.getByLabelText("Remove u-x")).toBeTruthy();
+  });
+
+  it("submits a new allowlist entry", async () => {
+    addAllowedEmailServerFnMock.mockResolvedValueOnce({
+      id: "ae-2",
+      email: "newviewer@example.com",
+    });
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const input = screen.getByPlaceholderText("viewer@example.com");
+    fireEvent.change(input, { target: { value: " newviewer@example.com " } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => {
+      expect(addAllowedEmailServerFnMock).toHaveBeenCalledWith({
+        data: { email: "newviewer@example.com" },
+      });
+    });
+    expect(mockToast.success).toHaveBeenCalled();
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it("shows an error toast when adding an allowed email fails", async () => {
+    addAllowedEmailServerFnMock.mockRejectedValueOnce(new Error("nope"));
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+
+    const input = screen.getByPlaceholderText("viewer@example.com");
+    fireEvent.change(input, { target: { value: "bad@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("nope");
+    });
+  });
+
+  it("falls back to a generic error string when the rejection is not an Error", async () => {
+    addAllowedEmailServerFnMock.mockRejectedValueOnce("string failure");
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    const input = screen.getByPlaceholderText("viewer@example.com");
+    fireEvent.change(input, { target: { value: "x@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: "Add" }));
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Failed to add email");
+    });
+  });
+
+  it("does nothing when the email input is empty", async () => {
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    // submit button is disabled for empty input — but submit via form to test guard
+    const form = screen
+      .getByPlaceholderText("viewer@example.com")
+      .closest("form");
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+    expect(addAllowedEmailServerFnMock).not.toHaveBeenCalled();
+  });
+
+  it("removes an allowlist entry", async () => {
+    removeAllowedEmailServerFnMock.mockResolvedValueOnce({ success: true });
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByLabelText("Remove pending@example.com"));
+    await waitFor(() => {
+      expect(removeAllowedEmailServerFnMock).toHaveBeenCalledWith({
+        data: { id: "ae-1" },
+      });
+    });
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it("toasts an error when removing an allowlist entry fails", async () => {
+    removeAllowedEmailServerFnMock.mockRejectedValueOnce(new Error("nope"));
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByLabelText("Remove pending@example.com"));
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("nope");
+    });
+  });
+
+  it("falls back to a generic error string when allowlist removal rejection is not an Error", async () => {
+    removeAllowedEmailServerFnMock.mockRejectedValueOnce("string failure");
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByLabelText("Remove pending@example.com"));
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Failed to remove");
+    });
+  });
+
+  it("removes a non-owner user via the table button", async () => {
+    removeUserServerFnMock.mockResolvedValueOnce({ success: true });
+    mockLoaderData = {
+      users: [
+        {
+          id: "owner-1",
+          email: "owner@example.com",
+          name: "Owner",
+          image: null,
+          createdAt: new Date("2026-05-01"),
+          roles: ["OWNER"],
+        },
+        {
+          id: "viewer-1",
+          email: "viewer@example.com",
+          name: "V",
+          image: null,
+          createdAt: new Date("2026-05-02"),
+          roles: ["VIEWER"],
+        },
+      ],
+      allowedEmails: [],
+      currentUserId: "owner-1",
+    };
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByLabelText("Remove viewer@example.com"));
+    await waitFor(() => {
+      expect(removeUserServerFnMock).toHaveBeenCalledWith({
+        data: { userId: "viewer-1" },
+      });
+    });
+    expect(mockToast.success).toHaveBeenCalledWith("User removed");
+    expect(mockInvalidate).toHaveBeenCalled();
+  });
+
+  it("toasts an error when removing a user fails", async () => {
+    removeUserServerFnMock.mockRejectedValueOnce(new Error("cannot"));
+    mockLoaderData = {
+      users: [
+        {
+          id: "owner-1",
+          email: "owner@example.com",
+          name: "Owner",
+          image: null,
+          createdAt: new Date("2026-05-01"),
+          roles: ["OWNER"],
+        },
+        {
+          id: "viewer-1",
+          email: "v@example.com",
+          name: "V",
+          image: null,
+          createdAt: new Date("2026-05-02"),
+          roles: ["VIEWER"],
+        },
+      ],
+      allowedEmails: [],
+      currentUserId: "owner-1",
+    };
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByLabelText("Remove v@example.com"));
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("cannot");
+    });
+  });
+
+  it("falls back to a generic error string when user removal rejection is not an Error", async () => {
+    removeUserServerFnMock.mockRejectedValueOnce("oh no");
+    mockLoaderData = {
+      users: [
+        {
+          id: "owner-1",
+          email: "owner@example.com",
+          name: "Owner",
+          image: null,
+          createdAt: new Date("2026-05-01"),
+          roles: ["OWNER"],
+        },
+        {
+          id: "viewer-1",
+          email: "v@example.com",
+          name: "V",
+          image: null,
+          createdAt: new Date("2026-05-02"),
+          roles: ["VIEWER"],
+        },
+      ],
+      allowedEmails: [],
+      currentUserId: "owner-1",
+    };
+    const { Route } = await import("./users");
+    const Page = Route.options.component as React.ComponentType;
+    render(<Page />);
+    fireEvent.click(screen.getByLabelText("Remove v@example.com"));
+    await waitFor(() => {
+      expect(mockToast.error).toHaveBeenCalledWith("Failed to remove user");
+    });
+  });
+
+  it("beforeLoad redirects viewers away from the owner-only Users page", async () => {
+    const { Route } = await import("./users");
+    const beforeLoad = Route.options.beforeLoad as (args: {
+      context: { user?: { roles?: string[] } };
+    }) => void;
+
+    expect(() => {
+      beforeLoad({ context: { user: { roles: ["VIEWER"] } } });
+    }).toThrow();
+    expect(() => {
+      beforeLoad({ context: {} });
+    }).toThrow();
+    // Owner is allowed through.
+    expect(() => {
+      beforeLoad({ context: { user: { roles: ["OWNER"] } } });
+    }).not.toThrow();
+  });
+
+  it("calls the loader to populate users and allowedEmails", async () => {
+    listUsersServerFnMock.mockResolvedValueOnce([]);
+    listAllowedEmailsServerFnMock.mockResolvedValueOnce([]);
+    const { Route } = await import("./users");
+    const loader = Route.options.loader as (args: {
+      context: { user?: { id: string } };
+    }) => Promise<MockLoaderData>;
+    const result = await loader({ context: { user: { id: "owner-1" } } });
+    expect(listUsersServerFnMock).toHaveBeenCalled();
+    expect(listAllowedEmailsServerFnMock).toHaveBeenCalled();
+    expect(result.currentUserId).toBe("owner-1");
+  });
+
+  it("defaults currentUserId to empty string when context has no user", async () => {
+    listUsersServerFnMock.mockResolvedValueOnce([]);
+    listAllowedEmailsServerFnMock.mockResolvedValueOnce([]);
+    const { Route } = await import("./users");
+    const loader = Route.options.loader as (args: {
+      context: { user?: { id: string } };
+    }) => Promise<MockLoaderData>;
+    const result = await loader({ context: {} });
+    expect(result.currentUserId).toBe("");
+  });
+});

--- a/apps/web/src/routes/_authenticated/settings/index.tsx
+++ b/apps/web/src/routes/_authenticated/settings/index.tsx
@@ -113,8 +113,57 @@ export interface LibraryRootWithExtras extends LibraryRootRow {
 }
 
 export const Route = createFileRoute("/_authenticated/settings/")({
-  loader: async () => {
-    const [roots, missingFileBehavior, jobsResult, concurrencies, integrations, backupHistory, smtpStatus, kindleStatus, koboDevices, shelves, opdsCredentials, koreaderCredential] = await Promise.all([
+  loader: async ({ context }) => {
+    const ctx = context as { user?: { roles?: string[] } };
+    const isOwner = ctx.user?.roles?.includes("OWNER") ?? false;
+
+    const [koboDevices, shelves, opdsCredentials, koreaderCredential] =
+      await Promise.all([
+        getKoboDevicesServerFn(),
+        getShelvesServerFn(),
+        getOpdsCredentialsServerFn(),
+        getKoreaderCredentialServerFn(),
+      ]);
+
+    if (!isOwner) {
+      return {
+        roots: [] as LibraryRootWithExtras[],
+        missingFileBehavior: "manual" as const,
+        jobs: [] as Awaited<ReturnType<typeof getImportJobsServerFn>>["jobs"],
+        totalCount: 0,
+        concurrencies: {
+          full: 8,
+          onDemand: 5,
+          incremental: 3,
+        } satisfies Awaited<ReturnType<typeof getAllScanConcurrenciesServerFn>>,
+        integrations: {
+          openlibrary: { configured: false, label: "Open Library" },
+          googlebooks: { configured: false, label: "Google Books" },
+          hardcover: { configured: false, label: "Hardcover" },
+          audible: { configured: false, label: "Audible" },
+        } satisfies Awaited<ReturnType<typeof getIntegrationStatusServerFn>>,
+        backupHistory: [] as Awaited<
+          ReturnType<typeof getBackupHistoryServerFn>
+        >,
+        smtpStatus: { configured: false },
+        kindleStatus: { configured: false },
+        koboDevices,
+        shelves,
+        opdsCredentials,
+        koreaderCredential,
+      };
+    }
+
+    const [
+      roots,
+      missingFileBehavior,
+      jobsResult,
+      concurrencies,
+      integrations,
+      backupHistory,
+      smtpStatus,
+      kindleStatus,
+    ] = await Promise.all([
       getLibraryRootsServerFn(),
       getMissingFileBehaviorServerFn(),
       getImportJobsServerFn({ data: { page: 1, pageSize: 100 } }),
@@ -123,10 +172,6 @@ export const Route = createFileRoute("/_authenticated/settings/")({
       getBackupHistoryServerFn(),
       getSmtpStatusServerFn(),
       getKindleStatusServerFn(),
-      getKoboDevicesServerFn(),
-      getShelvesServerFn(),
-      getOpdsCredentialsServerFn(),
-      getKoreaderCredentialServerFn(),
     ]);
     const rootsWithExtras: LibraryRootWithExtras[] = await Promise.all(
       roots.map(async (root) => {
@@ -171,6 +216,8 @@ function SettingsSkeleton() {
 
 function SettingsPage() {
   const { roots, missingFileBehavior, jobs, totalCount, concurrencies, integrations, backupHistory: initialBackupHistory, smtpStatus, kindleStatus, koboDevices, shelves, opdsCredentials, koreaderCredential } = Route.useLoaderData();
+  const routeContext: { user?: { roles?: string[] } } = Route.useRouteContext();
+  const isOwner = routeContext.user?.roles?.includes("OWNER") ?? false;
   const [backupHistory, setBackupHistory] = useState(initialBackupHistory);
 
   const handleBackupComplete = async (manifest: BackupManifest) => {
@@ -192,43 +239,72 @@ function SettingsPage() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Settings</h1>
 
-      <Tabs defaultValue="library">
+      <Tabs defaultValue={isOwner ? "library" : "devices"}>
         <TabsList className="h-10">
-          <TabsTrigger value="library" className="px-4 py-1.5">Library</TabsTrigger>
-          <TabsTrigger value="appearance" className="px-4 py-1.5">Appearance</TabsTrigger>
-          <TabsTrigger value="jobs" className="px-4 py-1.5">Jobs</TabsTrigger>
-          <TabsTrigger value="integrations" className="px-4 py-1.5">Integrations</TabsTrigger>
-          <TabsTrigger value="backup" className="px-4 py-1.5">Backup</TabsTrigger>
+          {isOwner && <TabsTrigger value="library" className="px-4 py-1.5">Library</TabsTrigger>}
+          {isOwner && <TabsTrigger value="appearance" className="px-4 py-1.5">Appearance</TabsTrigger>}
+          {isOwner && <TabsTrigger value="jobs" className="px-4 py-1.5">Jobs</TabsTrigger>}
+          {isOwner && <TabsTrigger value="integrations" className="px-4 py-1.5">Integrations</TabsTrigger>}
+          {isOwner && <TabsTrigger value="backup" className="px-4 py-1.5">Backup</TabsTrigger>}
           <TabsTrigger value="devices" className="px-4 py-1.5">Devices</TabsTrigger>
+          {isOwner && <TabsTrigger value="users" className="px-4 py-1.5">Users</TabsTrigger>}
         </TabsList>
 
-        <TabsContent value="library" forceMount className="space-y-6 data-[state=inactive]:hidden">
-          <LibraryTab roots={roots} missingFileBehavior={missingFileBehavior} />
-        </TabsContent>
+        {isOwner && (
+          <TabsContent value="library" forceMount className="space-y-6 data-[state=inactive]:hidden">
+            <LibraryTab roots={roots} missingFileBehavior={missingFileBehavior} />
+          </TabsContent>
+        )}
 
-        <TabsContent value="appearance" forceMount className="space-y-6 data-[state=inactive]:hidden">
-          <AppearanceCard />
-          <BrandPaletteCard />
-          <ColorCard />
-        </TabsContent>
+        {isOwner && (
+          <TabsContent value="appearance" forceMount className="space-y-6 data-[state=inactive]:hidden">
+            <AppearanceCard />
+            <BrandPaletteCard />
+            <ColorCard />
+          </TabsContent>
+        )}
 
-        <TabsContent value="jobs" forceMount className="space-y-6 data-[state=inactive]:hidden">
-          <JobsTab jobs={jobs} totalCount={totalCount} initialConcurrencies={concurrencies} />
-        </TabsContent>
+        {isOwner && (
+          <TabsContent value="jobs" forceMount className="space-y-6 data-[state=inactive]:hidden">
+            <JobsTab jobs={jobs} totalCount={totalCount} initialConcurrencies={concurrencies} />
+          </TabsContent>
+        )}
 
-        <TabsContent value="integrations" forceMount className="space-y-6 data-[state=inactive]:hidden">
-          <IntegrationsTab integrations={integrations} smtpConfigured={smtpStatus.configured} kindleConfigured={kindleStatus.configured} />
-        </TabsContent>
+        {isOwner && (
+          <TabsContent value="integrations" forceMount className="space-y-6 data-[state=inactive]:hidden">
+            <IntegrationsTab integrations={integrations} smtpConfigured={smtpStatus.configured} kindleConfigured={kindleStatus.configured} />
+          </TabsContent>
+        )}
 
-        <TabsContent value="backup" forceMount className="space-y-6 data-[state=inactive]:hidden">
-          <BackupTab history={backupHistory} onBackupComplete={(manifest) => { void handleBackupComplete(manifest); }} />
-        </TabsContent>
+        {isOwner && (
+          <TabsContent value="backup" forceMount className="space-y-6 data-[state=inactive]:hidden">
+            <BackupTab history={backupHistory} onBackupComplete={(manifest) => { void handleBackupComplete(manifest); }} />
+          </TabsContent>
+        )}
 
         <TabsContent value="devices" forceMount className="space-y-6 data-[state=inactive]:hidden">
           <KoreaderSyncCard credential={koreaderCredential} />
           <OpdsCredentialsCard credentials={opdsCredentials} />
           <KoboDevicesTab devices={koboDevices} shelves={shelves} />
         </TabsContent>
+
+        {isOwner && (
+          <TabsContent value="users" forceMount className="space-y-6 data-[state=inactive]:hidden">
+            <div className="rounded-lg border p-6">
+              <h2 className="mb-2 text-lg font-semibold">Manage users</h2>
+              <p className="mb-4 text-sm text-muted-foreground">
+                Add allow-listed emails so other people can sign in to your library
+                as viewers.
+              </p>
+              <Link
+                to="/settings/users"
+                className="inline-flex items-center rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground hover:bg-primary/90"
+              >
+                Open Users page
+              </Link>
+            </div>
+          </TabsContent>
+        )}
       </Tabs>
     </div>
   );

--- a/apps/web/src/routes/_authenticated/settings/users.tsx
+++ b/apps/web/src/routes/_authenticated/settings/users.tsx
@@ -1,0 +1,201 @@
+import { useState, type SyntheticEvent } from "react";
+import { createFileRoute, redirect, useRouter } from "@tanstack/react-router";
+import { toast } from "sonner";
+import { Trash2 } from "lucide-react";
+import { Badge } from "~/components/ui/badge";
+import { Button } from "~/components/ui/button";
+import { Input } from "~/components/ui/input";
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "~/components/ui/table";
+import {
+  addAllowedEmailServerFn,
+  listAllowedEmailsServerFn,
+  listUsersServerFn,
+  removeAllowedEmailServerFn,
+  removeUserServerFn,
+} from "~/lib/server-fns/users";
+
+export interface UsersLoaderData {
+  users: Awaited<ReturnType<typeof listUsersServerFn>>;
+  allowedEmails: Awaited<ReturnType<typeof listAllowedEmailsServerFn>>;
+  currentUserId: string;
+}
+
+export const Route = createFileRoute("/_authenticated/settings/users")({
+  beforeLoad: ({ context }) => {
+    const ctx = context as { user?: { roles?: string[] } };
+    if (!ctx.user?.roles?.includes("OWNER")) {
+      throw redirect({ to: "/settings" });
+    }
+  },
+  loader: async ({ context }) => {
+    const ctx = context as { user?: { id: string } | null };
+    const [users, allowedEmails] = await Promise.all([
+      listUsersServerFn(),
+      listAllowedEmailsServerFn(),
+    ]);
+    return {
+      users,
+      allowedEmails,
+      currentUserId: ctx.user?.id ?? "",
+    } satisfies UsersLoaderData;
+  },
+  component: UsersPage,
+});
+
+export function UsersPage() {
+  const { users, allowedEmails, currentUserId } = Route.useLoaderData();
+  const router = useRouter();
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+
+  async function handleAddEmail(e: SyntheticEvent) {
+    e.preventDefault();
+    const trimmed = email.trim();
+    if (!trimmed) return;
+    setSubmitting(true);
+    try {
+      await addAllowedEmailServerFn({ data: { email: trimmed } });
+      toast.success(`Added ${trimmed} to allowlist`);
+      setEmail("");
+      await router.invalidate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to add email");
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function handleRemoveAllowed(id: string) {
+    try {
+      await removeAllowedEmailServerFn({ data: { id } });
+      await router.invalidate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to remove");
+    }
+  }
+
+  async function handleRemoveUser(userId: string) {
+    try {
+      await removeUserServerFn({ data: { userId } });
+      toast.success("User removed");
+      await router.invalidate();
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : "Failed to remove user");
+    }
+  }
+
+  return (
+    <div className="container mx-auto space-y-8 p-6">
+      <div>
+        <h1 className="text-2xl font-bold">Users</h1>
+        <p className="text-muted-foreground">
+          Manage who can access this library.
+        </p>
+      </div>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">Current users</h2>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Name</TableHead>
+              <TableHead>Role</TableHead>
+              <TableHead className="w-24" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {users.map((u) => (
+              <TableRow key={u.id}>
+                <TableCell>{u.email ?? "—"}</TableCell>
+                <TableCell>{u.name ?? "—"}</TableCell>
+                <TableCell>
+                  {u.roles.map((r) => (
+                    <Badge key={r} variant="secondary" className="mr-1">
+                      {r}
+                    </Badge>
+                  ))}
+                </TableCell>
+                <TableCell>
+                  {u.id !== currentUserId && (
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => {
+                        void handleRemoveUser(u.id);
+                      }}
+                      aria-label={`Remove ${u.email ?? u.id}`}
+                    >
+                      <Trash2 className="h-4 w-4" />
+                    </Button>
+                  )}
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+
+      <section>
+        <h2 className="mb-3 text-lg font-semibold">Allow-listed emails</h2>
+        <form
+          onSubmit={(e) => {
+            void handleAddEmail(e);
+          }}
+          className="mb-4 flex gap-2"
+        >
+          <Input
+            type="email"
+            placeholder="viewer@example.com"
+            value={email}
+            onChange={(e) => {
+              setEmail(e.target.value);
+            }}
+            disabled={submitting}
+          />
+          <Button type="submit" disabled={submitting || !email.trim()}>
+            Add
+          </Button>
+        </form>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Email</TableHead>
+              <TableHead>Added</TableHead>
+              <TableHead className="w-24" />
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {allowedEmails.map((entry) => (
+              <TableRow key={entry.id}>
+                <TableCell>{entry.email}</TableCell>
+                <TableCell>
+                  {new Date(entry.createdAt).toLocaleDateString()}
+                </TableCell>
+                <TableCell>
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => {
+                      void handleRemoveAllowed(entry.id);
+                    }}
+                    aria-label={`Remove ${entry.email}`}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </TableCell>
+              </TableRow>
+            ))}
+          </TableBody>
+        </Table>
+      </section>
+    </div>
+  );
+}

--- a/apps/web/src/routes/auth/-routes.test.tsx
+++ b/apps/web/src/routes/auth/-routes.test.tsx
@@ -48,4 +48,11 @@ describe("auth routes", () => {
     await expect(handlers.POST()).resolves.toBeInstanceOf(Response);
     expect(handleLogoutRequestMock).toHaveBeenCalledTimes(2);
   });
+
+  it("renders the access-denied page", async () => {
+    const { Route } = await import("./denied");
+    const Component = Route.options.component as () => React.ReactElement;
+    const element = Component();
+    expect(React.isValidElement(element)).toBe(true);
+  });
 });

--- a/apps/web/src/routes/auth/denied.tsx
+++ b/apps/web/src/routes/auth/denied.tsx
@@ -1,0 +1,18 @@
+import { createFileRoute } from "@tanstack/react-router";
+
+export const Route = createFileRoute("/auth/denied")({
+  component: AccessDeniedPage,
+});
+
+export function AccessDeniedPage() {
+  return (
+    <div>
+      <h1>Access denied</h1>
+      <p>
+        Your email is not authorized to access this Bookhouse library. Ask the
+        library owner to add your email to the allowlist.
+      </p>
+      <a href="/auth/login">Try again with a different account</a>
+    </div>
+  );
+}

--- a/packages/auth/src/errors.ts
+++ b/packages/auth/src/errors.ts
@@ -1,0 +1,6 @@
+export class AuthAccessDeniedError extends Error {
+  constructor(message = "Access denied") {
+    super(message);
+    this.name = "AuthAccessDeniedError";
+  }
+}

--- a/packages/auth/src/index.ts
+++ b/packages/auth/src/index.ts
@@ -1,5 +1,7 @@
 export * from "./config";
+export * from "./errors";
 export * from "./oidc";
+export * from "./roles";
 export * from "./session";
 export * from "./types";
 export * from "./users";

--- a/packages/auth/src/roles.test.ts
+++ b/packages/auth/src/roles.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  OWNER_ROLE,
+  VIEWER_ROLE,
+  getUserRoles,
+  hasRole,
+  isOwner,
+} from "./roles";
+
+describe("role helpers", () => {
+  it("exposes role string constants", () => {
+    expect(OWNER_ROLE).toBe("OWNER");
+    expect(VIEWER_ROLE).toBe("VIEWER");
+  });
+
+  it("returns the list of roles for a user", async () => {
+    const findMany = vi
+      .fn()
+      .mockResolvedValue([{ role: "OWNER" }, { role: "VIEWER" }]);
+
+    const roles = await getUserRoles(
+      { userRole: { findMany } } as never,
+      "user-1",
+    );
+
+    expect(findMany).toHaveBeenCalledWith({
+      where: { userId: "user-1" },
+      select: { role: true },
+    });
+    expect(roles).toEqual(["OWNER", "VIEWER"]);
+  });
+
+  it("returns true when the role exists for the user", async () => {
+    const findUnique = vi.fn().mockResolvedValue({ id: "urole-1" });
+
+    const result = await hasRole(
+      { userRole: { findUnique } } as never,
+      "user-1",
+      "OWNER",
+    );
+
+    expect(findUnique).toHaveBeenCalledWith({
+      where: { userId_role: { userId: "user-1", role: "OWNER" } },
+      select: { id: true },
+    });
+    expect(result).toBe(true);
+  });
+
+  it("returns false when the role is not assigned", async () => {
+    const findUnique = vi.fn().mockResolvedValue(null);
+
+    const result = await hasRole(
+      { userRole: { findUnique } } as never,
+      "user-1",
+      "OWNER",
+    );
+
+    expect(result).toBe(false);
+  });
+
+  it("identifies owner via roles list", () => {
+    expect(isOwner(["OWNER"])).toBe(true);
+    expect(isOwner(["VIEWER"])).toBe(false);
+    expect(isOwner([])).toBe(false);
+  });
+});

--- a/packages/auth/src/roles.ts
+++ b/packages/auth/src/roles.ts
@@ -1,0 +1,35 @@
+import type { PrismaClient } from "@bookhouse/db";
+
+export const OWNER_ROLE = "OWNER";
+export const VIEWER_ROLE = "VIEWER";
+
+type RoleQueryClient = Pick<PrismaClient, "userRole">;
+
+export async function getUserRoles(
+  db: RoleQueryClient,
+  userId: string,
+): Promise<string[]> {
+  const rows = await db.userRole.findMany({
+    where: { userId },
+    select: { role: true },
+  });
+
+  return rows.map((row) => row.role);
+}
+
+export async function hasRole(
+  db: RoleQueryClient,
+  userId: string,
+  role: string,
+): Promise<boolean> {
+  const row = await db.userRole.findUnique({
+    where: { userId_role: { userId, role } },
+    select: { id: true },
+  });
+
+  return row !== null;
+}
+
+export function isOwner(roles: readonly string[]): boolean {
+  return roles.includes(OWNER_ROLE);
+}

--- a/packages/auth/src/types.ts
+++ b/packages/auth/src/types.ts
@@ -42,6 +42,7 @@ export interface AuthenticatedUser {
   image: string | null;
   issuer: string;
   subject: string;
+  roles: string[];
 }
 
 export interface AuthorizationRequestResult {

--- a/packages/auth/src/users.test.ts
+++ b/packages/auth/src/users.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
+import { AuthAccessDeniedError } from "./errors";
 import type { AuthenticatedUser } from "./types";
 import { resolveAuthenticatedUser, upsertOidcUser } from "./users";
 
@@ -12,11 +13,28 @@ interface MockTransactionClient {
     update?: ReturnType<typeof vi.fn>;
     findUnique?: ReturnType<typeof vi.fn>;
     create?: ReturnType<typeof vi.fn>;
+    count?: ReturnType<typeof vi.fn>;
+  };
+  userRole: {
+    findMany?: ReturnType<typeof vi.fn>;
+    create?: ReturnType<typeof vi.fn>;
+  };
+  allowedEmail: {
+    findUnique?: ReturnType<typeof vi.fn>;
   };
 }
 
+const baseConfig = {
+  secret: "a".repeat(32),
+  issuer: "https://issuer.example.com",
+  clientId: "bookhouse",
+  clientSecret: "secret",
+  appUrl: "http://localhost:3000",
+  scopes: ["openid"],
+};
+
 describe("user linking", () => {
-  it("updates an existing identity-linked user", async () => {
+  it("updates an existing identity-linked user and returns roles", async () => {
     const updateUser = vi.fn().mockResolvedValue({
       id: "user-1",
       email: "updated@example.com",
@@ -43,19 +61,18 @@ describe("user linking", () => {
           user: {
             update: updateUser,
           },
+          userRole: {
+            findMany: vi
+              .fn()
+              .mockResolvedValue([{ role: "OWNER" }]),
+          },
+          allowedEmail: {},
         }),
     };
 
     const user = await upsertOidcUser({
       db: db as never,
-      config: {
-        secret: "a".repeat(32),
-        issuer: "https://issuer.example.com",
-        clientId: "bookhouse",
-        clientSecret: "secret",
-        appUrl: "http://localhost:3000",
-        scopes: ["openid"],
-      },
+      config: baseConfig,
       claims: {
         sub: "subject-1",
         email: "updated@example.com",
@@ -81,6 +98,7 @@ describe("user linking", () => {
       image: "https://avatar.example.com/pic.png",
       issuer: "https://issuer.example.com",
       subject: "subject-1",
+      roles: ["OWNER"],
     });
   });
 
@@ -110,19 +128,16 @@ describe("user linking", () => {
           user: {
             update: updateUser,
           },
+          userRole: {
+            findMany: vi.fn().mockResolvedValue([]),
+          },
+          allowedEmail: {},
         }),
     };
 
     await upsertOidcUser({
       db: db as never,
-      config: {
-        secret: "a".repeat(32),
-        issuer: "https://issuer.example.com",
-        clientId: "bookhouse",
-        clientSecret: "secret",
-        appUrl: "http://localhost:3000",
-        scopes: ["openid"],
-      },
+      config: baseConfig,
       claims: {
         sub: "subject-1",
         email: null,
@@ -146,9 +161,17 @@ describe("user linking", () => {
     });
   });
 
-  it("links by verified email when no identity exists", async () => {
+  it("makes the first user the OWNER without checking the allowlist", async () => {
+    const createUser = vi.fn().mockResolvedValue({
+      id: "user-1",
+      email: "owner@example.com",
+      name: "Owner",
+      image: null,
+    });
     const createIdentity = vi.fn().mockResolvedValue(undefined);
-    const createUser = vi.fn();
+    const createRole = vi.fn().mockResolvedValue(undefined);
+    const allowedFindUnique = vi.fn();
+
     const db = {
       $transaction: async (callback: (tx: MockTransactionClient) => Promise<AuthenticatedUser>) =>
         callback({
@@ -157,6 +180,183 @@ describe("user linking", () => {
             create: createIdentity,
           },
           user: {
+            count: vi.fn().mockResolvedValue(0),
+            findUnique: vi.fn().mockResolvedValue(null),
+            create: createUser,
+          },
+          userRole: {
+            create: createRole,
+          },
+          allowedEmail: {
+            findUnique: allowedFindUnique,
+          },
+        }),
+    };
+
+    const user = await upsertOidcUser({
+      db: db as never,
+      config: baseConfig,
+      claims: {
+        sub: "subject-owner",
+        email: "owner@example.com",
+        emailVerified: true,
+        name: "Owner",
+        preferredUsername: null,
+        image: null,
+        raw: { sub: "subject-owner" },
+      },
+    });
+
+    expect(allowedFindUnique).not.toHaveBeenCalled();
+    expect(createRole).toHaveBeenCalledWith({
+      data: { userId: "user-1", role: "OWNER" },
+    });
+    expect(user.roles).toEqual(["OWNER"]);
+  });
+
+  it("rejects a new user whose email is not on the allowlist", async () => {
+    const createUser = vi.fn();
+    const createRole = vi.fn();
+    const db = {
+      $transaction: async (callback: (tx: MockTransactionClient) => Promise<AuthenticatedUser>) =>
+        callback({
+          userIdentity: {
+            findUnique: vi.fn().mockResolvedValue(null),
+            create: vi.fn(),
+          },
+          user: {
+            count: vi.fn().mockResolvedValue(1),
+            findUnique: vi.fn().mockResolvedValue(null),
+            create: createUser,
+          },
+          userRole: { create: createRole },
+          allowedEmail: {
+            findUnique: vi.fn().mockResolvedValue(null),
+          },
+        }),
+    };
+
+    await expect(
+      upsertOidcUser({
+        db: db as never,
+        config: baseConfig,
+        claims: {
+          sub: "subject-viewer",
+          email: "viewer@example.com",
+          emailVerified: true,
+          name: "Viewer",
+          preferredUsername: null,
+          image: null,
+          raw: { sub: "subject-viewer" },
+        },
+      }),
+    ).rejects.toBeInstanceOf(AuthAccessDeniedError);
+
+    expect(createUser).not.toHaveBeenCalled();
+    expect(createRole).not.toHaveBeenCalled();
+  });
+
+  it("creates an allow-listed new user as a VIEWER (case-insensitive email)", async () => {
+    const createUser = vi.fn().mockResolvedValue({
+      id: "user-2",
+      email: "Viewer@Example.com",
+      name: "Viewer",
+      image: null,
+    });
+    const createRole = vi.fn().mockResolvedValue(undefined);
+    const allowedFindUnique = vi
+      .fn()
+      .mockResolvedValue({ id: "allowed-1" });
+
+    const db = {
+      $transaction: async (callback: (tx: MockTransactionClient) => Promise<AuthenticatedUser>) =>
+        callback({
+          userIdentity: {
+            findUnique: vi.fn().mockResolvedValue(null),
+            create: vi.fn().mockResolvedValue(undefined),
+          },
+          user: {
+            count: vi.fn().mockResolvedValue(1),
+            findUnique: vi.fn().mockResolvedValue(null),
+            create: createUser,
+          },
+          userRole: { create: createRole },
+          allowedEmail: { findUnique: allowedFindUnique },
+        }),
+    };
+
+    const user = await upsertOidcUser({
+      db: db as never,
+      config: baseConfig,
+      claims: {
+        sub: "subject-viewer",
+        email: "Viewer@Example.com",
+        emailVerified: true,
+        name: "Viewer",
+        preferredUsername: null,
+        image: null,
+        raw: { sub: "subject-viewer" },
+      },
+    });
+
+    expect(allowedFindUnique).toHaveBeenCalledWith({
+      where: { email: "viewer@example.com" },
+      select: { id: true },
+    });
+    expect(createRole).toHaveBeenCalledWith({
+      data: { userId: "user-2", role: "VIEWER" },
+    });
+    expect(user.roles).toEqual(["VIEWER"]);
+  });
+
+  it("rejects when claims have no email and the user is not first", async () => {
+    const db = {
+      $transaction: async (callback: (tx: MockTransactionClient) => Promise<AuthenticatedUser>) =>
+        callback({
+          userIdentity: {
+            findUnique: vi.fn().mockResolvedValue(null),
+            create: vi.fn(),
+          },
+          user: {
+            count: vi.fn().mockResolvedValue(1),
+            findUnique: vi.fn().mockResolvedValue(null),
+            create: vi.fn(),
+          },
+          userRole: { create: vi.fn() },
+          allowedEmail: { findUnique: vi.fn() },
+        }),
+    };
+
+    await expect(
+      upsertOidcUser({
+        db: db as never,
+        config: baseConfig,
+        claims: {
+          sub: "subject-noemail",
+          email: null,
+          emailVerified: false,
+          name: null,
+          preferredUsername: null,
+          image: null,
+          raw: { sub: "subject-noemail" },
+        },
+      }),
+    ).rejects.toBeInstanceOf(AuthAccessDeniedError);
+  });
+
+  it("links by verified email to an existing user and preserves their roles", async () => {
+    const createIdentity = vi.fn().mockResolvedValue(undefined);
+    const createUser = vi.fn();
+    const createRole = vi.fn();
+    const db = {
+      $transaction: async (callback: (tx: MockTransactionClient) => Promise<AuthenticatedUser>) =>
+        callback({
+          userIdentity: {
+            findUnique: vi.fn().mockResolvedValue(null),
+            create: createIdentity,
+          },
+          user: {
+            count: vi.fn().mockResolvedValue(1),
             findUnique: vi.fn().mockResolvedValue({
               id: "user-2",
               email: "reader@example.com",
@@ -165,19 +365,19 @@ describe("user linking", () => {
             }),
             create: createUser,
           },
+          userRole: {
+            findMany: vi.fn().mockResolvedValue([{ role: "VIEWER" }]),
+            create: createRole,
+          },
+          allowedEmail: {
+            findUnique: vi.fn().mockResolvedValue(null),
+          },
         }),
     };
 
     const user = await upsertOidcUser({
       db: db as never,
-      config: {
-        secret: "a".repeat(32),
-        issuer: "https://issuer.example.com",
-        clientId: "bookhouse",
-        clientSecret: "secret",
-        appUrl: "http://localhost:3000",
-        scopes: ["openid"],
-      },
+      config: baseConfig,
       claims: {
         sub: "subject-2",
         email: "reader@example.com",
@@ -190,6 +390,7 @@ describe("user linking", () => {
     });
 
     expect(createUser).not.toHaveBeenCalled();
+    expect(createRole).not.toHaveBeenCalled();
     expect(createIdentity).toHaveBeenCalledWith({
       data: {
         userId: "user-2",
@@ -199,62 +400,10 @@ describe("user linking", () => {
       },
     });
     expect(user.id).toBe("user-2");
+    expect(user.roles).toEqual(["VIEWER"]);
   });
 
-  it("creates a new user when no verified email match exists", async () => {
-    const createUser = vi.fn().mockResolvedValue({
-      id: "user-3",
-      email: "new@example.com",
-      name: "New User",
-      image: null,
-    });
-    const createIdentity = vi.fn().mockResolvedValue(undefined);
-    const db = {
-      $transaction: async (callback: (tx: MockTransactionClient) => Promise<AuthenticatedUser>) =>
-        callback({
-          userIdentity: {
-            findUnique: vi.fn().mockResolvedValue(null),
-            create: createIdentity,
-          },
-          user: {
-            findUnique: vi.fn().mockResolvedValue(null),
-            create: createUser,
-          },
-        }),
-    };
-
-    const user = await upsertOidcUser({
-      db: db as never,
-      config: {
-        secret: "a".repeat(32),
-        issuer: "https://issuer.example.com",
-        clientId: "bookhouse",
-        clientSecret: "secret",
-        appUrl: "http://localhost:3000",
-        scopes: ["openid"],
-      },
-      claims: {
-        sub: "subject-3",
-        email: "new@example.com",
-        emailVerified: false,
-        name: null,
-        preferredUsername: "new-user",
-        image: null,
-        raw: { sub: "subject-3" },
-      },
-    });
-
-    expect(createUser).toHaveBeenCalledWith({
-      data: {
-        email: "new@example.com",
-        name: "new-user",
-        image: null,
-      },
-    });
-    expect(user.id).toBe("user-3");
-  });
-
-  it("falls back to the email address when a new user has no display name claims", async () => {
+  it("falls back to the email address when a new owner has no display name claims", async () => {
     const createUser = vi.fn().mockResolvedValue({
       id: "user-4",
       email: "email-only@example.com",
@@ -269,22 +418,18 @@ describe("user linking", () => {
             create: vi.fn().mockResolvedValue(undefined),
           },
           user: {
+            count: vi.fn().mockResolvedValue(0),
             findUnique: vi.fn().mockResolvedValue(null),
             create: createUser,
           },
+          userRole: { create: vi.fn().mockResolvedValue(undefined) },
+          allowedEmail: { findUnique: vi.fn() },
         }),
     };
 
     await upsertOidcUser({
       db: db as never,
-      config: {
-        secret: "a".repeat(32),
-        issuer: "https://issuer.example.com",
-        clientId: "bookhouse",
-        clientSecret: "secret",
-        appUrl: "http://localhost:3000",
-        scopes: ["openid"],
-      },
+      config: baseConfig,
       claims: {
         sub: "subject-4",
         email: "email-only@example.com",
@@ -305,7 +450,7 @@ describe("user linking", () => {
     });
   });
 
-  it("resolves an authenticated user from the session", async () => {
+  it("resolves an authenticated user with their roles from the session", async () => {
     const user = await resolveAuthenticatedUser({
       db: {
         user: {
@@ -320,6 +465,7 @@ describe("user linking", () => {
                 providerAccountId: "subject-1",
               },
             ],
+            roles: [{ role: "OWNER" }],
           }),
         },
       } as never,
@@ -337,6 +483,7 @@ describe("user linking", () => {
       image: null,
       issuer: "https://issuer.example.com",
       subject: "subject-1",
+      roles: ["OWNER"],
     });
   });
 
@@ -377,6 +524,7 @@ describe("user linking", () => {
               name: "Reader",
               image: null,
               identities: [],
+              roles: [],
             }),
           },
         } as never,

--- a/packages/auth/src/users.ts
+++ b/packages/auth/src/users.ts
@@ -1,4 +1,6 @@
 import type { Prisma, PrismaClient } from "@bookhouse/db";
+import { AuthAccessDeniedError } from "./errors";
+import { OWNER_ROLE, VIEWER_ROLE } from "./roles";
 import type {
   AuthenticatedUser,
   AuthConfig,
@@ -6,7 +8,10 @@ import type {
   NormalizedOidcClaims,
 } from "./types";
 
-type DatabaseClient = Pick<PrismaClient, "$transaction" | "user">;
+type DatabaseClient = Pick<
+  PrismaClient,
+  "$transaction" | "user" | "userRole" | "allowedEmail"
+>;
 
 function toAuthenticatedUser(input: {
   id: string;
@@ -15,6 +20,7 @@ function toAuthenticatedUser(input: {
   image: string | null;
   issuer: string;
   subject: string;
+  roles: string[];
 }): AuthenticatedUser {
   return {
     id: input.id,
@@ -23,7 +29,15 @@ function toAuthenticatedUser(input: {
     image: input.image,
     issuer: input.issuer,
     subject: input.subject,
+    roles: input.roles,
   };
+}
+
+function normalizeEmail(email: string | null): string | null {
+  if (!email) {
+    return null;
+  }
+  return email.trim().toLowerCase();
 }
 
 export async function upsertOidcUser(input: {
@@ -33,7 +47,19 @@ export async function upsertOidcUser(input: {
 }): Promise<AuthenticatedUser> {
   const { db, config, claims } = input;
 
-  return db.$transaction(async (tx) => {
+  // Normalize the email up front so storage, allowlist lookups, and
+  // email-based account linking are all case-insensitive.
+  const normalizedEmail = normalizeEmail(claims.email);
+  const normalizedClaims: NormalizedOidcClaims = {
+    ...claims,
+    email: normalizedEmail,
+  };
+
+  // Serializable isolation prevents the first-user race: two concurrent
+  // OIDC callbacks would otherwise each see User count = 0 and both
+  // promote themselves to OWNER. Serializable forces one to abort.
+  return db.$transaction(
+    async (tx) => {
     const existingIdentity = await tx.userIdentity.findUnique({
       where: {
         provider_providerAccountId: {
@@ -52,9 +78,9 @@ export async function upsertOidcUser(input: {
           id: existingIdentity.userId,
         },
         data: {
-          email: claims.email ?? existingIdentity.user.email,
-          name: claims.name ?? existingIdentity.user.name,
-          image: claims.image ?? existingIdentity.user.image,
+          email: normalizedClaims.email ?? existingIdentity.user.email,
+          name: normalizedClaims.name ?? existingIdentity.user.name,
+          image: normalizedClaims.image ?? existingIdentity.user.image,
         },
       });
 
@@ -63,8 +89,13 @@ export async function upsertOidcUser(input: {
           id: existingIdentity.id,
         },
         data: {
-          metadata: claims.raw as Prisma.InputJsonValue,
+          metadata: normalizedClaims.raw as Prisma.InputJsonValue,
         },
+      });
+
+      const roleRows = await tx.userRole.findMany({
+        where: { userId: updatedUser.id },
+        select: { role: true },
       });
 
       return toAuthenticatedUser({
@@ -73,15 +104,42 @@ export async function upsertOidcUser(input: {
         name: updatedUser.name,
         image: updatedUser.image,
         issuer: config.issuer,
-        subject: claims.sub,
+        subject: normalizedClaims.sub,
+        roles: roleRows.map((row) => row.role),
       });
     }
 
+    const userCount = await tx.user.count();
+    const isFirstUser = userCount === 0;
+
+    if (!isFirstUser) {
+      const allowed = normalizedEmail
+        ? await tx.allowedEmail.findUnique({
+            where: { email: normalizedEmail },
+            select: { id: true },
+          })
+        : null;
+
+      const linkableExistingUser =
+        normalizedEmail && normalizedClaims.emailVerified
+          ? await tx.user.findUnique({
+              where: { email: normalizedEmail },
+              select: { id: true },
+            })
+          : null;
+
+      if (!allowed && !linkableExistingUser) {
+        throw new AuthAccessDeniedError(
+          "This email is not authorized to access this library.",
+        );
+      }
+    }
+
     const existingUser =
-      claims.email && claims.emailVerified
+      normalizedEmail && normalizedClaims.emailVerified
         ? await tx.user.findUnique({
             where: {
-              email: claims.email,
+              email: normalizedEmail,
             },
           })
         : null;
@@ -90,9 +148,12 @@ export async function upsertOidcUser(input: {
       existingUser ??
       (await tx.user.create({
         data: {
-          email: claims.email,
-          name: claims.name ?? claims.preferredUsername ?? claims.email,
-          image: claims.image,
+          email: normalizedEmail,
+          name:
+            normalizedClaims.name ??
+            normalizedClaims.preferredUsername ??
+            normalizedEmail,
+          image: normalizedClaims.image,
         },
       }));
 
@@ -100,10 +161,28 @@ export async function upsertOidcUser(input: {
       data: {
         userId: user.id,
         provider: config.issuer,
-        providerAccountId: claims.sub,
-        metadata: claims.raw as Prisma.InputJsonValue,
+        providerAccountId: normalizedClaims.sub,
+        metadata: normalizedClaims.raw as Prisma.InputJsonValue,
       },
     });
+
+    let assignedRoles: string[];
+    if (existingUser) {
+      const roleRows = await tx.userRole.findMany({
+        where: { userId: user.id },
+        select: { role: true },
+      });
+      assignedRoles = roleRows.map((row) => row.role);
+    } else {
+      const role = isFirstUser ? OWNER_ROLE : VIEWER_ROLE;
+      await tx.userRole.create({
+        data: {
+          userId: user.id,
+          role,
+        },
+      });
+      assignedRoles = [role];
+    }
 
     return toAuthenticatedUser({
       id: user.id,
@@ -111,9 +190,12 @@ export async function upsertOidcUser(input: {
       name: user.name,
       image: user.image,
       issuer: config.issuer,
-      subject: claims.sub,
+      subject: normalizedClaims.sub,
+      roles: assignedRoles,
     });
-  });
+  },
+    { isolationLevel: "Serializable" },
+  );
 }
 
 export async function resolveAuthenticatedUser(input: {
@@ -132,6 +214,7 @@ export async function resolveAuthenticatedUser(input: {
     },
     include: {
       identities: true,
+      roles: { select: { role: true } },
     },
   });
 
@@ -156,5 +239,6 @@ export async function resolveAuthenticatedUser(input: {
     image: user.image,
     issuer: session.issuer,
     subject: session.subject,
+    roles: user.roles.map((row) => row.role),
   });
 }

--- a/packages/db/prisma/migrations/20260515120000_add_multi_user_accounts/migration.sql
+++ b/packages/db/prisma/migrations/20260515120000_add_multi_user_accounts/migration.sql
@@ -1,0 +1,52 @@
+-- AllowedEmail: pre-approved emails permitted to log in as viewers.
+CREATE TABLE "AllowedEmail" (
+    "id" TEXT NOT NULL,
+    "email" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "createdBy" TEXT,
+
+    CONSTRAINT "AllowedEmail_pkey" PRIMARY KEY ("id")
+);
+
+CREATE UNIQUE INDEX "AllowedEmail_email_key" ON "AllowedEmail"("email");
+
+-- Backfill: if there is exactly one User row (the typical upgrade from
+-- pre-multi-user installs), promote them to OWNER. If there are zero users,
+-- the first login through upsertOidcUser will self-promote. If there are
+-- multiple users (anomalous — possibly stray E2E identities mixed into a dev
+-- DB), DO NOTHING and require the operator to run scripts/promote-owner.ts
+-- explicitly so a stale identity does not silently take over the install.
+INSERT INTO "UserRole" ("id", "userId", "role")
+SELECT
+    'mig_' || md5("User"."id" || '|OWNER'),
+    "User"."id",
+    'OWNER'
+FROM "User"
+WHERE (SELECT COUNT(*) FROM "User") = 1
+  AND NOT EXISTS (
+    SELECT 1 FROM "UserRole"
+    WHERE "UserRole"."userId" = "User"."id" AND "UserRole"."role" = 'OWNER'
+  )
+ON CONFLICT ("id") DO NOTHING;
+
+-- Assign any existing collections without an owner to the owner we just
+-- promoted (or any pre-existing owner, if the OWNER role was already set).
+UPDATE "Collection"
+SET "ownerUserId" = (
+    SELECT "userId" FROM "UserRole"
+    WHERE "role" = 'OWNER'
+    ORDER BY "id" ASC
+    LIMIT 1
+)
+WHERE "ownerUserId" IS NULL
+  AND EXISTS (SELECT 1 FROM "UserRole" WHERE "role" = 'OWNER');
+
+-- Cascade-delete Collections when their owner User is deleted. Without this,
+-- the optional FK defaults to SET NULL, leaving orphaned per-user shelves
+-- that nobody can see or clean up.
+ALTER TABLE "Collection"
+DROP CONSTRAINT IF EXISTS "Collection_ownerUserId_fkey";
+
+ALTER TABLE "Collection"
+ADD CONSTRAINT "Collection_ownerUserId_fkey"
+FOREIGN KEY ("ownerUserId") REFERENCES "User"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -175,6 +175,13 @@ model UserRole {
   @@unique([userId, role])
 }
 
+model AllowedEmail {
+  id        String   @id @default(cuid())
+  email     String   @unique
+  createdAt DateTime @default(now())
+  createdBy String?
+}
+
 model LibraryRoot {
   id            String            @id @default(cuid())
   name          String
@@ -340,7 +347,7 @@ model Collection {
   kind         CollectionKind    @default(MANUAL)
   formatFilter ShelfFormatFilter @default(ALL)
 
-  ownerUser             User?                  @relation(fields: [ownerUserId], references: [id])
+  ownerUser             User?                  @relation(fields: [ownerUserId], references: [id], onDelete: Cascade)
   items                 CollectionItem[]
   koboDeviceCollections KoboDeviceCollection[]
 }

--- a/scripts/check-user-roles.ts
+++ b/scripts/check-user-roles.ts
@@ -1,0 +1,45 @@
+/**
+ * Diagnostic: prints all users + their roles + their identities.
+ * Run with: pnpm --filter @bookhouse/db exec tsx ../../scripts/check-user-roles.ts
+ * Or from the repo root with the .env loaded.
+ */
+import { db } from "@bookhouse/db";
+
+async function main(): Promise<void> {
+  const users = await db.user.findMany({
+    include: {
+      roles: { select: { role: true } },
+      identities: {
+        select: { provider: true, providerAccountId: true },
+      },
+    },
+    orderBy: { createdAt: "asc" },
+  });
+
+  console.log(`Found ${users.length} user(s):\n`);
+
+  for (const u of users) {
+    console.log(`  id:        ${u.id}`);
+    console.log(`  email:     ${u.email ?? "(null)"}`);
+    console.log(`  name:      ${u.name ?? "(null)"}`);
+    console.log(`  createdAt: ${u.createdAt.toISOString()}`);
+    console.log(`  roles:     ${u.roles.map((r) => r.role).join(", ") || "(none)"}`);
+    for (const i of u.identities) {
+      console.log(`  identity:  provider=${i.provider} sub=${i.providerAccountId}`);
+    }
+    console.log("");
+  }
+
+  const allowed = await db.allowedEmail.findMany({ orderBy: { createdAt: "asc" } });
+  console.log(`AllowedEmail entries: ${allowed.length}`);
+  for (const a of allowed) {
+    console.log(`  - ${a.email}`);
+  }
+
+  await db.$disconnect();
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/promote-owner.ts
+++ b/scripts/promote-owner.ts
@@ -1,0 +1,81 @@
+/**
+ * Promotes the user with the given email to OWNER role. Idempotent.
+ *
+ * Usage:
+ *   pnpm --filter @bookhouse/web exec tsx ../../scripts/promote-owner.ts <email>
+ *
+ * Optional second argument: --delete-others to remove all other users (use
+ * with care — cascade-deletes their shelves, reading progress, devices, etc.).
+ */
+import { db } from "@bookhouse/db";
+
+async function main(): Promise<void> {
+  const email = process.argv[2];
+  const deleteOthers = process.argv[3] === "--delete-others";
+
+  if (!email) {
+    console.error("Usage: promote-owner.ts <email> [--delete-others]");
+    process.exit(1);
+  }
+
+  const normalized = email.trim().toLowerCase();
+  const user = await db.user.findUnique({
+    where: { email: normalized },
+    include: { roles: { select: { role: true } } },
+  });
+
+  if (!user) {
+    // Try case-insensitive fallback in case existing rows weren't normalized.
+    const candidates = await db.user.findMany({
+      where: { email: { equals: email, mode: "insensitive" } },
+    });
+    if (candidates.length === 0) {
+      console.error(`No user found with email ${email}`);
+      process.exit(1);
+    }
+    if (candidates.length > 1) {
+      console.error(
+        `Multiple users found with email ${email} (case-insensitive). Pick one and run with that exact casing.`,
+      );
+      for (const c of candidates) {
+        console.error(`  - ${c.id}  ${c.email}`);
+      }
+      process.exit(1);
+    }
+    console.log(
+      `Using case-insensitive match: ${candidates[0]!.email} (${candidates[0]!.id})`,
+    );
+  }
+
+  const target = user ?? (await db.user.findFirst({
+    where: { email: { equals: email, mode: "insensitive" } },
+    include: { roles: { select: { role: true } } },
+  }))!;
+
+  if (target.roles.some((r) => r.role === "OWNER")) {
+    console.log(`${target.email} already has OWNER role.`);
+  } else {
+    await db.userRole.create({
+      data: { userId: target.id, role: "OWNER" },
+    });
+    console.log(`Promoted ${target.email} to OWNER.`);
+  }
+
+  if (deleteOthers) {
+    const others = await db.user.findMany({
+      where: { id: { not: target.id } },
+      select: { id: true, email: true },
+    });
+    for (const o of others) {
+      await db.user.delete({ where: { id: o.id } });
+      console.log(`Deleted user ${o.email ?? o.id}`);
+    }
+  }
+
+  await db.$disconnect();
+}
+
+main().catch((err: unknown) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

Adds OIDC-based multi-user support. The first/only user becomes **OWNER** (full read/write); additional users are pre-approved by email allowlist and get **VIEWER** (read + download only). Existing single-user installs upgrade transparently — the migration promotes the existing user to OWNER and backfills shelf ownership.

## What's new

**Roles**
- New `AllowedEmail` table; existing `UserRole` table now used with `OWNER` / `VIEWER` strings.
- `requireOwner` / `requireAuthenticated` helpers gate every write surface and per-user resource.
- `Collection.ownerUser` FK changed to `ON DELETE CASCADE` to clean up shelves when a viewer is removed.

**Auth flow**
- `upsertOidcUser`: first user becomes OWNER; subsequent logins gated by allowlist. Transaction is `Serializable` (prevents two concurrent first-logins both becoming OWNER). Emails normalized to lowercase for case-insensitive matching.
- Denied logins land on a new `/auth/denied` page.
- `AuthenticatedUser` now carries `roles[]`. Sidebar hides owner-only nav for viewers; Settings page shows only the Devices tab.

**Server-fn / API gates**
- Every write server-fn (editing, deletion, library-roots, app-settings, duplicates, enrichment, bulk-enrich, match-suggestions, integrations, smtp, kindle, backup, authors enrichment / photo upload, library-health) checks `ownerOnly()`.
- API routes `/api/backup/{download,upload}`, `/api/upload-cover/[workId]`, `/api/upload-author-photo/[contributorId]` are owner-gated.
- Auth middleware now also enforces session on `/_serverFn/*` (previously only `/api/*` was protected — unauthenticated callers could read server-fn data directly).
- Shelves, OPDS credentials, and Kobo devices now verify ownership before any mutation (previously accepted arbitrary IDs).

**Operator tools**
- `scripts/check-user-roles.ts` — diagnose user / role state.
- `scripts/promote-owner.ts <email> [--delete-others]` — fallback for upgrade scenarios the migration intentionally won't handle (DB with 2+ pre-existing users, e.g. stray E2E identities).

## Upgrade procedure

- Production with exactly one existing user: migration auto-promotes them to OWNER. No action needed.
- Fresh install (zero users): first OIDC login self-promotes.
- Multi-user dev DBs with stray identities: run `scripts/promote-owner.ts <email>`. Migration intentionally does nothing in this case so a stale identity can't silently take over.
- Documented in `CLAUDE.md` (local notes).

## Test plan

- [ ] Manual: log in as owner via Pocket ID. Confirm all nav items / settings tabs visible.
- [ ] Manual: Settings → Users → add a second email. Log in with that account. Confirm viewer sees only library / series / authors / shelves / settings → devices.
- [ ] Manual: viewer tries to call `deleteWorkServerFn` directly → returns 403.
- [ ] Manual: viewer downloads a file from the library → succeeds.
- [ ] Manual: each user's shelves and reading progress are isolated.
- [ ] Manual: owner removes a viewer → viewer's shelves cascade-delete; their Kobo / OPDS / Koreader credentials cascade-delete; their session no longer resolves.