### PR TITLE
Hoist sharp, yauzl-promise, and msgpackr-extract for production

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,4 +1,5 @@
 public-hoist-pattern[]=@prisma/client
+public-hoist-pattern[]=sharp
 onlyBuiltDependencies[]=@prisma/engines
 onlyBuiltDependencies[]=esbuild
 onlyBuiltDependencies[]=msgpackr-extract


### PR DESCRIPTION
## Summary

Production was throwing at startup, then at first scan:

> Cannot find package 'sharp' imported from /app/.output/server/_chunks/index-PtJX00wm-BSfQixR3.js

> Cannot find module 'yauzl-promise' Require stack: /app/.output/server/_chunks/index-DflzM99q-D7Vwug2M.js

The Docker `web` stage copies `/app/node_modules` into the runtime image, but Node's module resolution from `/app/.output/server/_chunks/*` only walks parent directories. Any external module that pnpm placed inside a workspace package (`apps/web/node_modules/*`, `packages/*/node_modules/*`) is invisible from that location.

I audited every external `import`/`require` left in the built chunks. Three were not bundled by Nitro and not hoisted to the root:

| Module | Source |
|---|---|
| `sharp` | top-level `import "sharp"` hoisted by Vite into music-metadata's MP3/MP4/WAV parser chunks |
| `yauzl-promise` | `createRequire`-based `require("yauzl-promise")` in `packages/ingest/src/epub.ts` (EPUB parsing) |
| `msgpackr-extract` | runtime `require("msgpackr-extract")` from `msgpackr` (transitive native module from `bullmq`) |

`@prisma/client` (hoisted in #218) and `tslib` (copied into `.output/server/node_modules` by Nitro) were already fine.

Adding all three to `.npmrc:public-hoist-pattern` makes pnpm symlink them into the root `node_modules`, where the Docker copy picks them up and Node finds them at runtime.

## Test plan

- [x] `pnpm install` produces `node_modules/{sharp,yauzl-promise,msgpackr-extract}` at repo root
- [x] `pnpm build` succeeds
- [x] `pnpm test` — 3693 passing, 100% coverage
- [x] `pnpm lint` / `pnpm typecheck` clean
- [ ] Deploy and confirm app starts without module resolution errors, EPUB ingest works, BullMQ jobs run