### PR TITLE
Hoist yauzl-promise and msgpackr-extract for production

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,5 +1,7 @@
 public-hoist-pattern[]=@prisma/client
 public-hoist-pattern[]=sharp
+public-hoist-pattern[]=yauzl-promise
+public-hoist-pattern[]=msgpackr-extract
 onlyBuiltDependencies[]=@prisma/engines
 onlyBuiltDependencies[]=esbuild
 onlyBuiltDependencies[]=msgpackr-extract


### PR DESCRIPTION
## Summary

Production after #221 hit:

> Cannot find module 'yauzl-promise' Require stack: /app/.output/server/_chunks/index-DflzM99q-D7Vwug2M.js

Same root cause as #218 (prisma) and #221 (sharp): pnpm places these modules inside workspace package `node_modules` directories, but Node's resolution from `/app/.output/server/_chunks/*` only walks parent directories, so anything outside the root `node_modules` is invisible.

I audited every external `import`/`require` left in the built chunks. Beyond `sharp` (#221) and `@prisma/client` (#218), two more were unreachable:

| Module | Source |
|---|---|
| `yauzl-promise` | `createRequire`-based `require("yauzl-promise")` in `packages/ingest/src/epub.ts` (EPUB metadata parsing) |
| `msgpackr-extract` | runtime `require("msgpackr-extract")` inside `msgpackr` — transitive native module from `bullmq`, fires when queue jobs run |

Sorry for the back-and-forth — I should have caught all three together when investigating the sharp issue instead of fixing only the reported symptom.

## Test plan

- [x] `pnpm install` produces `node_modules/{yauzl-promise,msgpackr-extract}` at repo root
- [x] `pnpm build` succeeds
- [x] `pnpm test` — 3693 passing, 100% coverage
- [x] `pnpm lint` / `pnpm typecheck` clean
- [ ] Deploy and confirm EPUB ingest works + BullMQ jobs run without module resolution errors