### PR TITLE
Track standalone batch ImportJob lifecycle and add worker observability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ coverage/
 .idea/
 *.swp
 *.swo
+.claude/
 
 # OS
 .DS_Store

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,7 @@
+services:
+  db:
+    ports:
+      - "5432:5432"
+  queue:
+    ports:
+      - "6379:6379"

--- a/scripts/strip-paren-numbers.sh
+++ b/scripts/strip-paren-numbers.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Recursively rename files and directories under the current working
+# directory, stripping " (NNN)" patterns (a literal space + parens with
+# one or more digits inside). Multiple occurrences per name are all
+# stripped. Names that don't contain the pattern are left alone.
+#
+# Usage:
+#   ./strip-paren-numbers.sh           # dry-run, prints what would change
+#   ./strip-paren-numbers.sh --apply   # actually rename
+#
+# Depth-first so we rename children before their parent directories.
+
+set -euo pipefail
+
+APPLY=0
+if [[ "${1:-}" == "--apply" ]]; then
+  APPLY=1
+fi
+
+# -depth: process directory contents before the directory itself
+# -print0 / read -d '': handle names containing spaces, newlines, etc.
+find . -depth -mindepth 1 -print0 |
+while IFS= read -r -d '' path; do
+  base=$(basename "$path")
+  parent=$(dirname "$path")
+
+  # Strip every occurrence of optional-space + (digits).
+  # The leading [[:space:]]* eats the space that usually precedes the
+  # parens so we don't leave a trailing space behind.
+  new_base=$(printf '%s' "$base" | perl -pe 's/[[:space:]]*\(\d+\)//g')
+
+  # Also collapse any leftover trailing whitespace.
+  new_base=$(printf '%s' "$new_base" | perl -pe 's/[[:space:]]+$//')
+
+  if [[ "$base" == "$new_base" ]]; then
+    continue
+  fi
+
+  if [[ -z "$new_base" ]]; then
+    echo "SKIP (would be empty): $path"
+    continue
+  fi
+
+  new_path="$parent/$new_base"
+
+  if [[ -e "$new_path" ]]; then
+    echo "SKIP (target exists): $path -> $new_path"
+    continue
+  fi
+
+  if [[ "$APPLY" == "1" ]]; then
+    mv -- "$path" "$new_path"
+    echo "RENAMED: $path -> $new_path"
+  else
+    echo "WOULD: $path -> $new_path"
+  fi
+done
+
+if [[ "$APPLY" == "0" ]]; then
+  echo ""
+  echo "Dry run. Re-run with --apply to perform the renames."
+fi

--- a/workers/library-worker/src/enrichment-worker.ts
+++ b/workers/library-worker/src/enrichment-worker.ts
@@ -41,6 +41,7 @@ import {
   getQueueConnectionConfig,
 } from "@bookhouse/shared";
 import { fileURLToPath } from "node:url";
+import { recordBatchJobProgress } from "./import-job-progress.js";
 
 const logger = createLogger("enrichment-worker");
 
@@ -373,20 +374,6 @@ const defaultHandlers: EnrichmentWorkerHandlers = {
   processBulkEnrichWork,
 };
 
-async function checkBatchCompletion(importJobId: string): Promise<void> {
-  const job = await db.importJob.findUnique({
-    where: { id: importJobId },
-    select: { totalFiles: true, processedFiles: true },
-  });
-  if (job && job.totalFiles !== null && job.processedFiles !== null && job.processedFiles >= job.totalFiles) {
-    await db.importJob.update({
-      where: { id: importJobId },
-      data: { status: "SUCCEEDED", finishedAt: new Date() },
-    });
-    logger.info({ importJobId }, "Author photo enrichment batch completed");
-  }
-}
-
 const ENRICHMENT_ERROR_STATUSES = new Set(["no-results", "no-photo", "not-found", "no-editions"]);
 
 export function createEnrichmentWorkerProcessor(
@@ -403,29 +390,15 @@ export function createEnrichmentWorkerProcessor(
       logger.info({ jobId: job.id, jobName: job.name, status: result.status, ...extra }, "Enrichment job completed");
       if (importJobId) {
         const isError = ENRICHMENT_ERROR_STATUSES.has(result.status);
-        await db.importJob.update({
-          where: { id: importJobId },
-          data: {
-            status: "RUNNING",
-            startedAt: new Date(),
-            processedFiles: { increment: 1 },
-            ...(isError ? { errorCount: { increment: 1 } } : {}),
-          },
-        });
-        await checkBatchCompletion(importJobId);
+        await recordBatchJobProgress(importJobId, isError);
       }
       return result;
     } catch (error) {
       logger.error({ jobId: job.id, jobName: job.name, err: error }, "Enrichment job failed");
       if (importJobId) {
-        await db.importJob.update({
-          where: { id: importJobId },
-          data: {
-            status: "RUNNING",
-            processedFiles: { increment: 1 },
-            errorCount: { increment: 1 },
-          },
-        }).catch(() => { /* ImportJob update is best-effort */ });
+        await recordBatchJobProgress(importJobId, true).catch(() => {
+          /* ImportJob update is best-effort */
+        });
       }
       throw error;
     }

--- a/workers/library-worker/src/import-job-progress.test.ts
+++ b/workers/library-worker/src/import-job-progress.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const updateMock = vi.fn();
+const findUniqueMock = vi.fn();
+
+vi.mock("@bookhouse/db", () => ({
+  db: {
+    importJob: {
+      update: updateMock,
+      findUnique: findUniqueMock,
+    },
+  },
+}));
+
+beforeEach(() => {
+  updateMock.mockReset();
+  updateMock.mockResolvedValue({});
+  findUniqueMock.mockReset();
+});
+
+describe("recordBatchJobProgress", () => {
+  it("increments processedFiles and sets RUNNING on success", async () => {
+    findUniqueMock.mockResolvedValue({ totalFiles: 10, processedFiles: 1 });
+    const { recordBatchJobProgress } = await import("./import-job-progress");
+
+    await recordBatchJobProgress("ij-1", false);
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: "ij-1" },
+      data: {
+        status: "RUNNING",
+        startedAt: expect.any(Date) as Date,
+        processedFiles: { increment: 1 },
+      },
+    });
+  });
+
+  it("increments errorCount alongside processedFiles when isError is true", async () => {
+    findUniqueMock.mockResolvedValue({ totalFiles: 10, processedFiles: 1 });
+    const { recordBatchJobProgress } = await import("./import-job-progress");
+
+    await recordBatchJobProgress("ij-2", true);
+
+    expect(updateMock).toHaveBeenCalledWith({
+      where: { id: "ij-2" },
+      data: {
+        status: "RUNNING",
+        startedAt: expect.any(Date) as Date,
+        processedFiles: { increment: 1 },
+        errorCount: { increment: 1 },
+      },
+    });
+  });
+
+  it("marks SUCCEEDED when processedFiles reaches totalFiles", async () => {
+    findUniqueMock.mockResolvedValue({ totalFiles: 5, processedFiles: 5 });
+    const { recordBatchJobProgress } = await import("./import-job-progress");
+
+    await recordBatchJobProgress("ij-3", false);
+
+    expect(updateMock).toHaveBeenCalledTimes(2);
+    expect(updateMock).toHaveBeenLastCalledWith({
+      where: { id: "ij-3" },
+      data: { status: "SUCCEEDED", finishedAt: expect.any(Date) as Date },
+    });
+  });
+
+  it("does not mark SUCCEEDED when processedFiles is below totalFiles", async () => {
+    findUniqueMock.mockResolvedValue({ totalFiles: 5, processedFiles: 3 });
+    const { recordBatchJobProgress } = await import("./import-job-progress");
+
+    await recordBatchJobProgress("ij-4", false);
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark SUCCEEDED when ImportJob is missing", async () => {
+    findUniqueMock.mockResolvedValue(null);
+    const { recordBatchJobProgress } = await import("./import-job-progress");
+
+    await recordBatchJobProgress("ij-5", false);
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark SUCCEEDED when totalFiles is null", async () => {
+    findUniqueMock.mockResolvedValue({ totalFiles: null, processedFiles: 5 });
+    const { recordBatchJobProgress } = await import("./import-job-progress");
+
+    await recordBatchJobProgress("ij-6", false);
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not mark SUCCEEDED when processedFiles is null", async () => {
+    findUniqueMock.mockResolvedValue({ totalFiles: 10, processedFiles: null });
+    const { recordBatchJobProgress } = await import("./import-job-progress");
+
+    await recordBatchJobProgress("ij-7", false);
+
+    expect(updateMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/workers/library-worker/src/import-job-progress.ts
+++ b/workers/library-worker/src/import-job-progress.ts
@@ -1,0 +1,31 @@
+import { db } from "@bookhouse/db";
+
+export async function recordBatchJobProgress(
+  importJobId: string,
+  isError: boolean,
+): Promise<void> {
+  await db.importJob.update({
+    where: { id: importJobId },
+    data: {
+      status: "RUNNING",
+      startedAt: new Date(),
+      processedFiles: { increment: 1 },
+      ...(isError ? { errorCount: { increment: 1 } } : {}),
+    },
+  });
+  const job = await db.importJob.findUnique({
+    where: { id: importJobId },
+    select: { totalFiles: true, processedFiles: true },
+  });
+  if (
+    job &&
+    job.totalFiles !== null &&
+    job.processedFiles !== null &&
+    job.processedFiles >= job.totalFiles
+  ) {
+    await db.importJob.update({
+      where: { id: importJobId },
+      data: { status: "SUCCEEDED", finishedAt: new Date() },
+    });
+  }
+}

--- a/workers/library-worker/src/index.test.ts
+++ b/workers/library-worker/src/index.test.ts
@@ -27,6 +27,7 @@ const detectDuplicatesMock = vi.fn();
 const matchSuggestionsMock = vi.fn();
 const importJobUpdateMock = vi.fn();
 const importJobUpdateManyMock = vi.fn();
+const importJobFindUniqueMock = vi.fn();
 const appSettingFindUniqueMock = vi.fn();
 const enqueueLibraryJobMock = vi.fn();
 
@@ -75,6 +76,7 @@ vi.mock("@bookhouse/db", () => ({
     importJob: {
       update: importJobUpdateMock,
       updateMany: importJobUpdateManyMock,
+      findUnique: importJobFindUniqueMock,
     },
   },
 }));
@@ -149,6 +151,8 @@ beforeEach(() => {
   importJobUpdateMock.mockResolvedValue({});
   importJobUpdateManyMock.mockReset();
   importJobUpdateManyMock.mockResolvedValue({ count: 0 });
+  importJobFindUniqueMock.mockReset();
+  importJobFindUniqueMock.mockResolvedValue(null);
   enqueueLibraryJobMock.mockReset();
   matchFileAssetToEditionMock.mockReset();
   onMock.mockReset();
@@ -363,7 +367,7 @@ describe("library worker", () => {
     });
   });
 
-  it("does not set RUNNING or update parent progress for child jobs with importJobId", async () => {
+  it("does not set RUNNING or update parent progress for scan-child jobs with importJobId", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({
       hashFileAsset: hashFileAssetMock,
@@ -377,7 +381,7 @@ describe("library worker", () => {
 
     hashFileAssetMock.mockResolvedValueOnce("hash-result");
     const mockJob = createMockJob({
-      data: { fileAssetId: "file-1", importJobId: "ij-child" },
+      data: { fileAssetId: "file-1", importJobId: "ij-child", scanJobId: "scan-1", scanQueueName: "bull:library" },
       name: "hash-file-asset",
     });
     await processor(mockJob as never);
@@ -1003,7 +1007,7 @@ describe("library worker", () => {
     }));
   });
 
-  it("marks the parent scan FAILED when a child job exhausts retries", async () => {
+  it("marks the parent scan FAILED when a scan-child job exhausts retries", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({
       hashFileAsset: hashFileAssetMock,
@@ -1019,7 +1023,7 @@ describe("library worker", () => {
 
     await expect(
       processor(createMockJob({
-        data: { fileAssetId: "file-1", importJobId: "ij-child-fail" },
+        data: { fileAssetId: "file-1", importJobId: "ij-child-fail", scanJobId: "scan-1", scanQueueName: "bull:library" },
         opts: { attempts: 1 },
         name: "hash-file-asset",
       }) as never),
@@ -1037,7 +1041,7 @@ describe("library worker", () => {
     });
   });
 
-  it("records String(error) for final child job failures when opts are missing", async () => {
+  it("records String(error) for final scan-child job failures when opts are missing", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({
       hashFileAsset: hashFileAssetMock,
@@ -1053,7 +1057,7 @@ describe("library worker", () => {
 
     await expect(
       processor(createMockJob({
-        data: { fileAssetId: "file-1", importJobId: "ij-child-string-fail" },
+        data: { fileAssetId: "file-1", importJobId: "ij-child-string-fail", scanJobId: "scan-1", scanQueueName: "bull:library" },
         name: "hash-file-asset",
         opts: {},
       }) as never),
@@ -1071,7 +1075,7 @@ describe("library worker", () => {
     });
   });
 
-  it("marks ImportJob FAILED for final child failure", async () => {
+  it("marks ImportJob FAILED for final scan-child failure", async () => {
     const { createLibraryWorkerProcessor } = await import("./index");
     const processor = createLibraryWorkerProcessor({
       hashFileAsset: hashFileAssetMock,
@@ -1087,7 +1091,7 @@ describe("library worker", () => {
 
     await expect(
       processor(createMockJob({
-        data: { fileAssetId: "file-1", importJobId: "ij-child-no-parent" },
+        data: { fileAssetId: "file-1", importJobId: "ij-child-no-parent", scanJobId: "scan-1", scanQueueName: "bull:library" },
         opts: { attempts: 1 },
         name: "hash-file-asset",
       }) as never),
@@ -1121,7 +1125,7 @@ describe("library worker", () => {
 
     await expect(
       processor(createMockJob({
-        data: { fileAssetId: "file-1", importJobId: "ij-child-retry" },
+        data: { fileAssetId: "file-1", importJobId: "ij-child-retry", scanJobId: "scan-1", scanQueueName: "bull:library" },
         opts: { attempts: 3 },
         attemptsMade: 0,
         name: "hash-file-asset",
@@ -1131,6 +1135,99 @@ describe("library worker", () => {
     expect(importJobUpdateMock).not.toHaveBeenCalledWith(expect.objectContaining({
       where: expect.objectContaining({ id: "ij-child-retry" }) as object,
     }));
+  });
+
+  it("increments processedFiles and sets RUNNING for standalone batch job on success", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+
+    matchSuggestionsMock.mockResolvedValueOnce({ fileAssetId: "file-1", skipped: false, linksCreated: 0 });
+    importJobFindUniqueMock.mockResolvedValue({ totalFiles: 5, processedFiles: 1 });
+
+    await processor(createMockJob({
+      data: { fileAssetId: "file-1", importJobId: "ij-batch" },
+      name: "match-suggestions",
+    }) as never);
+
+    expect(importJobUpdateMock).toHaveBeenCalledTimes(1);
+    expect(importJobUpdateMock).toHaveBeenCalledWith({
+      where: { id: "ij-batch" },
+      data: {
+        status: "RUNNING",
+        startedAt: expect.any(Date) as Date,
+        processedFiles: { increment: 1 },
+      },
+    });
+  });
+
+  it("marks standalone batch ImportJob SUCCEEDED when last job completes", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+
+    matchSuggestionsMock.mockResolvedValueOnce({ fileAssetId: "file-1", skipped: false, linksCreated: 0 });
+    importJobFindUniqueMock.mockResolvedValue({ totalFiles: 1, processedFiles: 1 });
+
+    await processor(createMockJob({
+      data: { fileAssetId: "file-1", importJobId: "ij-batch-done" },
+      name: "match-suggestions",
+    }) as never);
+
+    expect(importJobUpdateMock).toHaveBeenCalledTimes(2);
+    expect(importJobUpdateMock).toHaveBeenLastCalledWith({
+      where: { id: "ij-batch-done" },
+      data: { status: "SUCCEEDED", finishedAt: expect.any(Date) as Date },
+    });
+  });
+
+  it("soft-fails standalone batch ImportJob on final-attempt failure (errorCount, not FAILED)", async () => {
+    const { createLibraryWorkerProcessor } = await import("./index");
+    const processor = createLibraryWorkerProcessor({
+      hashFileAsset: hashFileAssetMock,
+      matchFileAssetToEdition: matchFileAssetToEditionMock,
+      parseFileAssetMetadata: parseFileAssetMetadataMock,
+      processCoverForWork: processCoverForWorkMock,
+      scanLibraryRoot: scanLibraryRootMock,
+      detectDuplicates: detectDuplicatesMock,
+      matchSuggestions: matchSuggestionsMock,
+    });
+
+    matchSuggestionsMock.mockRejectedValueOnce(new Error("suggestion boom"));
+    importJobFindUniqueMock.mockResolvedValue({ totalFiles: 5, processedFiles: 1 });
+
+    await expect(
+      processor(createMockJob({
+        data: { fileAssetId: "file-1", importJobId: "ij-batch-fail" },
+        opts: { attempts: 1 },
+        name: "match-suggestions",
+      }) as never),
+    ).rejects.toThrow("suggestion boom");
+
+    expect(importJobUpdateManyMock).not.toHaveBeenCalled();
+    expect(importJobUpdateMock).toHaveBeenCalledWith({
+      where: { id: "ij-batch-fail" },
+      data: {
+        status: "RUNNING",
+        startedAt: expect.any(Date) as Date,
+        processedFiles: { increment: 1 },
+        errorCount: { increment: 1 },
+      },
+    });
   });
 
   it("creates and shuts down a redis-backed worker", async () => {
@@ -1165,10 +1262,12 @@ describe("library worker", () => {
 
     bootstrapLibraryWorker();
 
-    expect(onMock).toHaveBeenCalledTimes(3);
+    expect(onMock).toHaveBeenCalledTimes(5);
     expect(onMock).toHaveBeenNthCalledWith(1, "ready", expect.any(Function));
-    expect(onMock).toHaveBeenNthCalledWith(2, "completed", expect.any(Function));
-    expect(onMock).toHaveBeenNthCalledWith(3, "failed", expect.any(Function));
+    expect(onMock).toHaveBeenNthCalledWith(2, "active", expect.any(Function));
+    expect(onMock).toHaveBeenNthCalledWith(3, "completed", expect.any(Function));
+    expect(onMock).toHaveBeenNthCalledWith(4, "failed", expect.any(Function));
+    expect(onMock).toHaveBeenNthCalledWith(5, "stalled", expect.any(Function));
     expect(processOnSpy).toHaveBeenCalledWith("SIGINT", expect.any(Function));
     expect(processOnSpy).toHaveBeenCalledWith("SIGTERM", expect.any(Function));
 
@@ -1187,12 +1286,18 @@ describe("library worker", () => {
     const readyCallback = onMock.mock.calls.find(([e]) => e === "ready")?.[1] as () => void;
     readyCallback();
 
+    const activeCallback = onMock.mock.calls.find(([e]) => e === "active")?.[1] as (job: { id?: string; name?: string }) => void;
+    activeCallback({ id: "job-1", name: "scan-library-root" });
+
     const completedCallback = onMock.mock.calls.find(([e]) => e === "completed")?.[1] as (job: { id?: string; name?: string } | undefined) => void;
     completedCallback({ id: "job-1", name: "scan-library-root" });
 
     const failedCallback = onMock.mock.calls.find(([e]) => e === "failed")?.[1] as (job: { id?: string; name?: string } | undefined, err: Error) => void;
     failedCallback({ id: "job-1", name: "scan-library-root" }, new Error("disk full"));
     failedCallback(undefined, new Error("no job ref"));
+
+    const stalledCallback = onMock.mock.calls.find(([e]) => e === "stalled")?.[1] as (jobId: string) => void;
+    stalledCallback("stalled-job-1");
 
     processOnSpy.mockRestore();
     processExitSpy.mockRestore();

--- a/workers/library-worker/src/index.ts
+++ b/workers/library-worker/src/index.ts
@@ -20,6 +20,7 @@ import {
   enqueueLibraryJob,
   getQueueConnectionConfig,
 } from "@bookhouse/shared";
+import { recordBatchJobProgress } from "./import-job-progress.js";
 
 const logger = createLogger("library-worker");
 
@@ -188,8 +189,13 @@ export function createLibraryWorkerProcessor(
     job: Job<LibraryJobPayload<LibraryJobName>, LibraryJobResult, LibraryJobName>,
     token?: string,
   ) => {
-  const importJobId = (job.data as BaseJobPayload).importJobId;
+  const basePayload = job.data as BaseJobPayload;
+  const importJobId = basePayload.importJobId;
   const isScanJob = job.name === LIBRARY_JOB_NAMES.SCAN_LIBRARY_ROOT;
+  // A standalone batch job is a non-scan job with its own ImportJob (e.g. re-match,
+  // bulk enrich) — it has no scanJobId because it wasn't enqueued under a scan root.
+  // Scan-children carry scanJobId via the wrapped enqueue in createJobHandlers.
+  const isStandaloneBatch = !isScanJob && importJobId !== undefined && basePayload.scanJobId === undefined;
   const totalAttempts = job.opts.attempts ?? 1;
   const finalAttempt = job.attemptsMade + 1 >= totalAttempts;
 
@@ -282,6 +288,10 @@ export function createLibraryWorkerProcessor(
         activeScanType = null;
       }
 
+      if (isStandaloneBatch) {
+        await recordBatchJobProgress(importJobId, false);
+      }
+
       return result;
     } catch (error) {
       if (error instanceof WaitingChildrenError) {
@@ -301,16 +311,24 @@ export function createLibraryWorkerProcessor(
         });
       }
       if (importJobId && !isScanJob && finalAttempt) {
-        await db.importJob.updateMany({
-          where: { id: importJobId, status: { in: ["QUEUED", "RUNNING"] } },
-          data: {
-            status: "FAILED",
-            finishedAt: new Date(),
-            error: `Child job ${job.name} failed: ${error instanceof Error ? error.message : String(error)}`,
-            scanStage: null,
-            bullmqJobId: null,
-          },
-        });
+        if (isStandaloneBatch) {
+          // Soft-fail: one bad file shouldn't kill the whole batch. Bump the
+          // ImportJob's errorCount and let recordBatchJobProgress mark SUCCEEDED
+          // once all jobs have terminated.
+          await recordBatchJobProgress(importJobId, true);
+        } else {
+          // Scan-child failure: hard-fail the parent scan's ImportJob.
+          await db.importJob.updateMany({
+            where: { id: importJobId, status: { in: ["QUEUED", "RUNNING"] } },
+            data: {
+              status: "FAILED",
+              finishedAt: new Date(),
+              error: `Child job ${job.name} failed: ${error instanceof Error ? error.message : String(error)}`,
+              scanStage: null,
+              bullmqJobId: null,
+            },
+          });
+        }
       }
       if (isScanJob) activeScanType = null;
       throw error;
@@ -408,10 +426,14 @@ export function bootstrapLibraryWorker(): void {
   const { connection, pollInterval, worker } = createLibraryWorker();
 
   worker.on("ready", () => { logger.info("Worker ready, waiting for jobs"); });
+  worker.on("active", (job) => { logger.info({ jobId: job.id, jobName: job.name }, "Job started"); });
   worker.on("completed", (job) => { logger.info({ jobId: job.id, jobName: job.name }, "Job completed"); });
   worker.on("failed", (job, error) => {
     logger.error({ jobId: job?.id, jobName: job?.name, err: error }, "Job failed");
   });
+  worker.on("stalled", (jobId) => { logger.warn({ jobId }, "Job stalled — will be retried"); });
+
+  logger.info({ concurrency: worker.concurrency }, "Worker concurrency at startup");
 
   const shutdown = async () => {
     logger.info("Shutting down worker");


### PR DESCRIPTION
## Summary

Fixes a production bug where re-match and bulk-enrich jobs appeared to "never start": jobs were enqueued and processed in Redis, but the parent ImportJob stayed in QUEUED forever, so the UI showed no progress.

- The library worker only updated ImportJob status for scan jobs. Standalone batch jobs (re-match, bulk-enrich) created their own ImportJob but no worker code transitioned it out of QUEUED. Distinguish standalone batches (`importJobId` only) from scan-children (`scanJobId` present) and apply the existing progress-tracking pattern: increment `processedFiles` on success, soft-fail with `errorCount` on final-attempt failure, mark SUCCEEDED when `processedFiles >= totalFiles`.
- Extract `recordBatchJobProgress` into a shared helper so the library worker and enrichment worker share one implementation.
- Add `active` + `stalled` event handlers and a startup concurrency log. Previously a worker that was alive but not pulling jobs left no diagnostic trail — the only recovery was Stop All Jobs (which flushes Redis).
- Add local dev utilities (`docker-compose.override.yml`, `scripts/strip-paren-numbers.sh`) and gitignore `.claude/`.

Verified locally: `pnpm lint`, `pnpm typecheck`, `pnpm test` (3703/3703, 100% coverage), `pnpm build` all green. Manual end-to-end smoke not yet run.