### PR TITLE
Make web container's covers volume writable

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,7 @@ services:
       KEPUB_CACHE_DIR: /data/kepub-cache
       KOBO_API_BASE_URL: ${KOBO_API_BASE_URL:-http://localhost:3000/kobo}
     volumes:
-      - covers:/data/covers:ro
+      - covers:/data/covers
       - kepub-cache:/data/kepub-cache
     depends_on:
       - db


### PR DESCRIPTION
## Summary

Fixes EROFS in production when applying a cover/author photo from URL or uploading a manual cover/photo. The web container had `covers:/data/covers:ro` — read-only — but several user-triggered server functions write to that path inline from the web container:

- `applyCoverFromUrlServerFn` in `apps/web/src/lib/server-fns/enrichment.ts` (this is the one that surfaced the bug — applying a cover during enrichment)
- `fetchAuthorPhotoFromUrlServerFn` in `apps/web/src/lib/server-fns/authors.ts`
- `apps/web/server/routes/api/upload-cover/[workId].ts`
- `apps/web/server/routes/api/upload-author-photo/[contributorId].ts`

These are synchronous user actions where the immediate-feedback UX matters; moving them to the worker would mean the dialog closes before the cover applies. Drop the `:ro` so the web container can write covers; the worker still writes covers via the same shared volume.

After pulling, redeploy with `docker compose up -d web` to remount the volume read-write.

Verified the change is a one-character flag removal in `docker-compose.yml`; no code changes, no tests affected. Not yet validated against a live deploy.